### PR TITLE
fix: PlantProvider に hasAnyWateringScheduledForToday を追加

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -286,6 +286,21 @@ class PlantProvider with ChangeNotifier {
     await loadPlants();
   }
 
+  /// 今日水やり予定の植物が1つ以上あるか返す。
+  /// 通知コールバック用。
+  Future<bool> hasAnyWateringScheduledForToday() async {
+    final today = DateTime.now();
+    final todayDate = DateTime(today.year, today.month, today.day);
+    for (final plant in _plants) {
+      final next = _nextWateringCache[plant.id];
+      if (next != null) {
+        final nextDate = DateTime(next.year, next.month, next.day);
+        if (!nextDate.isAfter(todayDate)) return true;
+      }
+    }
+    return false;
+  }
+
   /// 最終水やりログから次回水やり日を動的に計算する。
   /// 水やり間隔が未設定の場合は null を返す。
   // 動的に次回水やり日を計算（ログから算出）


### PR DESCRIPTION
## 概要
SettingsProvider.setupNotificationCallback() から呼び出される hasAnyWateringScheduledForToday() メソッドが PlantProvider に未定義だったコンパイルエラーを修正する。

## 変更内容
- PlantProvider に hasAnyWateringScheduledForToday() メソッドを追加
  - _nextWateringCache を参照し、今日以前に水やり予定がある植物が1つ以上あれば 	rue を返す
  - 通知スケジュールのコールバック用途

## 修正前のエラー
\\\
The method 'hasAnyWateringScheduledForToday' isn't defined for the type 'PlantProvider'.
\\\

## テスト
- lutter analyze でエラーなし確認済み