### PR TITLE
fix: Batch 5 パフォーマンス＆トリミング改善 (#50, #47)

### DIFF
--- a/lib/screens/image_crop_screen.dart
+++ b/lib/screens/image_crop_screen.dart
@@ -109,6 +109,7 @@ class _ImageCropScreenState extends State<ImageCropScreen> {
                   onCropped: _onCropped,
                   aspectRatio: 1,
                   withCircleUi: false,
+                  interactive: true,
                 ),
                 if (_isCropping)
                   const Center(child: CircularProgressIndicator()),

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -175,13 +175,11 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     // _refreshAfterLogChange() 内で _selectedPlantIds.clear() が呼ばれるため、
     // 件数は先にローカル変数にコピーしておく (#37)
     final count = _selectedPlantIds.length;
+    final plantIds = _selectedPlantIds.toList();
+    final logTypes = _selectedBulkLogTypes.toList();
 
-    // Register all selected log types for each plant
-    for (final plantId in _selectedPlantIds) {
-      for (final logType in _selectedBulkLogTypes) {
-        await _recordLog(plantProvider, plantId, logType);
-      }
-    }
+    // bulkRecordLogs で全挿入後に loadPlants を1回だけ呼ぶ (#50 ちらつき修正)
+    await plantProvider.bulkRecordLogs(plantIds, logTypes, _selectedDate);
 
     await _refreshAfterLogChange();
     _showSuccessMessage(_buildLogMessage(count));


### PR DESCRIPTION
## 概要
Batch 5 のパフォーマンス改善とトリミング操作性改善を実装。

## 変更内容

### Issue #50 — 一括水やり時の画面ちらつき
**原因**: _bulkLog() が植物ごとに _recordLog() → ecordWatering() → loadPlants() を呼んでいたため、N植物 × M種別回の 
otifyListeners() が発火していた。

**修正** (plant_provider.dart + 	oday_watering_screen.dart):
- PlantProvider.bulkRecordLogs(plantIds, logTypes, date) を新設: 全ログを DB に挿入後、loadPlants() を**1回だけ**呼ぶ
- _bulkLog() を ulkRecordLogs() 呼び出しに切り替え

### Issue #47 — トリミング時のピンチズーム
**修正** (image_crop_screen.dart):
- Crop ウィジェットに interactive: true を追加
- crop_your_image v1.1.0 が標準サポートするピンチ操作（ズーム・パン）を有効化