### PR TITLE
fix(#107): 肥料・活力剤の間隔を水やり予定画面に反映

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -319,6 +319,144 @@ class PlantProvider with ChangeNotifier {
     return lastWatering.date.add(Duration(days: plant.wateringIntervalDays!));
   }
 
+  /// 最終肥料ログから次回肥料予定日を動的に計算する。
+  /// - [fertilizerIntervalDays] が設定されている場合: 最終肥料日 + 日数
+  /// - [fertilizerEveryNWaterings] が設定されている場合: 最終肥料日以降の
+  ///   水やり回数が N 回に達する日（水やり間隔から推定）
+  /// どちらも未設定の場合は null を返す。
+  Future<DateTime?> calculateNextFertilizerDate(String plantId) async {
+    Plant? plant;
+    if (kIsWeb) {
+      plant = await _web!.getPlant(plantId);
+    } else {
+      plant = await _db!.getPlant(plantId);
+    }
+    if (plant == null) return null;
+
+    List<LogEntry> fertLogs;
+    if (kIsWeb) {
+      fertLogs = await _web!.getLogsByPlantAndType(plantId, LogType.fertilizer);
+    } else {
+      fertLogs = await _db!.getLogsByPlantAndType(plantId, LogType.fertilizer);
+    }
+
+    // 日数指定の場合
+    if (plant.fertilizerIntervalDays != null) {
+      if (fertLogs.isEmpty) {
+        final base = plant.purchaseDate ?? plant.createdAt;
+        return base.add(Duration(days: plant.fertilizerIntervalDays!));
+      }
+      fertLogs.sort((a, b) => b.date.compareTo(a.date));
+      return fertLogs.first.date
+          .add(Duration(days: plant.fertilizerIntervalDays!));
+    }
+
+    // 水やりN回に1回の場合
+    if (plant.fertilizerEveryNWaterings != null &&
+        plant.wateringIntervalDays != null) {
+      final n = plant.fertilizerEveryNWaterings!;
+      // 最終肥料日以降の水やりログを数える
+      final lastFertDate =
+          fertLogs.isEmpty ? (plant.purchaseDate ?? plant.createdAt) : () {
+            fertLogs.sort((a, b) => b.date.compareTo(a.date));
+            return fertLogs.first.date;
+          }();
+
+      List<LogEntry> wateringLogs;
+      if (kIsWeb) {
+        wateringLogs =
+            await _web!.getLogsByPlantAndType(plantId, LogType.watering);
+      } else {
+        wateringLogs =
+            await _db!.getLogsByPlantAndType(plantId, LogType.watering);
+      }
+      final wateringsAfter = wateringLogs
+          .where((l) => l.date.isAfter(lastFertDate))
+          .toList()
+        ..sort((a, b) => a.date.compareTo(b.date));
+
+      // 既にN回以上水やりしていれば今日が予定
+      if (wateringsAfter.length >= n) {
+        return wateringsAfter[n - 1].date;
+      }
+      // 不足回数分を水やり間隔で推定
+      final remaining = n - wateringsAfter.length;
+      final baseDate = wateringsAfter.isNotEmpty
+          ? wateringsAfter.last.date
+          : lastFertDate;
+      return baseDate
+          .add(Duration(days: plant.wateringIntervalDays! * remaining));
+    }
+
+    return null;
+  }
+
+  /// 最終活力剤ログから次回活力剤予定日を動的に計算する。
+  /// ロジックは [calculateNextFertilizerDate] と同様。
+  Future<DateTime?> calculateNextVitalizerDate(String plantId) async {
+    Plant? plant;
+    if (kIsWeb) {
+      plant = await _web!.getPlant(plantId);
+    } else {
+      plant = await _db!.getPlant(plantId);
+    }
+    if (plant == null) return null;
+
+    List<LogEntry> vitLogs;
+    if (kIsWeb) {
+      vitLogs = await _web!.getLogsByPlantAndType(plantId, LogType.vitalizer);
+    } else {
+      vitLogs = await _db!.getLogsByPlantAndType(plantId, LogType.vitalizer);
+    }
+
+    // 日数指定の場合
+    if (plant.vitalizerIntervalDays != null) {
+      if (vitLogs.isEmpty) {
+        final base = plant.purchaseDate ?? plant.createdAt;
+        return base.add(Duration(days: plant.vitalizerIntervalDays!));
+      }
+      vitLogs.sort((a, b) => b.date.compareTo(a.date));
+      return vitLogs.first.date
+          .add(Duration(days: plant.vitalizerIntervalDays!));
+    }
+
+    // 水やりN回に1回の場合
+    if (plant.vitalizerEveryNWaterings != null &&
+        plant.wateringIntervalDays != null) {
+      final n = plant.vitalizerEveryNWaterings!;
+      final lastVitDate =
+          vitLogs.isEmpty ? (plant.purchaseDate ?? plant.createdAt) : () {
+            vitLogs.sort((a, b) => b.date.compareTo(a.date));
+            return vitLogs.first.date;
+          }();
+
+      List<LogEntry> wateringLogs;
+      if (kIsWeb) {
+        wateringLogs =
+            await _web!.getLogsByPlantAndType(plantId, LogType.watering);
+      } else {
+        wateringLogs =
+            await _db!.getLogsByPlantAndType(plantId, LogType.watering);
+      }
+      final wateringsAfter = wateringLogs
+          .where((l) => l.date.isAfter(lastVitDate))
+          .toList()
+        ..sort((a, b) => a.date.compareTo(b.date));
+
+      if (wateringsAfter.length >= n) {
+        return wateringsAfter[n - 1].date;
+      }
+      final remaining = n - wateringsAfter.length;
+      final baseDate = wateringsAfter.isNotEmpty
+          ? wateringsAfter.last.date
+          : lastVitDate;
+      return baseDate
+          .add(Duration(days: plant.wateringIntervalDays! * remaining));
+    }
+
+    return null;
+  }
+
   /// 指定植物・種別・日付のログ一覧を取得する。
   Future<List<LogEntry>> getLogsForDate(
     String plantId,

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -33,12 +33,18 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
   // 日付ごとのログステータスキャッシュ。キーは日付の数値表現（millisecondsSinceEpoch）。
   final Map<int, DailyLogStatus> _logStatusCache = {};
   final Map<int, Map<String, DateTime?>> _nextWateringCache = {};
+  final Map<int, Map<String, DateTime?>> _nextFertilizerCache = {};
+  final Map<int, Map<String, DateTime?>> _nextVitalizerCache = {};
 
   // 現在選択日のデータ（現在ページ対応）
   DailyLogStatus get _logStatus =>
       _logStatusCache[_dateKey(_selectedDate)] ?? DailyLogStatus.empty();
   Map<String, DateTime?> get _nextWateringDateCache =>
       _nextWateringCache[_dateKey(_selectedDate)] ?? {};
+  Map<String, DateTime?> get _nextFertilizerDateCache =>
+      _nextFertilizerCache[_dateKey(_selectedDate)] ?? {};
+  Map<String, DateTime?> get _nextVitalizerDateCache =>
+      _nextVitalizerCache[_dateKey(_selectedDate)] ?? {};
 
   final Set<String> _selectedPlantIds = {};
   final Set<LogType> _selectedBulkLogTypes = {LogType.watering};
@@ -92,10 +98,16 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     final fertilizedMap = <String, bool>{};
     final vitalizedMap = <String, bool>{};
     final nextWateringDateCache = <String, DateTime?>{};
+    final nextFertilizerDateCache = <String, DateTime?>{};
+    final nextVitalizerDateCache = <String, DateTime?>{};
 
     for (var plant in plants) {
       nextWateringDateCache[plant.id] =
           await plantProvider.calculateNextWateringDate(plant.id);
+      nextFertilizerDateCache[plant.id] =
+          await plantProvider.calculateNextFertilizerDate(plant.id);
+      nextVitalizerDateCache[plant.id] =
+          await plantProvider.calculateNextVitalizerDate(plant.id);
       wateredMap[plant.id] =
           await plantProvider.hasLogOnDate(plant.id, LogType.watering, date);
       fertilizedMap[plant.id] =
@@ -112,6 +124,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
           vitalized: vitalizedMap,
         );
         _nextWateringCache[key] = nextWateringDateCache;
+        _nextFertilizerCache[key] = nextFertilizerDateCache;
+        _nextVitalizerCache[key] = nextVitalizerDateCache;
       });
     }
   }
@@ -122,8 +136,11 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     setState(() {
       _logStatusCache.remove(key);
       _nextWateringCache.remove(key);
+      _nextFertilizerCache.remove(key);
+      _nextVitalizerCache.remove(key);
     });
     await _loadLogsForDate(date);
+  }
   }
 
   /// 指定日に表示すべき植物リストを決定する
@@ -132,6 +149,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     DateTime date,
     DailyLogStatus logStatus,
     Map<String, DateTime?> nextWateringDateCache,
+    Map<String, DateTime?> nextFertilizerDateCache,
+    Map<String, DateTime?> nextVitalizerDateCache,
   ) {
     final selectedDay = AppDateUtils.getDateOnly(date);
     final todayDay = AppDateUtils.getDateOnly(DateTime.now());
@@ -141,22 +160,25 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
         .where((plant) => logStatus.hasAnyLog(plant.id))
         .toSet();
 
-    // 水やりが必要な植物
-    final plantsNeedingAction = plants.where((plant) {
-      final nextWateringDate = nextWateringDateCache[plant.id];
-      if (nextWateringDate == null) return false;
-      final nextDay = AppDateUtils.getDateOnly(nextWateringDate);
-
-      // 今日：当日予定 + 今日時点で超過分
+    // 予定日が来ている植物か判定するヘルパー
+    bool isActionNeeded(DateTime? nextDate) {
+      if (nextDate == null) return false;
+      final nextDay = AppDateUtils.getDateOnly(nextDate);
       if (AppDateUtils.isSameDay(selectedDay, todayDay)) {
         return !nextDay.isAfter(selectedDay);
       }
-      // 過去の日付：その日の実績把握（その日予定 + その日時点で超過分）
       if (selectedDay.isBefore(todayDay)) {
         return !nextDay.isAfter(selectedDay);
       }
-      // 未来の日付（#91）：その日予定 + 今日時点ですでに超過している植物
+      // 未来の日付
       return nextDay.isAtSameMomentAs(selectedDay) || nextDay.isBefore(todayDay);
+    }
+
+    // 水やり・肥料・活力剤のいずれかが必要な植物
+    final plantsNeedingAction = plants.where((plant) {
+      return isActionNeeded(nextWateringDateCache[plant.id]) ||
+          isActionNeeded(nextFertilizerDateCache[plant.id]) ||
+          isActionNeeded(nextVitalizerDateCache[plant.id]);
     }).toSet();
 
     final allPlants = {...plantsWithRecords, ...plantsNeedingAction}.toList();
@@ -588,13 +610,16 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     final key = _dateKey(date);
     final logStatus = _logStatusCache[key] ?? DailyLogStatus.empty();
     final nextWateringDateCache = _nextWateringCache[key] ?? {};
+    final nextFertilizerDateCache = _nextFertilizerCache[key] ?? {};
+    final nextVitalizerDateCache = _nextVitalizerCache[key] ?? {};
     final isLoaded = _logStatusCache.containsKey(key);
 
     return Consumer<PlantProvider>(
       builder: (context, plantProvider, _) {
         final plantsForDate = isLoaded
             ? _getPlantsForDate(
-                plantProvider.plants, date, logStatus, nextWateringDateCache)
+                plantProvider.plants, date, logStatus,
+                nextWateringDateCache, nextFertilizerDateCache, nextVitalizerDateCache)
             : <Plant>[];
 
         return Column(
@@ -604,7 +629,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
             Expanded(
               child: isLoaded
                   ? _buildPlantList(plantsForDate, isToday, logStatus,
-                      nextWateringDateCache, date)
+                      nextWateringDateCache, nextFertilizerDateCache,
+                      nextVitalizerDateCache, date)
                   : const Center(child: CircularProgressIndicator()),
             ),
           ],
@@ -754,6 +780,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     bool isToday,
     DailyLogStatus logStatus,
     Map<String, DateTime?> nextWateringDateCache,
+    Map<String, DateTime?> nextFertilizerDateCache,
+    Map<String, DateTime?> nextVitalizerDateCache,
     DateTime date,
   ) {
     if (plantsForDate.isEmpty) {
@@ -783,7 +811,9 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
             itemBuilder: (context, index) {
               if (index < incompletePlants.length) {
                 return _buildPlantCard(
-                    incompletePlants[index], logStatus, nextWateringDateCache, date);
+                    incompletePlants[index], logStatus,
+                    nextWateringDateCache, nextFertilizerDateCache,
+                    nextVitalizerDateCache, date);
               }
               if (index == incompletePlants.length &&
                   completedPlants.isNotEmpty) {
@@ -793,7 +823,9 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
                   incompletePlants.length -
                   (completedPlants.isNotEmpty ? 1 : 0);
               return _buildPlantCard(
-                  completedPlants[completedIndex], logStatus, nextWateringDateCache, date);
+                  completedPlants[completedIndex], logStatus,
+                  nextWateringDateCache, nextFertilizerDateCache,
+                  nextVitalizerDateCache, date);
             },
           ),
         ),
@@ -958,7 +990,9 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     final plantProvider = context.read<PlantProvider>();
     final allPlants = plantProvider.plants;
     final plantsForDate = _getPlantsForDate(
-      allPlants, _selectedDate, _logStatus, _nextWateringDateCache).toSet();
+      allPlants, _selectedDate, _logStatus,
+      _nextWateringDateCache, _nextFertilizerDateCache, _nextVitalizerDateCache,
+    ).toSet();
     
     // Get plants not in today's list
     final unscheduledPlants = allPlants
@@ -1007,6 +1041,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     Plant plant,
     DailyLogStatus logStatus,
     Map<String, DateTime?> nextWateringDateCache,
+    Map<String, DateTime?> nextFertilizerDateCache,
+    Map<String, DateTime?> nextVitalizerDateCache,
     DateTime date,
   ) {
     final isWatered = logStatus.isWatered(plant.id);
@@ -1016,6 +1052,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     final isSelected = _selectedPlantIds.contains(plant.id);
     final selectedDay = AppDateUtils.getDateOnly(date);
     final nextWateringDate = nextWateringDateCache[plant.id];
+    final nextFertilizerDate = nextFertilizerDateCache[plant.id];
+    final nextVitalizerDate = nextVitalizerDateCache[plant.id];
     final nextDay = nextWateringDate != null
         ? AppDateUtils.getDateOnly(nextWateringDate)
         : null;
@@ -1046,6 +1084,9 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
         subtitle: _buildPlantSubtitle(
           plant,
           nextWateringDate,
+          nextFertilizerDate,
+          nextVitalizerDate,
+          selectedDay,
           isOverdue,
           hasAnyLog,
           isWatered,
@@ -1070,12 +1111,18 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
   Widget _buildPlantSubtitle(
     Plant plant,
     DateTime? nextWateringDate,
+    DateTime? nextFertilizerDate,
+    DateTime? nextVitalizerDate,
+    DateTime selectedDay,
     bool isOverdue,
     bool hasAnyLog,
     bool isWatered,
     bool isFertilized,
     bool isVitalized,
   ) {
+    bool isDateDue(DateTime? d) =>
+        d != null && !AppDateUtils.getDateOnly(d).isAfter(selectedDay);
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -1095,6 +1142,48 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
                 AppDateUtils.formatDateDifference(nextWateringDate),
                 style: TextStyle(
                   color: isOverdue ? Theme.of(context).colorScheme.error : null,
+                ),
+              ),
+            ],
+          ),
+        if (nextFertilizerDate != null)
+          Row(
+            children: [
+              Icon(
+                Icons.grass,
+                size: 14,
+                color: isDateDue(nextFertilizerDate)
+                    ? Theme.of(context).colorScheme.error
+                    : Theme.of(context).colorScheme.secondary,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                AppDateUtils.formatDateDifference(nextFertilizerDate),
+                style: TextStyle(
+                  color: isDateDue(nextFertilizerDate)
+                      ? Theme.of(context).colorScheme.error
+                      : null,
+                ),
+              ),
+            ],
+          ),
+        if (nextVitalizerDate != null)
+          Row(
+            children: [
+              Icon(
+                Icons.favorite,
+                size: 14,
+                color: isDateDue(nextVitalizerDate)
+                    ? Theme.of(context).colorScheme.error
+                    : Theme.of(context).colorScheme.tertiary,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                AppDateUtils.formatDateDifference(nextVitalizerDate),
+                style: TextStyle(
+                  color: isDateDue(nextVitalizerDate)
+                      ? Theme.of(context).colorScheme.error
+                      : null,
                 ),
               ),
             ],


### PR DESCRIPTION
## 概要
Issue #107 の対応。肥料・活力剤のスケジュールが水やり予定画面に反映されていなかった問題を修正。

## 変更内容

### lib/providers/plant_provider.dart
- calculateNextFertilizerDate(plantId) を追加
  - ertilizerIntervalDays が設定されている場合: 最後の施肥ログから日数計算
  - ertilizerEveryNWaterings が設定されている場合: 最後の施肥後の水やり回数から次回を推定
- calculateNextVitalizerDate(plantId) を同様のロジックで追加

### lib/screens/today_watering_screen.dart
- _nextFertilizerCache / _nextVitalizerCache フィールドとゲッターを追加
- _loadLogsForDate() で全植物の次回肥料・活力剤日を取得しキャッシュ
- _invalidateAndReload() で3種すべてのキャッシュをクリア
- _getPlantsForDate() が水やり・肥料・活力剤のいずれかが期限の植物を返すよう修正
- _buildPlantSubtitle() に Icons.grass（肥料）・Icons.favorite（活力剤）アイコン付きで次回予定日を表示（期限超過時は赤色）

## 修正したバグ
- _getPlantsForDate() が 
extWateringDate のみを参照しており、肥料・活力剤スケジュールが無視されていた
- 植物カードに水やり日のみ表示され、肥料・活力剤の次回予定が見えなかった

Closes #107