### PR TITLE
fix(#117): 肥料・活力剤のN回に1回でn=1を選択可能にする

### DIFF
--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -619,7 +619,7 @@ class _LogIntervalDialogState extends State<_LogIntervalDialog> {
     } else {
       _modeIndex = 0;
       _days = widget.initialDays ?? 7;
-      _everyN = widget.initialEveryN ?? 2;
+      _everyN = widget.initialEveryN ?? 1;
     }
   }
 
@@ -656,9 +656,9 @@ class _LogIntervalDialogState extends State<_LogIntervalDialog> {
                 style: Theme.of(context).textTheme.headlineSmall),
             Slider(
               value: _everyN.toDouble(),
-              min: 2,
+              min: 1,
               max: 10,
-              divisions: 8,
+              divisions: 9,
               label: '$_everyN回に1回',
               onChanged: (v) => setState(() => _everyN = v.toInt()),
             ),


### PR DESCRIPTION
## 概要
Issue #117 の対応。肥料・活力剤の「水やりN回に1回」スライダーで n=1 が選択できなかった問題を修正。

## 変更内容

### \lib/screens/add_plant_screen.dart\
- \_LogIntervalDialog\ のスライダー設定を変更:
  - \min: 2\ → \min: 1\
  - \divisions: 8\ → \divisions: 9\
- モード未選択時の初期値を \2\ → \1\ に変更

## 修正したバグ
- スライダーの最小値が 2 に固定されており、n=1（毎回の水やりのたびに施肥）を設定できなかった

Closes #117