### PR TITLE
feat: Batch B improvements (#59, #60)

### DIFF
--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -21,6 +21,8 @@ enum PlantSortOrder {
   nameDesc,          // 名前降順
   purchaseDateDesc,  // 購入日が新しい順
   purchaseDateAsc,   // 購入日が古い順
+  createdAtAsc,      // 登録日が古い順
+  createdAtDesc,     // 登録日が新しい順
   custom,            // ユーザー指定
 }
 
@@ -101,7 +103,7 @@ class AppSettings {
     this.notificationHour = 9,
     this.notificationMinute = 0,
     LogTypeColors? logTypeColors,
-    this.plantSortOrder = PlantSortOrder.nameAsc,
+    this.plantSortOrder = PlantSortOrder.createdAtAsc,
     this.customSortOrder = const [],
   }) : logTypeColors = logTypeColors ?? LogTypeColors();
 
@@ -143,7 +145,7 @@ class AppSettings {
           : LogTypeColors(),
       plantSortOrder: PlantSortOrder.values.firstWhere(
         (e) => e.name == map['plantSortOrder'],
-        orElse: () => PlantSortOrder.nameAsc,
+        orElse: () => PlantSortOrder.createdAtAsc,
       ),
       customSortOrder: map['customSortOrder'] != null
           ? List<String>.from(map['customSortOrder'])

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -12,7 +12,7 @@ class PlantProvider with ChangeNotifier {
   final WebStorageService? _web = kIsWeb ? WebStorageService() : null;
   List<Plant> _plants = [];
   bool _isLoading = false;
-  Map<String, DateTime?> _nextWateringCache = {};
+  final Map<String, DateTime?> _nextWateringCache = {};
 
   List<Plant> get plants => _plants;
   bool get isLoading => _isLoading;
@@ -66,6 +66,12 @@ class PlantProvider with ChangeNotifier {
           if (b.purchaseDate == null) return -1;
           return a.purchaseDate!.compareTo(b.purchaseDate!);
         });
+        break;
+      case PlantSortOrder.createdAtAsc:
+        plantsCopy.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+        break;
+      case PlantSortOrder.createdAtDesc:
+        plantsCopy.sort((a, b) => b.createdAt.compareTo(a.createdAt));
         break;
       case PlantSortOrder.custom:
         if (customOrder.isNotEmpty) {

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -283,6 +283,10 @@ class _PlantListScreenState extends State<PlantListScreen> {
         return '購入日が新しい順';
       case PlantSortOrder.purchaseDateAsc:
         return '購入日が古い順';
+      case PlantSortOrder.createdAtAsc:
+        return '登録日が古い順';
+      case PlantSortOrder.createdAtDesc:
+        return '登録日が新しい順';
       case PlantSortOrder.custom:
         return 'カスタム（ドラッグで並び替え）';
     }
@@ -296,6 +300,9 @@ class _PlantListScreenState extends State<PlantListScreen> {
       case PlantSortOrder.purchaseDateDesc:
       case PlantSortOrder.purchaseDateAsc:
         return Icons.calendar_today;
+      case PlantSortOrder.createdAtAsc:
+      case PlantSortOrder.createdAtDesc:
+        return Icons.access_time;
       case PlantSortOrder.custom:
         return Icons.reorder;
     }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -70,7 +70,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                         color: _getThemeColor(theme),
                       ),
                     );
-                  }).toList(),
+                  }),
                 ],
               );
             },
@@ -372,6 +372,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
     try {
       final path = await ExportService().exportToFile();
       if (!mounted) return;
+      if (path == null) {
+        // ユーザーがキャンセル
+        return;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('エクスポートしました: $path')),
       );


### PR DESCRIPTION
## 概要
Batch B の機能改修 2 件をまとめて対応します。

## 変更内容

### #60 植物一覧ソートに登録日順を追加
- PlantSortOrder enum に createdAtAsc/createdAtDesc を追加
- デフォルトソートを createdAtAsc に変更
- getSortedPlants() にソートケースを追加
- 表示名・アイコン追加

### #59 データエクスポート先をユーザーが指定できるよう修正
- exportToFile() を FilePicker.platform.saveFile() ベースに変更
- キャンセル時は null を返す

Closes #59
Closes #60