### PR TITLE
feat: fertilizer/vitalizer interval settings (#65)

### DIFF
--- a/lib/models/plant.dart
+++ b/lib/models/plant.dart
@@ -6,6 +6,12 @@ class Plant {
   final String? purchaseLocation;
   final String? imagePath;
   final int? wateringIntervalDays;
+  // 肥料間隔（日数指定 / 水やりN回に1回 どちらか一方のみ設定）
+  final int? fertilizerIntervalDays;
+  final int? fertilizerEveryNWaterings;
+  // 活力剤間隔（同上）
+  final int? vitalizerIntervalDays;
+  final int? vitalizerEveryNWaterings;
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -17,6 +23,10 @@ class Plant {
     this.purchaseLocation,
     this.imagePath,
     this.wateringIntervalDays,
+    this.fertilizerIntervalDays,
+    this.fertilizerEveryNWaterings,
+    this.vitalizerIntervalDays,
+    this.vitalizerEveryNWaterings,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -30,6 +40,10 @@ class Plant {
       'purchaseLocation': purchaseLocation,
       'imagePath': imagePath,
       'wateringIntervalDays': wateringIntervalDays,
+      'fertilizerIntervalDays': fertilizerIntervalDays,
+      'fertilizerEveryNWaterings': fertilizerEveryNWaterings,
+      'vitalizerIntervalDays': vitalizerIntervalDays,
+      'vitalizerEveryNWaterings': vitalizerEveryNWaterings,
       'createdAt': createdAt.toIso8601String(),
       'updatedAt': updatedAt.toIso8601String(),
     };
@@ -46,6 +60,10 @@ class Plant {
       purchaseLocation: map['purchaseLocation'],
       imagePath: map['imagePath'],
       wateringIntervalDays: map['wateringIntervalDays'],
+      fertilizerIntervalDays: map['fertilizerIntervalDays'],
+      fertilizerEveryNWaterings: map['fertilizerEveryNWaterings'],
+      vitalizerIntervalDays: map['vitalizerIntervalDays'],
+      vitalizerEveryNWaterings: map['vitalizerEveryNWaterings'],
       createdAt: DateTime.parse(map['createdAt']),
       updatedAt: DateTime.parse(map['updatedAt']),
     );
@@ -58,6 +76,10 @@ class Plant {
     String? purchaseLocation,
     String? imagePath,
     int? wateringIntervalDays,
+    Object? fertilizerIntervalDays = _sentinel,
+    Object? fertilizerEveryNWaterings = _sentinel,
+    Object? vitalizerIntervalDays = _sentinel,
+    Object? vitalizerEveryNWaterings = _sentinel,
     DateTime? updatedAt,
   }) {
     return Plant(
@@ -68,8 +90,22 @@ class Plant {
       purchaseLocation: purchaseLocation ?? this.purchaseLocation,
       imagePath: imagePath ?? this.imagePath,
       wateringIntervalDays: wateringIntervalDays ?? this.wateringIntervalDays,
+      fertilizerIntervalDays: fertilizerIntervalDays == _sentinel
+          ? this.fertilizerIntervalDays
+          : fertilizerIntervalDays as int?,
+      fertilizerEveryNWaterings: fertilizerEveryNWaterings == _sentinel
+          ? this.fertilizerEveryNWaterings
+          : fertilizerEveryNWaterings as int?,
+      vitalizerIntervalDays: vitalizerIntervalDays == _sentinel
+          ? this.vitalizerIntervalDays
+          : vitalizerIntervalDays as int?,
+      vitalizerEveryNWaterings: vitalizerEveryNWaterings == _sentinel
+          ? this.vitalizerEveryNWaterings
+          : vitalizerEveryNWaterings as int?,
       createdAt: createdAt,
       updatedAt: updatedAt ?? DateTime.now(),
     );
   }
 }
+
+const Object _sentinel = Object();

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -106,6 +106,10 @@ class PlantProvider with ChangeNotifier {
     String? purchaseLocation,
     String? imagePath,
     int? wateringIntervalDays,
+    int? fertilizerIntervalDays,
+    int? fertilizerEveryNWaterings,
+    int? vitalizerIntervalDays,
+    int? vitalizerEveryNWaterings,
   }) async {
     final now = DateTime.now();
     final plant = Plant(
@@ -116,6 +120,10 @@ class PlantProvider with ChangeNotifier {
       purchaseLocation: purchaseLocation,
       imagePath: imagePath,
       wateringIntervalDays: wateringIntervalDays,
+      fertilizerIntervalDays: fertilizerIntervalDays,
+      fertilizerEveryNWaterings: fertilizerEveryNWaterings,
+      vitalizerIntervalDays: vitalizerIntervalDays,
+      vitalizerEveryNWaterings: vitalizerEveryNWaterings,
       createdAt: now,
       updatedAt: now,
     );

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -443,6 +443,13 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
         _buildBasicInfoCard(),
         const SizedBox(height: 16),
         _buildWateringInfoCard(),
+        if (widget.plant.fertilizerIntervalDays != null ||
+            widget.plant.fertilizerEveryNWaterings != null ||
+            widget.plant.vitalizerIntervalDays != null ||
+            widget.plant.vitalizerEveryNWaterings != null) ...[
+          const SizedBox(height: 16),
+          _buildFertilizerInfoCard(),
+        ],
       ],
     );
   }
@@ -481,6 +488,36 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
             valueColor: _nextWateringDate!.isBefore(DateTime.now())
                 ? Theme.of(context).colorScheme.error
                 : null,
+          ),
+      ],
+    );
+  }
+
+  Widget _buildFertilizerInfoCard() {
+    String _intervalText(int? days, int? everyN) {
+      if (days != null) return '$days日ごと';
+      if (everyN != null) return '水やり${everyN}回に1回';
+      return '未設定';
+    }
+
+    return _InfoCard(
+      title: '施肥情報',
+      children: [
+        if (widget.plant.fertilizerIntervalDays != null ||
+            widget.plant.fertilizerEveryNWaterings != null)
+          _InfoRow(
+            label: '肥料間隔',
+            value: _intervalText(
+                widget.plant.fertilizerIntervalDays,
+                widget.plant.fertilizerEveryNWaterings),
+          ),
+        if (widget.plant.vitalizerIntervalDays != null ||
+            widget.plant.vitalizerEveryNWaterings != null)
+          _InfoRow(
+            label: '活力剤間隔',
+            value: _intervalText(
+                widget.plant.vitalizerIntervalDays,
+                widget.plant.vitalizerEveryNWaterings),
           ),
       ],
     );

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -31,7 +31,7 @@ class DatabaseService {
     String path = join(await getDatabasesPath(), 'water_me.db');
     return await openDatabase(
       path,
-      version: 3,
+      version: 4,
       onCreate: _onCreate,
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -56,6 +56,22 @@ class DatabaseService {
             // ignore if column already exists
           }
         }
+        if (oldVersion < 4) {
+          // add fertilizer/vitalizer interval columns to plants
+          for (final col in [
+            'fertilizerIntervalDays',
+            'fertilizerEveryNWaterings',
+            'vitalizerIntervalDays',
+            'vitalizerEveryNWaterings',
+          ]) {
+            try {
+              await db.execute(
+                  'ALTER TABLE plants ADD COLUMN $col INTEGER');
+            } catch (_) {
+              // ignore if column already exists
+            }
+          }
+        }
       },
     );
   }
@@ -70,6 +86,10 @@ class DatabaseService {
         purchaseLocation TEXT,
         imagePath TEXT,
         wateringIntervalDays INTEGER,
+        fertilizerIntervalDays INTEGER,
+        fertilizerEveryNWaterings INTEGER,
+        vitalizerIntervalDays INTEGER,
+        vitalizerEveryNWaterings INTEGER,
         createdAt TEXT NOT NULL,
         updatedAt TEXT NOT NULL
       )


### PR DESCRIPTION
## 概要
肥料・活力剤の間隔設定機能を追加します。

## 変更内容

### モデル・DB
- \Plant\ に 4 フィールド追加: \ertilizerIntervalDays\, \ertilizerEveryNWaterings\, \italizerIntervalDays\, \italizerEveryNWaterings\
- DB version 3→4: \ALTER TABLE plants ADD COLUMN\ でマイグレーション

### 植物登録・編集画面
- 肥料/活力剤の間隔設定行を追加
- **\_LogIntervalDialog\**: \SegmentedButton\ で 2 モード切り替え
  - 日数指定（スライダー 1〜60日）
  - 水やり N 回に 1 回（スライダー 2〜10回）
  - 水やり間隔設定済みの場合は「≈ X日ごと」のヒント表示

### 植物詳細画面
- 情報タブに「施肥情報」カードを追加（設定済みの場合のみ表示）

Closes #65