### PR TITLE
fix: rename app to Botanote (#62)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application
-        android:label="WaterMe"
+        android:label="Botanote"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>WaterMe</string>
+	<string>Botanote</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -15,7 +15,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>WaterMe</string>
+	<string>Botanote</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "WaterMe",
-    "short_name": "WaterMe",
+    "name": "Botanote",
+    "short_name": "Botanote",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#FFFFFF",


### PR DESCRIPTION
## 概要\nアプリ名を **WaterMe** から **Botanote** に変更する。\n\n## 変更内容\n- \ndroid/app/src/main/AndroidManifest.xml\: \ndroid:label\ を Botanote に変更\n- \ios/Runner/Info.plist\: \CFBundleDisplayName\ / \CFBundleName\ を Botanote に変更\n- \web/manifest.json\: \
ame\ / \short_name\ を Botanote に変更\n\nCloses #62