### PR TITLE
fix: 一括水やりバグ・ノート保存バグ・アプリ名修正

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
-        android:label="water_me"
+        android:label="WaterMe"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Water Me</string>
+	<string>WaterMe</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>water_me</string>
+	<string>WaterMe</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -1,3 +1,6 @@
+// copyWith の sentinel 値（content を明示的に null にしたい場合に使用）
+const Object _sentinel = Object();
+
 class Note {
   final String id;
   final String title;
@@ -45,9 +48,10 @@ class Note {
     );
   }
 
+  // sentinel: content を明示的に null (削除) にしたい場合は clearContent: true を渡す
   Note copyWith({
     String? title,
-    String? content,
+    Object? content = _sentinel,
     List<String>? imagePaths,
     List<String>? plantIds,
     DateTime? updatedAt,
@@ -55,7 +59,7 @@ class Note {
     return Note(
       id: id,
       title: title ?? this.title,
-      content: content ?? this.content,
+      content: content == _sentinel ? this.content : content as String?,
       imagePaths: imagePaths ?? this.imagePaths,
       plantIds: plantIds ?? this.plantIds,
       createdAt: createdAt,

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -165,7 +165,10 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     if (_selectedPlantIds.isEmpty) return;
 
     final plantProvider = context.read<PlantProvider>();
-    
+    // _refreshAfterLogChange() 内で _selectedPlantIds.clear() が呼ばれるため、
+    // 件数は先にローカル変数にコピーしておく (#37)
+    final count = _selectedPlantIds.length;
+
     // Register all selected log types for each plant
     for (final plantId in _selectedPlantIds) {
       for (final logType in _selectedBulkLogTypes) {
@@ -174,7 +177,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     }
 
     await _refreshAfterLogChange();
-    _showSuccessMessage(_buildLogMessage(_selectedPlantIds.length));
+    _showSuccessMessage(_buildLogMessage(count));
   }
 
   Future<void> _recordLog(

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "water_me",
-    "short_name": "water_me",
+    "name": "WaterMe",
+    "short_name": "WaterMe",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#FFFFFF",


### PR DESCRIPTION
## 概要

Batch 1: バグ修正3件をまとめた PR。

## 変更内容

### Issue #37: 複数植物を選択して水やり登録すると0件と表示されるバグ
- `lib/screens/today_watering_screen.dart`: `_bulkLog()` で `_selectedPlantIds.length` を `_refreshAfterLogChange()` 呼び出し前にローカル変数 `count` へコピーするよう修正
- 原因: `_refreshAfterLogChange()` 内で `_selectedPlantIds.clear()` が実行されるため、その後に `.length` を参照すると 0 になっていた

### Issue #34: ノートの内容が保存されないバグ
- `lib/models/note.dart`: `Note.copyWith()` を sentinel パターンに変更
- 従来の `content: content ?? this.content` では明示的に null（内容削除）にしたい場合に対応できなかった
- `const Object _sentinel` を使って「引数未指定」と「null 指定」を区別できるよう修正

### Issue #40: インストールされたアプリ名が water_me になる
- `android/app/src/main/AndroidManifest.xml`: android:label を "WaterMe" に修正
- `ios/Runner/Info.plist`: CFBundleDisplayName / CFBundleName を "WaterMe" に修正
- `web/manifest.json`: name / short_name を "WaterMe" に修正

## 関連 Issue
Fixes #34
Fixes #37
Fixes #40
