### PR TITLE
fix: Batch A bug fixes (#56, #57, #58)

### DIFF
--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -88,38 +88,45 @@ class _NotesListScreenState extends State<NotesListScreen> {
       context: context,
       builder: (ctx) => SafeArea(
         child: Column(
-          mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
           children: [
             Padding(
               padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
               child: Text('植物で絞り込む',
                   style: Theme.of(context).textTheme.titleMedium),
             ),
-            ListTile(
-              leading: const Icon(Icons.all_inclusive),
-              title: const Text('すべて'),
-              trailing: _filterPlantId == null
-                  ? Icon(Icons.check,
-                      color: Theme.of(context).colorScheme.primary)
-                  : null,
-              onTap: () {
-                setState(() => _filterPlantId = null);
-                Navigator.of(ctx).pop();
-              },
+            Flexible(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.all_inclusive),
+                    title: const Text('すべて'),
+                    trailing: _filterPlantId == null
+                        ? Icon(Icons.check,
+                            color: Theme.of(context).colorScheme.primary)
+                        : null,
+                    onTap: () {
+                      setState(() => _filterPlantId = null);
+                      Navigator.of(ctx).pop();
+                    },
+                  ),
+                  ...plants.map((p) => ListTile(
+                        leading: const Icon(Icons.eco),
+                        title: Text(p.name),
+                        trailing: _filterPlantId == p.id
+                            ? Icon(Icons.check,
+                                color: Theme.of(context).colorScheme.primary)
+                            : null,
+                        onTap: () {
+                          setState(() => _filterPlantId = p.id);
+                          Navigator.of(ctx).pop();
+                        },
+                      )),
+                ],
+              ),
             ),
-            ...plants.map((p) => ListTile(
-                  leading: const Icon(Icons.eco),
-                  title: Text(p.name),
-                  trailing: _filterPlantId == p.id
-                      ? Icon(Icons.check,
-                          color: Theme.of(context).colorScheme.primary)
-                      : null,
-                  onTap: () {
-                    setState(() => _filterPlantId = p.id);
-                    Navigator.of(ctx).pop();
-                  },
-                )),
             const SizedBox(height: 8),
           ],
         ),
@@ -290,7 +297,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
           .firstOrNull;
       if (name != null) parts.add(name);
     }
-    return parts.join(' ・ ') + ' で絞り込み中';
+    return '${parts.join(' ・ ')} で絞り込み中';
   }
 
   Widget _buildNoteList(

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -23,8 +23,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
   DateTime _selectedDate = DateTime.now();
   DailyLogStatus _logStatus = DailyLogStatus.empty();
   Map<String, DateTime?> _nextWateringDateCache = {};
-  Set<String> _selectedPlantIds = {};
-  Set<LogType> _selectedBulkLogTypes = {LogType.watering};
+  final Set<String> _selectedPlantIds = {};
+  final Set<LogType> _selectedBulkLogTypes = {LogType.watering};
   final ScrollController _listScrollController = ScrollController();
 
   @override
@@ -207,7 +207,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     final actionNames = _selectedBulkLogTypes
         .map((type) => _getLogTypeName(type))
         .join('・');
-    return '${count}件の${actionNames}を登録しました';
+    return '$count件の$actionNamesを登録しました';
   }
 
   Future<void> _refreshAfterLogChange() async {
@@ -310,6 +310,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('水やりログ'),
+        scrolledUnderElevation: 0,
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),
@@ -611,7 +612,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
             },
           ),
         ),
-        _buildAddUnscheduledWateringButton(),
+        _buildAddUnscheduledWateringButton(hasPlants: true),
       ],
     );
   }
@@ -740,7 +741,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     );
   }
 
-  Widget _buildAddUnscheduledWateringButton() {
+  Widget _buildAddUnscheduledWateringButton({bool hasPlants = false}) {
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).colorScheme.surface,
@@ -758,7 +759,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
         child: OutlinedButton.icon(
           onPressed: _showUnscheduledWateringDialog,
           icon: const Icon(Icons.add),
-          label: const Text('水やり記録をつける'),
+          label: Text(hasPlants ? 'その他の植物に水やり' : '水やり記録をつける'),
           style: OutlinedButton.styleFrom(
             padding: const EdgeInsets.symmetric(vertical: 16),
             minimumSize: const Size(double.infinity, 48),
@@ -811,7 +812,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
         final logTypeNames = selectedLogTypes
             .map((type) => _getLogTypeName(type))
             .join('・');
-        _showSuccessMessage('${selectedPlant.name}に${logTypeNames}を記録しました');
+        _showSuccessMessage('${selectedPlant.name}に$logTypeNamesを記録しました');
       }
     }
   }


### PR DESCRIPTION
## 概要
Batch A のバグ修正 3 件をまとめて対応します。

## 変更内容

### #58 ノートフィルタダイアログの BOTTOM OVERFLOW 修正
- 
otes_list_screen.dart の _showPlantFilterSheet() で Column(mainAxisSize: MainAxisSize.min) のまま植物リストを直接展開していたため、植物数が多いとオーバーフローが発生していた
- 植物リスト部分を Flexible + ListView でラップして高さを制限

### #56 スクロール時のヘッダー色変化を修正（Android ダークテーマ）
- 	oday_watering_screen.dart の AppBar に scrolledUnderElevation: 0 を追加
- スクロール時に Material3 の surfaceTint が適用されて色が変わる問題を解消

### #57 水やりボタンのラベルを条件分岐
- 植物リストが空のとき: 水やり記録をつける
- 植物リストに表示中の植物があるとき: その他の植物に水やり
- _buildAddUnscheduledWateringButton に hasPlants パラメータを追加

## Close
Closes #56
Closes #57
Closes #58