### PR TITLE
fix: Batch E-2 データ・通知系バグ修正 (#83 #86 #89)

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -20,9 +20,18 @@ class SettingsProvider with ChangeNotifier {
   List<String> get customSortOrder => _settings.customSortOrder;
 
   /// 保存済み設定を読み込む。
+  /// 通知が有効な場合はアプリ起動時に再スケジュールする。
   Future<void> loadSettings() async {
     _settings = await _settingsService.loadSettings();
     notifyListeners();
+    // アプリ起動時に通知設定が有効なら再スケジュール
+    // （OSが再起動するとスケジュール済み通知が消えるため）
+    if (_settings.notificationEnabled && !kIsWeb) {
+      await NotificationService().scheduleDailyWateringReminder(
+        hour: _settings.notificationHour,
+        minute: _settings.notificationMinute,
+      );
+    }
   }
 
   /// 表示モードを変更する。

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -58,7 +58,23 @@ class _FullScreenImageViewerState extends State<_FullScreenImageViewer> {
           final heroTag = 'note_image_${widget.noteId}_$index';
           final img = kIsWeb
               ? Image.network(p, fit: BoxFit.contain)
-              : Image.file(File(p), fit: BoxFit.contain);
+              : Image.file(
+                  File(p),
+                  fit: BoxFit.contain,
+                  errorBuilder: (context, error, stackTrace) =>
+                      const Center(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(Icons.broken_image_outlined,
+                                color: Colors.white54, size: 64),
+                            SizedBox(height: 8),
+                            Text('画像を読み込めませんでした',
+                                style: TextStyle(color: Colors.white54)),
+                          ],
+                        ),
+                      ),
+                );
           return InteractiveViewer(
             minScale: 0.5,
             maxScale: 5.0,
@@ -163,8 +179,28 @@ class NoteDetailScreen extends StatelessWidget {
                   final p = entry.value;
                   final heroTag = 'note_image_${note.id}_$index';
                   final img = kIsWeb
-                      ? Image.network(p, width: 120, height: 120, fit: BoxFit.cover)
-                      : Image.file(File(p), width: 120, height: 120, fit: BoxFit.cover);
+                      ? Image.network(p,
+                          width: 120, height: 120, fit: BoxFit.cover)
+                      : Image.file(
+                          File(p),
+                          width: 120,
+                          height: 120,
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, error, stackTrace) =>
+                              Container(
+                                width: 120,
+                                height: 120,
+                                decoration: BoxDecoration(
+                                  color: Theme.of(context)
+                                      .colorScheme
+                                      .surfaceContainerHighest,
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                                child: const Icon(
+                                    Icons.broken_image_outlined,
+                                    size: 40),
+                              ),
+                        );
                   return GestureDetector(
                     onTap: () => Navigator.of(context).push(
                       MaterialPageRoute(

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -175,19 +175,46 @@ class ExportService {
     if (kIsWeb) {
       final bytes = file.bytes;
       if (bytes == null) return null;
-      // Web は JSON のみ
-      return _importFromJson(utf8.decode(bytes));
+      if (_isZipBytes(bytes)) {
+        // Web では一時パスがないため ZIP 展開はサポート外
+        throw const FormatException('WebブラウザではZIPインポートはサポートされていません');
+      }
+      // BOM付きUTF-8も考慮してデコード
+      return _importFromJson(_decodeUtf8(bytes));
     }
 
     final path = file.path;
     if (path == null) return null;
 
-    if (path.toLowerCase().endsWith('.zip')) {
+    // 拡張子ではなくバイナリのマジックバイトでZIP判定（#86）
+    final bytes = await File(path).readAsBytes();
+    if (_isZipBytes(bytes)) {
       return _importFromZip(path);
     } else {
-      final jsonStr = await File(path).readAsString(encoding: utf8);
-      return _importFromJson(jsonStr);
+      // BOM付きUTF-8・通常UTF-8のどちらも対応
+      return _importFromJson(_decodeUtf8(bytes));
     }
+  }
+
+  /// ZIPのマジックバイト（PK\x03\x04）でZIPかどうか判定する
+  bool _isZipBytes(List<int> bytes) {
+    return bytes.length >= 4 &&
+        bytes[0] == 0x50 && // P
+        bytes[1] == 0x4B && // K
+        bytes[2] == 0x03 &&
+        bytes[3] == 0x04;
+  }
+
+  /// BOM付きUTF-8も含めてUTF-8デコードする
+  String _decodeUtf8(List<int> bytes) {
+    // UTF-8 BOM (EF BB BF) が付いている場合は除去してデコード
+    if (bytes.length >= 3 &&
+        bytes[0] == 0xEF &&
+        bytes[1] == 0xBB &&
+        bytes[2] == 0xBF) {
+      return utf8.decode(bytes.sublist(3));
+    }
+    return utf8.decode(bytes);
   }
 
   /// ZIP ファイルからデータを復元する


### PR DESCRIPTION
## 概要
データ・通知系バグ3件を修正します。

## 変更内容

### fix #89 リマインダー通知が来ない
- **原因**: OS再起動やアプリ再インストール後、スケジュール済み通知が消えても再スケジュールされていなかった
- **修正**: \SettingsProvider.loadSettings()\ で設定読み込み後、\
otificationEnabled == true\ なら通知を再スケジュールするよう修正

### fix #86 インポートのUTF-8デコード失敗
- **原因**: ファイルの拡張子でZIP/JSONを判定していたが、一時ファイルにコピーされた場合など拡張子が変わるケースで \eadAsString(encoding: utf8)\ にZIPバイナリを渡してデコード例外が発生
- **修正**: ZIPのマジックバイト（\PK\\x03\\x04\）でフォーマットを判定するよう変更。BOM付きUTF-8 JSONも対応

### fix #83 ノート添付画像の PathNotFoundException・エラー表示改善
- **原因**: \Image.file()\ にエラーハンドラーがなく、ファイルが存在しない場合に例外がそのまま画面に表示されていた
- **修正**: サムネイル・フルスクリーンビューワー両方に \rrorBuilder\ を追加し、読み込み失敗時は \roken_image\ アイコンを表示するよう改善