### PR TITLE
feat: ノート機能の改修

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'providers/plant_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/note_provider.dart';
@@ -7,7 +8,9 @@ import 'screens/home_screen.dart';
 import 'theme/app_themes.dart';
 import 'models/app_settings.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await initializeDateFormatting('ja');
   runApp(const MyApp());
 }
 
@@ -34,7 +37,6 @@ class MyApp extends StatelessWidget {
               mode = ThemeMode.dark;
               break;
             case ThemePreference.system:
-            default:
               mode = ThemeMode.system;
               break;
           }

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -51,50 +51,6 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     super.dispose();
   }
 
-  Future<void> _pickImage() async {
-    try {
-      // Deprecated: use _showImageSourceOptions to choose source
-      final picker = ImagePicker();
-      final pickedFile = await picker.pickImage(source: ImageSource.gallery, maxWidth: 2048, maxHeight: 2048);
-
-      if (pickedFile != null) {
-        if (kIsWeb) {
-          setState(() => _imagePath = pickedFile.path);
-          return;
-        }
-
-        // For mobile: optionally allow cropping to square
-        final cropped = await ImageCropper().cropImage(
-          sourcePath: pickedFile.path,
-          aspectRatio: const CropAspectRatio(ratioX: 1, ratioY: 1),
-          uiSettings: [
-            AndroidUiSettings(
-              toolbarTitle: '画像をトリミング',
-              initAspectRatio: CropAspectRatioPreset.square,
-              lockAspectRatio: true,
-            ),
-            IOSUiSettings(
-              title: '画像をトリミング',
-              aspectRatioLockEnabled: true,
-            ),
-          ],
-        );
-
-        final toSavePath = cropped?.path ?? pickedFile.path;
-        final appDir = await getApplicationDocumentsDirectory();
-        final fileName = path.basename(toSavePath);
-        final savedImage = await File(toSavePath).copy('${appDir.path}/$fileName');
-        setState(() => _imagePath = savedImage.path);
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('画像の選択に失敗しました: $e')),
-        );
-      }
-    }
-  }
-
   Future<void> _showImageSourceOptions() async {
     final source = await showModalBottomSheet<ImageSource>(
       context: context,

--- a/lib/screens/image_crop_screen.dart
+++ b/lib/screens/image_crop_screen.dart
@@ -19,7 +19,6 @@ class _ImageCropScreenState extends State<ImageCropScreen> {
 
   @override
   void dispose() {
-    _controller.dispose();
     super.dispose();
   }
 

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,6 +1,9 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/note.dart';
+import '../providers/plant_provider.dart';
 import 'add_edit_note_screen.dart';
 import '../providers/note_provider.dart';
 
@@ -16,7 +19,9 @@ class NoteDetailScreen extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.edit),
-            onPressed: () => Navigator.of(context).push(MaterialPageRoute(builder: (_) => AddEditNoteScreen(note: note))),
+            onPressed: () => Navigator.of(context).push(
+              MaterialPageRoute(builder: (_) => AddEditNoteScreen(note: note)),
+            ),
           ),
           IconButton(
             icon: const Icon(Icons.delete),
@@ -27,35 +32,76 @@ class NoteDetailScreen extends StatelessWidget {
                   title: const Text('削除の確認'),
                   content: const Text('このノートを削除しますか？'),
                   actions: [
-                    TextButton(onPressed: () => Navigator.of(context).pop(false), child: const Text('キャンセル')),
-                    TextButton(onPressed: () => Navigator.of(context).pop(true), child: const Text('削除')),
+                    TextButton(
+                        onPressed: () => Navigator.of(context).pop(false),
+                        child: const Text('キャンセル')),
+                    TextButton(
+                        onPressed: () => Navigator.of(context).pop(true),
+                        child: const Text('削除')),
                   ],
                 ),
               );
-
               if (confirmed == true) {
                 await context.read<NoteProvider>().deleteNote(note.id);
-                if (Navigator.of(context).canPop()) Navigator.of(context).pop();
+                if (context.mounted && Navigator.of(context).canPop()) {
+                  Navigator.of(context).pop();
+                }
               }
             },
           ),
         ],
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                note.title,
-                style: Theme.of(context).textTheme.titleLarge,
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 植物チップ
+            if (note.plantIds.isNotEmpty)
+              Consumer<PlantProvider>(builder: (context, plantProv, _) {
+                final names = plantProv.plants
+                    .where((p) => note.plantIds.contains(p.id))
+                    .map((p) => p.name)
+                    .toList();
+                if (names.isEmpty) return const SizedBox.shrink();
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Wrap(
+                    spacing: 6,
+                    runSpacing: 4,
+                    children: names
+                        .map((name) => Chip(
+                              label: Text(name),
+                              avatar: const Icon(Icons.eco, size: 14),
+                              visualDensity: VisualDensity.compact,
+                            ))
+                        .toList(),
+                  ),
+                );
+              }),
+
+            // 内容
+            if (note.content != null && note.content!.isNotEmpty)
+              Text(note.content!, style: Theme.of(context).textTheme.bodyLarge),
+
+            // 画像
+            if (note.imagePaths.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: note.imagePaths.map((p) {
+                  final img = kIsWeb
+                      ? Image.network(p, width: 120, height: 120, fit: BoxFit.cover)
+                      : Image.file(File(p), width: 120, height: 120, fit: BoxFit.cover);
+                  return ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: img,
+                  );
+                }).toList(),
               ),
-              const SizedBox(height: 12),
-              if (note.content != null && note.content!.isNotEmpty)
-                Text(note.content!),
             ],
-          ),
+          ],
         ),
       ),
     );

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../models/note.dart';
 import '../providers/note_provider.dart';
+import '../providers/plant_provider.dart';
 import 'add_edit_note_screen.dart';
 import 'note_detail_screen.dart';
 
@@ -15,7 +18,38 @@ class _NotesListScreenState extends State<NotesListScreen> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(() => context.read<NoteProvider>().loadNotes());
+    Future.microtask(() {
+      context.read<NoteProvider>().loadNotes();
+      context.read<PlantProvider>().loadPlants();
+    });
+  }
+
+  /// ノートを日付（createdAt の日付部分）でグループ化して、降順で返す
+  Map<String, List<Note>> _groupByDate(List<Note> notes) {
+    final Map<String, List<Note>> grouped = {};
+    for (final note in notes) {
+      final key = DateFormat('yyyy-MM-dd').format(note.createdAt);
+      grouped.putIfAbsent(key, () => []).add(note);
+    }
+    // 各グループ内を新しい順に並べる
+    for (final key in grouped.keys) {
+      grouped[key]!.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    }
+    // キー（日付文字列）を降順に並べた LinkedHashMap 相当を返す
+    final sortedKeys = grouped.keys.toList()..sort((a, b) => b.compareTo(a));
+    return {for (final k in sortedKeys) k: grouped[k]!};
+  }
+
+  String _formatDateHeader(String dateKey) {
+    final dt = DateTime.parse(dateKey);
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = today.subtract(const Duration(days: 1));
+    final d = DateTime(dt.year, dt.month, dt.day);
+
+    if (d == today) return '今日  ${DateFormat('MM月dd日 (E)', 'ja').format(dt)}';
+    if (d == yesterday) return '昨日  ${DateFormat('MM月dd日 (E)', 'ja').format(dt)}';
+    return DateFormat('yyyy年MM月dd日 (E)', 'ja').format(dt);
   }
 
   @override
@@ -24,41 +58,249 @@ class _NotesListScreenState extends State<NotesListScreen> {
       appBar: AppBar(
         title: const Text('ノート'),
       ),
-      body: Consumer<NoteProvider>(
-        builder: (context, provider, _) {
-          if (provider.isLoading) return const Center(child: CircularProgressIndicator());
-          if (provider.notes.isEmpty) {
+      body: Consumer2<NoteProvider, PlantProvider>(
+        builder: (context, noteProvider, plantProvider, _) {
+          if (noteProvider.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (noteProvider.notes.isEmpty) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Icon(Icons.note_outlined, size: 64, color: Theme.of(context).colorScheme.primary.withOpacity(0.5)),
+                  Icon(Icons.menu_book_outlined,
+                      size: 72,
+                      color: Theme.of(context).colorScheme.primary.withOpacity(0.4)),
                   const SizedBox(height: 16),
-                  Text('ノートがありません', style: Theme.of(context).textTheme.titleMedium),
+                  Text('まだノートがありません',
+                      style: Theme.of(context).textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                  Text('右下の ＋ ボタンから記録しましょう',
+                      style: Theme.of(context).textTheme.bodySmall),
                 ],
               ),
             );
           }
 
+          final grouped = _groupByDate(noteProvider.notes);
+          final dateKeys = grouped.keys.toList();
+
           return ListView.builder(
-            itemCount: provider.notes.length,
-            itemBuilder: (context, index) {
-              final note = provider.notes[index];
-              return Card(
-                margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-                child: ListTile(
-                  title: Text(note.title),
-                  subtitle: note.content != null ? Text(note.content!, maxLines: 1, overflow: TextOverflow.ellipsis) : null,
-                  onTap: () => Navigator.of(context).push(MaterialPageRoute(builder: (_) => NoteDetailScreen(note: note))),
-                ),
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 88),
+            itemCount: dateKeys.length,
+            itemBuilder: (context, i) {
+              final key = dateKeys[i];
+              final dayNotes = grouped[key]!;
+
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // ── 日付ヘッダー ──
+                  Padding(
+                    padding: const EdgeInsets.only(top: 20, bottom: 8),
+                    child: Row(
+                      children: [
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                          decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.primaryContainer,
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Text(
+                            _formatDateHeader(key),
+                            style: Theme.of(context).textTheme.labelMedium?.copyWith(
+                                  color: Theme.of(context).colorScheme.onPrimaryContainer,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Divider(
+                            color: Theme.of(context).colorScheme.outlineVariant,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  // ── その日のノート一覧（タイムライン風） ──
+                  ...dayNotes.asMap().entries.map((entry) {
+                    final isLast = entry.key == dayNotes.length - 1;
+                    final note = entry.value;
+
+                    // 関連植物名
+                    final plantNames = plantProvider.plants
+                        .where((p) => note.plantIds.contains(p.id))
+                        .map((p) => p.name)
+                        .toList();
+
+                    return IntrinsicHeight(
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          // タイムライン縦線 + 丸
+                          SizedBox(
+                            width: 32,
+                            child: Column(
+                              children: [
+                                Container(
+                                  width: 10,
+                                  height: 10,
+                                  margin: const EdgeInsets.only(top: 14),
+                                  decoration: BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    color: Theme.of(context).colorScheme.primary,
+                                  ),
+                                ),
+                                if (!isLast)
+                                  Expanded(
+                                    child: Center(
+                                      child: Container(
+                                        width: 2,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .outlineVariant,
+                                      ),
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+
+                          // カード
+                          Expanded(
+                            child: Padding(
+                              padding: EdgeInsets.only(bottom: isLast ? 0 : 10),
+                              child: Card(
+                                margin: EdgeInsets.zero,
+                                elevation: 1,
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(12),
+                                  onTap: () => Navigator.of(context).push(
+                                    MaterialPageRoute(
+                                      builder: (_) => NoteDetailScreen(note: note),
+                                    ),
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(12),
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        // 時刻 + タイトル
+                                        Row(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              DateFormat('HH:mm').format(note.createdAt),
+                                              style: Theme.of(context)
+                                                  .textTheme
+                                                  .labelSmall
+                                                  ?.copyWith(
+                                                    color: Theme.of(context)
+                                                        .colorScheme
+                                                        .onSurface
+                                                        .withOpacity(0.5),
+                                                  ),
+                                            ),
+                                            const SizedBox(width: 8),
+                                            Expanded(
+                                              child: Text(
+                                                note.title,
+                                                style: Theme.of(context)
+                                                    .textTheme
+                                                    .titleSmall
+                                                    ?.copyWith(fontWeight: FontWeight.bold),
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+
+                                        // 内容プレビュー
+                                        if (note.content != null &&
+                                            note.content!.isNotEmpty) ...[
+                                          const SizedBox(height: 4),
+                                          Text(
+                                            note.content!,
+                                            maxLines: 2,
+                                            overflow: TextOverflow.ellipsis,
+                                            style: Theme.of(context).textTheme.bodySmall,
+                                          ),
+                                        ],
+
+                                        // 植物チップ
+                                        if (plantNames.isNotEmpty) ...[
+                                          const SizedBox(height: 6),
+                                          Wrap(
+                                            spacing: 4,
+                                            runSpacing: 2,
+                                            children: plantNames
+                                                .map((name) => Chip(
+                                                      label: Text(name),
+                                                      avatar: const Icon(Icons.eco, size: 12),
+                                                      visualDensity: VisualDensity.compact,
+                                                      padding: EdgeInsets.zero,
+                                                      labelStyle: Theme.of(context)
+                                                          .textTheme
+                                                          .labelSmall,
+                                                      materialTapTargetSize:
+                                                          MaterialTapTargetSize.shrinkWrap,
+                                                    ))
+                                                .toList(),
+                                          ),
+                                        ],
+
+                                        // 画像サムネイル
+                                        if (note.imagePaths.isNotEmpty) ...[
+                                          const SizedBox(height: 6),
+                                          Row(
+                                            children: [
+                                              Icon(Icons.photo_library_outlined,
+                                                  size: 14,
+                                                  color: Theme.of(context)
+                                                      .colorScheme
+                                                      .onSurface
+                                                      .withOpacity(0.5)),
+                                              const SizedBox(width: 4),
+                                              Text(
+                                                '${note.imagePaths.length} 枚',
+                                                style: Theme.of(context)
+                                                    .textTheme
+                                                    .labelSmall
+                                                    ?.copyWith(
+                                                      color: Theme.of(context)
+                                                          .colorScheme
+                                                          .onSurface
+                                                          .withOpacity(0.5),
+                                                    ),
+                                              ),
+                                            ],
+                                          ),
+                                        ],
+                                      ],
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    );
+                  }),
+                ],
               );
             },
           );
         },
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => Navigator.of(context).push(MaterialPageRoute(builder: (_) => const AddEditNoteScreen())),
-        child: const Icon(Icons.add),
+        onPressed: () => Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const AddEditNoteScreen()),
+        ),
+        child: const Icon(Icons.edit_outlined),
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: cb6a278ef2dbb298455e1a713bda08524a175630ec643a242c399c932a0a1f7d
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.1"
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: "direct main"
     description:
       name: crop_your_image
-      sha256: b6b42eb9b7d53690e9e3d0cfeae91acbd73e87ec407113c47e6c1a59b7468fa5
+      sha256: "9ae3b33042de5bda5321fc48aad41054c196bf2cc28350cd30cb8a85c1a7b1bd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0+1"
+    version: "1.1.0"
   cross_file:
     dependency: transitive
     description:
@@ -276,10 +276,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "8e9d133755c3e84c73288363e6343157c383a0c6c56fc51afcc5d4d7180306d6"
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "4.8.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -576,6 +576,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   provider:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   
   # Image handling
   image_picker: ^1.0.7
-  crop_your_image: ^0.6.0
+  crop_your_image: ^1.0.0
   
   # Notifications
   flutter_local_notifications: ^20.1.0


### PR DESCRIPTION
## 概要
ノート機能のUI改修とバグ修正を行いました。

## 変更内容

### 🐛 バグ修正
- **植物選択ダイアログが再描画されない問題を修正** (StatefulBuilder を使用)
- **重複植物の追加を防止**
- **LocaleDataException を修正** (initializeDateFormatting('ja') の追加)
- **crop_your_image 1.x 非対応の dispose() 呼び出しを削除**
- **未使用の _pickImage メソッドと ImageCropper 参照を削除**

### ✨ 機能改善

#### ノート一覧画面 (
otes_list_screen.dart)
- 日付でグループ化した日記スタイルのレイアウトに全面改修
- 今日・昨日の相対表示 + 曜日付き日付ヘッダー
- タイムライン風の縦線＋ドットレイアウト
- カード内に時刻・タイトル・内容プレビュー・植物Chip・画像枚数を表示

#### ノート編集画面 (dd_edit_note_screen.dart)
- フォームUIを全面改修（OutlineInputBorder で視認性向上）
- 選択した植物を削除可能な Chip で表示（「N個選択済み」から変更）
- 内容欄を minLines: 6 に拡張

#### ノート詳細画面 (
ote_detail_screen.dart)
- 植物名を Chip で表示
- 画像を Wrap でグリッド表示

### 📦 依存関係
- crop_your_image を ^0.6.0 → ^1.0.0 に更新（image 4.x 対応）