### PR TITLE
fix: ログ種別テキスト/exact alarm通知/ノート設定ボタン (#102 #103 #104)

### DIFF
--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -7,6 +7,7 @@ import '../providers/note_provider.dart';
 import '../providers/plant_provider.dart';
 import 'add_edit_note_screen.dart';
 import 'note_detail_screen.dart';
+import 'settings_screen.dart';
 
 class NotesListScreen extends StatefulWidget {
   const NotesListScreen({super.key});
@@ -164,6 +165,17 @@ class _NotesListScreenState extends State<NotesListScreen> {
               });
             },
           ),
+          // 設定画面へ遷移 (#104)
+          if (!_isSearching)
+            IconButton(
+              icon: const Icon(Icons.settings),
+              tooltip: '設定',
+              onPressed: () => Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (_) => const SettingsScreen(),
+                ),
+              ),
+            ),
           // 植物フィルタ
           Consumer<PlantProvider>(
             builder: (context, plantProvider, _) {

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -556,13 +556,26 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
             Expanded(
               child: Wrap(
                 spacing: 8,
+                runSpacing: 4,
                 children: logs.map((log) {
                   return Tooltip(
                     message: log.note ?? _getLogTypeName(log.type),
-                    child: Icon(
-                      _getIconForLogType(log.type),
-                      size: 20,
-                      color: Theme.of(context).colorScheme.primary,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          _getIconForLogType(log.type),
+                          size: 16,
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                        const SizedBox(width: 3),
+                        Text(
+                          _getLogTypeName(log.type),
+                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                        ),
+                      ],
                     ),
                   );
                 }).toList(),

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -48,7 +48,10 @@ class NotificationService {
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>();
     if (androidImpl != null) {
+      // 通知権限（Android 13+）
       final granted = await androidImpl.requestNotificationsPermission();
+      // Exact alarm権限（Android 12+で正確な時刻指定に必要）
+      await androidImpl.requestExactAlarmsPermission();
       return granted ?? false;
     }
 
@@ -111,18 +114,30 @@ class NotificationService {
       macOS: darwinDetails,
     );
 
+    // exact alarm権限がある場合はexactAllowWhileIdle、ない場合はinexactにフォールバック
+    AndroidScheduleMode scheduleMode = AndroidScheduleMode.inexact;
+    final androidImpl = _plugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    if (androidImpl != null) {
+      final hasExact = await androidImpl.canScheduleExactNotifications();
+      if (hasExact ?? false) {
+        scheduleMode = AndroidScheduleMode.exactAllowWhileIdle;
+      }
+    }
+
     await _plugin.zonedSchedule(
       id: _dailyWateringNotificationId,
       title: '💧 水やりの時間です',
       body: '水やりが必要な植物を確認しましょう',
       scheduledDate: scheduledDate,
       notificationDetails: details,
-      androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
+      androidScheduleMode: scheduleMode,
       matchDateTimeComponents: DateTimeComponents.time, // 毎日繰り返し
     );
 
     debugPrint(
-        'NotificationService: scheduled daily at $hour:${minute.toString().padLeft(2, '0')}');
+        'NotificationService: scheduled daily at $hour:${minute.toString().padLeft(2, '0')} (mode: $scheduleMode)');
   }
 
   /// 水やり通知をキャンセルする。


### PR DESCRIPTION
## 対応Issue
- #102 植物ログのアイコンにテキスト追加
- #103 リマインダー通知が来ない（Android exact alarm権限）
- #104 ノート画面から設定画面を開けるようにする

## 変更内容

### #102 — plant_detail_screen.dart
- _buildGroupedLogRow 内のアイコンを Row(Icon + Text) に変更
- アイコン横に「水やり」「肥料」等のテキストを横並び表示

### #103 — notification_service.dart
- equestPermission() に Android 12+ 向け equestExactAlarmsPermission() を追加
- scheduleDailyWateringReminder() に canScheduleExactNotifications() チェックを追加
- exact alarm権限がない場合は AndroidScheduleMode.inexact にフォールバック

### #104 — notes_list_screen.dart
- AppBar actions に設定ボタン（Icons.settings）を追加
- 検索モード中は非表示、通常時に表示
- タップで SettingsScreen へ遷移