### PR TITLE
fix: 旧DBバックアップ/移行機能を削除（Android サンドボックス制限）

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,10 +1,6 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:provider/provider.dart';
-import 'package:sqflite/sqflite.dart';
-import 'package:path/path.dart' as p;
-import 'package:share_plus/share_plus.dart';
 import '../providers/settings_provider.dart';
 import '../providers/plant_provider.dart';
 import '../providers/note_provider.dart';
@@ -21,9 +17,6 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _isExporting = false;
   bool _isImporting = false;
-  // ── データ移行（暫定: water_me.db → bota_note.db）
-  bool _isBackingUp = false;
-  bool _isMigrating = false;
 
   @override
   Widget build(BuildContext context) {
@@ -165,35 +158,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
             title: const Text('データをインポート'),
             subtitle: const Text('ZIP または JSON ファイルからデータを復元'),
             onTap: _isImporting ? null : () => _handleImport(context),
-          ),
-          const Divider(),
-
-          // ── データ移行（暫定: water_me.db → bota_note.db） ──────────
-          // TODO: リリース前に削除すること
-          _buildSectionHeader(context, 'データ移行（暫定）'),
-          ListTile(
-            leading: _isBackingUp
-                ? const SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.backup),
-            title: const Text('旧DBバックアップ'),
-            subtitle: const Text('water_me.db を共有／保存します'),
-            onTap: _isBackingUp ? null : () => _handleLegacyDbBackup(context),
-          ),
-          ListTile(
-            leading: _isMigrating
-                ? const SizedBox(
-                    width: 24,
-                    height: 24,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.drive_file_move),
-            title: const Text('bota_note.db に移行'),
-            subtitle: const Text('water_me.db を bota_note.db としてコピーします（旧DBは残します）'),
-            onTap: _isMigrating ? null : () => _handleLegacyDbMigrate(context),
           ),
           const Divider(),
 
@@ -472,161 +436,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
       );
     } finally {
       if (mounted) setState(() => _isImporting = false);
-    }
-  }
-
-  // ── データ移行（暫定: water_me.db → bota_note.db） ─────────────
-  // TODO: リリース前に削除すること
-
-  /// DBディレクトリ内の .db ファイルを列挙して返す（デバッグ用）
-  Future<List<String>> _listDbFiles(String dbDir) async {
-    try {
-      final dir = Directory(dbDir);
-      if (!await dir.exists()) return [];
-      return await dir
-          .list()
-          .where((e) => e is File && e.path.endsWith('.db'))
-          .map((e) => p.basename(e.path))
-          .toList();
-    } catch (_) {
-      return [];
-    }
-  }
-
-  /// 旧パッケージ (com.example.water_me) の databases ディレクトリパスを返す。
-  /// getDatabasesPath() は現パッケージのパスを返すため、パス文字列を置換して導出する。
-  Future<String> _legacyDbDir() async {
-    final currentDir = await getDatabasesPath();
-    // Android: /data/user/0/<package>/databases
-    final legacy = currentDir.replaceFirst(
-      'com.example.bota_note',
-      'com.example.water_me',
-    );
-    debugPrint('[Legacy] currentDir: $currentDir');
-    debugPrint('[Legacy] legacyDir : $legacy');
-    return legacy;
-  }
-
-  /// water_me.db を共有シートで保存・共有する（バックアップ）
-  Future<void> _handleLegacyDbBackup(BuildContext context) async {
-    setState(() => _isBackingUp = true);
-    try {
-      final dbDir = await _legacyDbDir();
-      final legacyPath = p.join(dbDir, 'water_me.db');
-      final legacyFile = File(legacyPath);
-
-      debugPrint('[LegacyBackup] legacyPath: $legacyPath');
-      debugPrint('[LegacyBackup] exists: ${await legacyFile.exists()}');
-
-      if (!await legacyFile.exists()) {
-        final dbFiles = await _listDbFiles(dbDir);
-        debugPrint('[LegacyBackup] .db files in dir: $dbFiles');
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              'water_me.db が見つかりません\n'
-              'パス: $dbDir\n'
-              '検出された .db: ${dbFiles.isEmpty ? "なし" : dbFiles.join(", ")}',
-            ),
-            duration: const Duration(seconds: 6),
-          ),
-        );
-        return;
-      }
-
-      // 共有シートで保存先を選択させる
-      final xFile = XFile(legacyPath, mimeType: 'application/octet-stream');
-      await Share.shareXFiles(
-        [xFile],
-        subject: 'water_me.db バックアップ',
-      );
-    } catch (e, st) {
-      debugPrint('[LegacyBackup] error: $e\n$st');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('バックアップに失敗しました: $e')),
-      );
-    } finally {
-      if (mounted) setState(() => _isBackingUp = false);
-    }
-  }
-
-  /// water_me.db → bota_note.db にコピーする（旧DBは削除しない）
-  Future<void> _handleLegacyDbMigrate(BuildContext context) async {
-    final legacyDbDir = await _legacyDbDir();
-    final currentDbDir = await getDatabasesPath();
-    final legacyPath = p.join(legacyDbDir, 'water_me.db');
-    final newPath = p.join(currentDbDir, 'bota_note.db');
-    final legacyFile = File(legacyPath);
-    final newFile = File(newPath);
-
-    debugPrint('[LegacyMigrate] legacyPath: $legacyPath');
-    debugPrint('[LegacyMigrate] newPath   : $newPath');
-    debugPrint('[LegacyMigrate] exists: ${await legacyFile.exists()}');
-
-    // 旧DBの存在確認
-    if (!await legacyFile.exists()) {
-      final dbFiles = await _listDbFiles(legacyDbDir);
-      debugPrint('[LegacyMigrate] .db files in legacyDir: $dbFiles');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            'water_me.db が見つかりません\n'
-            'パス: $legacyDbDir\n'
-            '検出された .db: ${dbFiles.isEmpty ? "なし" : dbFiles.join(", ")}',
-          ),
-          duration: const Duration(seconds: 6),
-        ),
-      );
-      return;
-    }
-
-    // 新DBが既に存在する場合は上書き確認
-    if (await newFile.exists()) {
-      if (!mounted) return;
-      final overwrite = await showDialog<bool>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: const Text('確認'),
-          content: const Text(
-            'bota_note.db が既に存在します。\n上書きしますか？\n（アプリを再起動すると移行後のデータが有効になります）',
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(ctx).pop(false),
-              child: const Text('キャンセル'),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.of(ctx).pop(true),
-              child: const Text('上書き'),
-            ),
-          ],
-        ),
-      );
-      if (overwrite != true) return;
-    }
-
-    setState(() => _isMigrating = true);
-    try {
-      await legacyFile.copy(newPath);
-      debugPrint('[LegacyMigrate] copy done: $newPath');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('移行完了。アプリを再起動してください。'),
-          duration: Duration(seconds: 4),
-        ),
-      );
-    } catch (e, st) {
-      debugPrint('[LegacyMigrate] error: $e\n$st');
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('移行に失敗しました: $e')),
-      );
-    } finally {
-      if (mounted) setState(() => _isMigrating = false);
     }
   }
 


### PR DESCRIPTION
## 概要

PR#112 で追加された旧DBバックアップ/移行機能（water_me.db → bota_note.db）が
Android のサンドボックス制限により動作不可と判明したため、削除する。

## 原因

getDatabasesPath() は現在のパッケージのディレクトリを返すが、
\water_me.db\ は旧パッケージ \com.example.water_me\ のディレクトリに存在する。

\\\
// 現パッケージ（アクセス可）
/data/user/0/com.example.bota_note/databases/bota_note.db

// 旧パッケージ（Android サンドボックスによりアクセス不可）
/data/user/0/com.example.water_me/databases/water_me.db
\\\

実機ログにて確認済み：
\\\
[LegacyBackup] legacyPath: /data/user/0/com.example.water_me/databases/water_me.db
[LegacyBackup] exists: false
[LegacyBackup] .db files in dir: []
\\\

## 変更内容

- 移行セクション UI（ListTile × 2）を削除
- _handleLegacyDbBackup() / _handleLegacyDbMigrate() を削除
- _legacyDbDir() / _listDbFiles() を削除
- _isBackingUp / _isMigrating フィールドを削除
- 不要 import（dart:io, sqflite, path, share_plus, debugPrint）を削除

## 代替手段

データ移行が必要な場合は、旧アプリ側で JSON エクスポートし、
新アプリの既存インポート機能で取り込む方法が必要。