### PR TITLE
feat: 水やり間隔の一括変更機能 (#38)

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -331,4 +331,53 @@ class PlantProvider with ChangeNotifier {
       await _db!.deleteLog(logId);
     }
   }
+
+  /// すべての植物の水やり間隔を指定した日数に一括設定する（interval が null の植物もセット）
+  Future<void> bulkUpdateWateringInterval(int days) async {
+    for (final plant in _plants) {
+      final updated = Plant(
+        id: plant.id,
+        name: plant.name,
+        variety: plant.variety,
+        purchaseDate: plant.purchaseDate,
+        purchaseLocation: plant.purchaseLocation,
+        imagePath: plant.imagePath,
+        wateringIntervalDays: days,
+        createdAt: plant.createdAt,
+        updatedAt: DateTime.now(),
+      );
+      if (kIsWeb) {
+        await _web!.updatePlant(updated);
+      } else {
+        await _db!.updatePlant(updated);
+      }
+    }
+    await loadPlants();
+  }
+
+  /// 水やり間隔が設定されている植物のみ、現在値に delta を加算して一括調整する
+  /// 結果は最低 1 日にクランプする
+  Future<void> bulkAdjustWateringInterval(int delta) async {
+    for (final plant in _plants) {
+      if (plant.wateringIntervalDays == null) continue;
+      final newDays = (plant.wateringIntervalDays! + delta).clamp(1, 9999);
+      final updated = Plant(
+        id: plant.id,
+        name: plant.name,
+        variety: plant.variety,
+        purchaseDate: plant.purchaseDate,
+        purchaseLocation: plant.purchaseLocation,
+        imagePath: plant.imagePath,
+        wateringIntervalDays: newDays,
+        createdAt: plant.createdAt,
+        updatedAt: DateTime.now(),
+      );
+      if (kIsWeb) {
+        await _web!.updatePlant(updated);
+      } else {
+        await _db!.updatePlant(updated);
+      }
+    }
+    await loadPlants();
+  }
 }


### PR DESCRIPTION
## 概要
Issue #38 の「水やり間隔を一括で変更する機能」を実装。

## 変更内容

### lib/providers/plant_provider.dart
- ulkUpdateWateringInterval(int days) — 全植物の wateringIntervalDays を指定値に一括セット（未設定植物も対象）
- ulkAdjustWateringInterval(int delta) — 水やり間隔が設定済みの植物のみ delta 日加算（最低1日にクランプ）

### lib/screens/settings_screen.dart
- 「水やり間隔」セクションを追加（データ管理セクションの直前）
  - **水やり間隔を一括設定**: テキストフィールドで任意の日数を入力し、全植物に適用
  - **水やり間隔を一括調整**: + / - ステッパーで増減日数を選択し、設定済み植物に適用

## 動作
- 一括設定: 全植物（間隔未設定含む）を指定日数に変更
- 一括調整: 間隔設定済み植物のみ現在値 ± delta、最小値は 1 日