### PR TITLE
feat: add calendar view toggle to watering log screen (#63)

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -153,6 +153,15 @@ class DatabaseService {
         conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
+  Future<List<LogEntry>> getAllLogs() async {
+    final db = await database;
+    final List<Map<String, dynamic>> maps = await db.query(
+      'logs',
+      orderBy: 'date DESC',
+    );
+    return List.generate(maps.length, (i) => LogEntry.fromMap(maps[i]));
+  }
+
   Future<List<LogEntry>> getLogsByPlant(String plantId) async {
     final db = await database;
     final List<Map<String, dynamic>> maps = await db.query(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -693,6 +693,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  simple_gesture_detector:
+    dependency: transitive
+    description:
+      name: simple_gesture_detector
+      sha256: ba2cd5af24ff20a0b8d609cec3f40e5b0744d2a71804a2616ae086b9c19d19a3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -778,6 +786,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0"
+  table_calendar:
+    dependency: "direct main"
+    description:
+      name: table_calendar
+      sha256: "0c0c6219878b363a2d5f40c7afb159d845f253d061dc3c822aa0d5fe0f721982"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   
   # Date & Time
   intl: ^0.20.2
+  table_calendar: ^3.1.2
   
   # File handling (export/import)
   path: ^1.8.3


### PR DESCRIPTION
## 概要\n水やりログ画面にカレンダービュー切り替え機能を追加します。\n\n## 変更内容\n- AppBar にカレンダー/リスト切り替えボタンを追加\n- TableCalendar ウィジェットを使ったカレンダービューを実装\n  - ログが存在する日付にマーカー（●）を表示\n  - 日付タップで選択日を変更し、ログ一覧を更新\n- カレンダービューではサマリーとプラントリストをカレンダー下に表示\n\n## 事前作業（前コミット）\n- pubspec.yaml に 	able_calendar: ^3.1.2 追加\n- database_service.dart に getAllLogs() メソッド追加\n- plant_provider.dart に _logDatesCache / logDates を追加し loadPlants() で更新\n\nCloses #63