### PR TITLE
fix: 植物詳細画面 UI バグ修正 (#45, #46)

### DIFF
--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -159,6 +159,26 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     }
   }
 
+  /// 画像背景上でも見やすいアクションボタンを生成する（半透明の丸背景付き）
+  Widget _buildImageOverlayAction(IconData icon, VoidCallback onPressed) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.black45,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: IconButton(
+          icon: Icon(icon, color: Colors.white),
+          onPressed: onPressed,
+          iconSize: 22,
+          padding: const EdgeInsets.all(6),
+          constraints: const BoxConstraints(minWidth: 36, minHeight: 36),
+        ),
+      ),
+    );
+  }
+
   Future<void> _deletePlant() async {
     final confirm = await showDialog<bool>(
       context: context,
@@ -215,16 +235,27 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
             floating: false,
             forceElevated: innerBoxIsScrolled,
             actions: [
-              IconButton(
-                icon: const Icon(Icons.edit),
-                onPressed: _navigateToEdit,
-              ),
-              IconButton(
-                icon: const Icon(Icons.delete),
-                onPressed: _deletePlant,
-              ),
+              if (widget.plant.imagePath != null) ...
+                _buildImageOverlayAction(Icons.edit, _navigateToEdit)
+              else
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  onPressed: _navigateToEdit,
+                ),
+              if (widget.plant.imagePath != null) ...
+                _buildImageOverlayAction(Icons.delete, _deletePlant)
+              else
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: _deletePlant,
+                ),
             ],
             flexibleSpace: FlexibleSpaceBar(
+              titlePadding: const EdgeInsetsDirectional.only(
+                start: 16,
+                bottom: 16,
+                end: 16,
+              ),
               title: Text(
                 widget.plant.name,
                 style: const TextStyle(


### PR DESCRIPTION
## 概要
植物詳細画面（SliverAppBar）の表示バグを 2 件修正。

## 変更内容

### Issue #46 — 植物名の左マージン
- FlexibleSpaceBar に 	itlePadding: EdgeInsetsDirectional.only(start:16, bottom:16, end:16) を追加
- Material デフォルトの大きな left indent（72px 程度）を解消し、自然な位置に植物名を表示

### Issue #45 — 画像とアクションボタンの被り
- 植物画像が設定されている場合、編集・削除ボタンを _buildImageOverlayAction() でラップ
- \Colors.black45\ の丸背景を付けてどんな画像背景でもアイコンが視認できるように
- 画像なしの場合は従来通りの透明背景 IconButton を使用