### PR TITLE
feat/fix: batch small improvements (#76 #77 #69 #70)

### DIFF
--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -9,7 +9,8 @@ import '../providers/note_provider.dart';
 
 class AddEditNoteScreen extends StatefulWidget {
   final Note? note;
-  const AddEditNoteScreen({this.note, super.key});
+  final String? initialPlantId;
+  const AddEditNoteScreen({this.note, this.initialPlantId, super.key});
 
   @override
   State<AddEditNoteScreen> createState() => _AddEditNoteScreenState();
@@ -27,7 +28,8 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
     super.initState();
     _titleController = TextEditingController(text: widget.note?.title ?? '');
     _contentController = TextEditingController(text: widget.note?.content ?? '');
-    _selectedPlantIds = widget.note?.plantIds ?? [];
+    _selectedPlantIds = widget.note?.plantIds ??
+        (widget.initialPlantId != null ? [widget.initialPlantId!] : []);
     _selectedImagePaths = widget.note?.imagePaths ?? [];
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -377,7 +377,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         return;
       }
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('エクスポートしました: $path')),
+        const SnackBar(content: Text('バックアップファイルを共有しました')),
       );
     } catch (e) {
       if (!mounted) return;

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -336,7 +336,18 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
           ),
         ],
       ),
-      body: _isCalendarView ? _buildCalendarView() : _buildLogList(isToday),
+      body: GestureDetector(
+        onHorizontalDragEnd: (details) {
+          // 左スワイプ → 翌日、右スワイプ → 前日
+          if (details.primaryVelocity == null) return;
+          if (details.primaryVelocity! < -300) {
+            _changeDate(1);
+          } else if (details.primaryVelocity! > 300) {
+            _changeDate(-1);
+          }
+        },
+        child: _isCalendarView ? _buildCalendarView() : _buildLogList(isToday),
+      ),
       floatingActionButton: _selectedPlantIds.isNotEmpty
           ? Column(
               mainAxisSize: MainAxisSize.min,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -637,6 +637,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  share_plus:
+    dependency: "direct main"
+    description:
+      name: share_plus
+      sha256: fce43200aa03ea87b91ce4c3ac79f0cecd52e2a7a56c7a4185023c271fbfa6da
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.4"
+  share_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: share_plus_platform_interface
+      sha256: cc012a23fc2d479854e6c80150696c4a5f5bb62cb89af4de1c505cf78d0a5d0b
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -826,6 +842,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,7 @@ dependencies:
   path: ^1.8.3
   file_picker: ^10.3.10
   archive: ^4.0.9
+  share_plus: ^10.1.4
   permission_handler: ^11.2.0
   
   # UUID generation


### PR DESCRIPTION
## 変更内容

### #76 エクスポート機能の修正
- FilePicker.saveFile → Share.shareXFiles (share_plus) に変更
- ZIP を一時ディレクトリに生成し OS シェアシートで共有

### #77 スワイプで日付切り替え
- 水やりログ画面の body を GestureDetector でラップ
- 左スワイプ → 翌日 / 右スワイプ → 前日

### #69 植物詳細の FAB を削除
- FAB (水やりボタン) を削除
- 「記録」アクションを SliverAppBar の actions に移動（+ アイコン）

### #70 植物詳細画面にノートタブ追加
- TabController length 2 → 3（情報 / ログ / ノート）
- ノートタブ: 当該植物に紐付くノートをリスト表示
- 空の場合は「ノートを追加」ボタン表示（植物を事前選択）
- AddEditNoteScreen に initialPlantId パラメータを追加

Closes #76, #77, #69, #70