### PR TITLE
feat: unify watering/fertilizer/vitalizer into single log tab (#64)

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -2,7 +2,6 @@ import 'package:flutter/foundation.dart';
 import 'package:uuid/uuid.dart';
 import '../models/plant.dart';
 import '../models/log_entry.dart';
-import '../models/note.dart';
 import '../models/app_settings.dart';
 import '../services/database_service.dart';
 import '../services/web_storage_service.dart';


### PR DESCRIPTION
## 概要\n植物管理画面の水やり/肥料/活力剤タブを1つのログタブに統合する。\n\n## 変更内容\n\n### タブ統合\n- タブ数 4 (情報/水やり/肥料/活力剤) -> 2 (情報/ログ) に変更\n- ログタブは3種類のログを日付降順でまとめて表示\n- 空状態に操作ガイダンステキストを追加\n\n### FAB変更\n- 「水やり」専用 FAB -> 「記録」FABに変更\n- タップするとボトムシートで水やり/肥料/活力剤を選択\n- 水やり期日超過時の赤色表示は維持\n\n### その他\n- plant_provider.dart の未使用 import (note.dart) を削除\n\nCloses #64