### PR TITLE
fix: Batch 2 UI improvements (#36, #39, #35)

### DIFF
--- a/lib/screens/image_crop_screen.dart
+++ b/lib/screens/image_crop_screen.dart
@@ -84,8 +84,11 @@ class _ImageCropScreenState extends State<ImageCropScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      extendBodyBehindAppBar: true,
       appBar: AppBar(
         title: const Text('画像をトリミング'),
+        backgroundColor: Colors.black54,
+        foregroundColor: Colors.white,
         actions: [
           IconButton(
             icon: const Icon(Icons.check),

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -7,6 +7,74 @@ import '../providers/plant_provider.dart';
 import 'add_edit_note_screen.dart';
 import '../providers/note_provider.dart';
 
+class _FullScreenImageViewer extends StatefulWidget {
+  final List<String> imagePaths;
+  final int initialIndex;
+  final String noteId;
+  const _FullScreenImageViewer({
+    required this.imagePaths,
+    required this.initialIndex,
+    required this.noteId,
+  });
+
+  @override
+  State<_FullScreenImageViewer> createState() => _FullScreenImageViewerState();
+}
+
+class _FullScreenImageViewerState extends State<_FullScreenImageViewer> {
+  late PageController _pageController;
+  late int _currentIndex;
+
+  @override
+  void initState() {
+    super.initState();
+    _currentIndex = widget.initialIndex;
+    _pageController = PageController(initialPage: widget.initialIndex);
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.black,
+      appBar: AppBar(
+        backgroundColor: Colors.black54,
+        foregroundColor: Colors.white,
+        title: widget.imagePaths.length > 1
+            ? Text('${_currentIndex + 1} / ${widget.imagePaths.length}')
+            : null,
+      ),
+      body: PageView.builder(
+        controller: _pageController,
+        itemCount: widget.imagePaths.length,
+        onPageChanged: (i) => setState(() => _currentIndex = i),
+        itemBuilder: (context, index) {
+          final p = widget.imagePaths[index];
+          final heroTag = 'note_image_${widget.noteId}_$index';
+          final img = kIsWeb
+              ? Image.network(p, fit: BoxFit.contain)
+              : Image.file(File(p), fit: BoxFit.contain);
+          return InteractiveViewer(
+            minScale: 0.5,
+            maxScale: 5.0,
+            child: Center(
+              child: Hero(
+                tag: heroTag,
+                child: img,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
 class NoteDetailScreen extends StatelessWidget {
   final Note note;
   const NoteDetailScreen({required this.note, super.key});
@@ -90,13 +158,30 @@ class NoteDetailScreen extends StatelessWidget {
               Wrap(
                 spacing: 8,
                 runSpacing: 8,
-                children: note.imagePaths.map((p) {
+                children: note.imagePaths.asMap().entries.map((entry) {
+                  final index = entry.key;
+                  final p = entry.value;
+                  final heroTag = 'note_image_${note.id}_$index';
                   final img = kIsWeb
                       ? Image.network(p, width: 120, height: 120, fit: BoxFit.cover)
                       : Image.file(File(p), width: 120, height: 120, fit: BoxFit.cover);
-                  return ClipRRect(
-                    borderRadius: BorderRadius.circular(8),
-                    child: img,
+                  return GestureDetector(
+                    onTap: () => Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => _FullScreenImageViewer(
+                          imagePaths: note.imagePaths,
+                          initialIndex: index,
+                          noteId: note.id,
+                        ),
+                      ),
+                    ),
+                    child: Hero(
+                      tag: heroTag,
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: img,
+                      ),
+                    ),
                   );
                 }).toList(),
               ),

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -230,6 +230,11 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                 style: const TextStyle(
                   shadows: [
                     Shadow(
+                      offset: Offset(0, 2),
+                      blurRadius: 8,
+                      color: Colors.black87,
+                    ),
+                    Shadow(
                       offset: Offset(0, 1),
                       blurRadius: 4,
                       color: Colors.black54,
@@ -276,8 +281,8 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
               gradient: LinearGradient(
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
-                colors: [Colors.transparent, Colors.black45],
-                stops: [0.5, 1.0],
+                colors: [Colors.transparent, Colors.black87],
+                stops: [0.3, 1.0],
               ),
             ),
           ),


### PR DESCRIPTION
## 概要
Batch 2 の UI 改善を実装。

## 変更内容

### Issue #36 — 背景画像と文字の被り (plant_detail_screen.dart)
- グラデーション stops: [0.5, 1.0] → [0.3, 1.0] に変更し、グラデーション開始を早める
- グラデーション色を Colors.black45 → Colors.black87 に強化
- FlexibleSpaceBar タイトルのシャドウを二重に強化（lurRadius: 4→8, lack54→black87）

### Issue #39 — トリミング四隅操作性 (image_crop_screen.dart)
- xtendBodyBehindAppBar: true を追加し、Crop ウィジェットが画面全体を使用できるように
- AppBar を半透明（ackgroundColor: Colors.black54, oregroundColor: Colors.white）に変更

### Issue #35 — ノート画像フルスクリーン (
ote_detail_screen.dart)
- サムネイル画像を GestureDetector でラップしてタップ検出
- Hero アニメーション付きで画面遷移
- _FullScreenImageViewer ウィジェットを追加
  - PageView で複数画像をスワイプ切替
  - InteractiveViewer でピンチズーム（最大5倍）対応
  - AppBar にページ番号表示

## テスト
- ビルドエラーなし