### PR TITLE
fix: 通知タイムゾーン修正・USE_EXACT_ALARM追加 (#103追加修正)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Push notification permissions -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <!-- Android 12 (API 31-32): ユーザーが許可設定画面で許可する必要あり -->
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
+    <!-- Android 13+ (API 33+): 自動付与（ユーザー許可不要） -->
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 
     <application

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart' show kIsWeb, debugPrint;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest_all.dart' as tz;
 
@@ -21,6 +22,14 @@ class NotificationService {
     if (_initialized) return;
 
     tz.initializeTimeZones();
+    // デバイスのタイムゾーンを取得してtzに設定（未設定だとUTCになる）
+    try {
+      final tzInfo = await FlutterTimezone.getLocalTimezone();
+      tz.setLocalLocation(tz.getLocation(tzInfo.identifier));
+      debugPrint('NotificationService: timezone set to ${tzInfo.identifier}');
+    } catch (e) {
+      debugPrint('NotificationService: failed to get timezone, using UTC: $e');
+    }
 
     const androidSettings =
         AndroidInitializationSettings('@mipmap/ic_launcher');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -264,6 +272,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: "direct main"
+    description:
+      name: flutter_timezone
+      sha256: "978192f2f9ea6d019a4de4f0211d76a9af955ca24865828fa98ca4e20cf0cb3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.1"
   flutter_web_plugins:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dependencies:
   
   # UUID generation
   uuid: ^4.3.3
+  flutter_timezone: ^5.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 対応Issue\n- #103 リマインダー通知が来ない（追加修正）\n\n## 根本原因\n	z.local が UTC のままで、日本時間と **9時間ずれて**いたため通知が届かなかった。\n\n## 変更内容\n\n### lib/services/notification_service.dart\n- lutter_timezone パッケージを追加\n- initialize() 内で FlutterTimezone.getLocalTimezone() → 	z.setLocalLocation() を呼び、デバイスの正確なタイムゾーン（Asia/Tokyo 等）を設定\n\n### ndroid/app/src/main/AndroidManifest.xml\n- USE_EXACT_ALARM パーミッションを追加\n  - Android 13+（API 33+）では自動付与でユーザー許可不要\n  - SCHEDULE_EXACT_ALARM（Android 12向け）は引き続き併記\n\n### pubspec.yaml / pubspec.lock\n- lutter_timezone: ^5.0.1 を追加