### PR TITLE
fix: add createdAtAsc/Desc cases to sort switch in today_watering_screen

### DIFF
--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -147,6 +147,10 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
         if (a.purchaseDate == null) return 1;
         if (b.purchaseDate == null) return -1;
         return a.purchaseDate!.compareTo(b.purchaseDate!);
+      case PlantSortOrder.createdAtAsc:
+        return a.createdAt.compareTo(b.createdAt);
+      case PlantSortOrder.createdAtDesc:
+        return b.createdAt.compareTo(a.createdAt);
       case PlantSortOrder.custom:
         final customOrder = settings.customSortOrder;
         if (customOrder.isNotEmpty) {


### PR DESCRIPTION
Batch B (#60) で PlantSortOrder に createdAtAsc/createdAtDesc を追加した際、today_watering_screen.dart 内の switch 文にケースを追加し忘れていたコンパイルエラーを修正。