### PR TITLE
fix: 植物選択ダイアログに品種表示・水やりログ画面の文言修正

### DIFF
--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -220,6 +220,7 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
                     return CheckboxListTile(
                       value: checked,
                       title: Text(p.name),
+                      subtitle: p.variety != null ? Text(p.variety!) : null,
                       onChanged: (v) {
                         setDialogState(() {
                           if (v == true) {

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -41,7 +41,7 @@ class _HomeScreenState extends State<HomeScreen> {
           NavigationDestination(
             icon: Icon(Icons.water_drop_outlined),
             selectedIcon: Icon(Icons.water_drop),
-            label: '今日の水やり',
+            label: '水やりログ',
           ),
           NavigationDestination(
             icon: Icon(Icons.eco_outlined),

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -291,7 +291,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('水やり管理'),
+        title: const Text('水やりログ'),
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),


### PR DESCRIPTION
## 概要

Issue #30（植物選択ダイアログに品種表示）と Issue #32（水やり画面のテキスト変更）を対応する。

## 変更内容

### Issue #30: 植物選択ダイアログに品種を表示
- lib/screens/add_edit_note_screen.dart: ノート編集画面の植物選択ダイアログ（CheckboxListTile）に subtitle: p.variety != null ? Text(p.variety!) : null を追加
- _UnscheduledWateringDialog（today_watering_screen.dart）は既に品種表示済みのため変更なし

### Issue #32: 水やりログ画面の文言修正
- lib/screens/today_watering_screen.dart: AppBar タイトル '水やり管理' → '水やりログ'（過去ログ・未来予定も確認できる画面であることを反映）
- lib/screens/home_screen.dart: BottomNavigationBar ラベル '今日の水やり' → '水やりログ'（同上）

## 関連 Issue
Fixes #30
Fixes #32