### PR TITLE
fix(#120): N回モードの肥料・活力剤予定日計算で過去日が返るバグを修正

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -418,12 +418,12 @@ class PlantProvider with ChangeNotifier {
                 .toList()
               ..sort((a, b) => a.date.compareTo(b.date)));
 
-      // 既にN回以上水やりしていれば今日が予定
-      if (wateringsAfter.length >= n) {
-        return wateringsAfter[n - 1].date;
-      }
-      // 不足回数分を水やり間隔で推定
-      final remaining = n - wateringsAfter.length;
+      // 現在のグループ内の残り回数を計算（N回ごとの次の区切りを求める）
+      // 例: N=3, 水やり7回の場合 → 7%3=1 → 残り2回（次の区切りは9回目）
+      final completedInCurrentGroup = wateringsAfter.length % n;
+      final remaining = completedInCurrentGroup == 0
+          ? n // ちょうど区切り済み → 次のN回目
+          : n - completedInCurrentGroup;
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
           : (lastFertDate ?? (await calculateNextWateringDate(plantId) ?? DateTime.now()));
@@ -515,10 +515,12 @@ class PlantProvider with ChangeNotifier {
                 .toList()
               ..sort((a, b) => a.date.compareTo(b.date)));
 
-      if (wateringsAfter.length >= n) {
-        return wateringsAfter[n - 1].date;
-      }
-      final remaining = n - wateringsAfter.length;
+      // 現在のグループ内の残り回数を計算（N回ごとの次の区切りを求める）
+      // 例: N=3, 水やり7回の場合 → 7%3=1 → 残り2回（次の区切りは9回目）
+      final completedInCurrentGroup = wateringsAfter.length % n;
+      final remaining = completedInCurrentGroup == 0
+          ? n // ちょうど区切り済み → 次のN回目
+          : n - completedInCurrentGroup;
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
           : (lastVitDate ?? (await calculateNextWateringDate(plantId) ?? DateTime.now()));

--- a/tool/generate_seed_sql.dart
+++ b/tool/generate_seed_sql.dart
@@ -34,7 +34,7 @@ void main() {
     final createdAt = purchaseDate;
     final updatedAt = today;
 
-    buffer.writeln("INSERT OR REPLACE INTO plants (id,name,variety,purchaseDate,purchaseLocation,imagePath,wateringIntervalDays,createdAt,updatedAt) VALUES ('${id.replaceAll("'", "''")}', '${name.replaceAll("'", "''")}', '${variety.replaceAll("'", "''")}', ${purchaseDate != null ? "'${iso(purchaseDate)}'" : 'NULL'}, '${location.replaceAll("'", "''")}', ${imagePath != null ? "'${imagePath.replaceAll("'", "''")}'" : 'NULL'}, ${interval}, '${iso(createdAt)}', '${iso(updatedAt)}');");
+    buffer.writeln("INSERT OR REPLACE INTO plants (id,name,variety,purchaseDate,purchaseLocation,imagePath,wateringIntervalDays,createdAt,updatedAt) VALUES ('${id.replaceAll("'", "''")}', '${name.replaceAll("'", "''")}', '${variety.replaceAll("'", "''")}', ${"'${iso(purchaseDate)}'"}, '${location.replaceAll("'", "''")}', ${imagePath != null ? "'${imagePath.replaceAll("'", "''")}'" : 'NULL'}, $interval, '${iso(createdAt)}', '${iso(updatedAt)}');");
 
     // Generate watering logs from purchaseDate up to today following interval, with occasional exceptions
     DateTime logDate = purchaseDate;
@@ -49,14 +49,14 @@ void main() {
 
       final logId = 'log_${id}_water_${logDate.millisecondsSinceEpoch}';
       final note = (['Watered generously', 'Light mist', 'Bottom watering', 'Quick water']..shuffle(rand)).first;
-      buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('${logId}', '${id}', 'watering', '${iso(logDate)}', '${note.replaceAll("'", "''")}', '${iso(logDate)}', '${iso(logDate)}');");
+      buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('$logId', '$id', 'watering', '${iso(logDate)}', '${note.replaceAll("'", "''")}', '${iso(logDate)}', '${iso(logDate)}');");
 
       // occasional extra off-schedule
       if (i % 6 == 0 && rand.nextBool()) {
         final extraDate = logDate.add(Duration(days: 3));
         if (!extraDate.isAfter(today)) {
           final extraId = 'log_${id}_water_extra_${extraDate.millisecondsSinceEpoch}';
-          buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('${extraId}', '${id}', 'watering', '${iso(extraDate)}', 'Extra watering', '${iso(extraDate)}', '${iso(extraDate)}');");
+          buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('$extraId', '$id', 'watering', '${iso(extraDate)}', 'Extra watering', '${iso(extraDate)}', '${iso(extraDate)}');");
         }
       }
 
@@ -67,14 +67,14 @@ void main() {
     if (i % 3 == 0) {
       final fertDate = today.subtract(Duration(days: 14 + i));
       final fertId = 'log_${id}_fert_${fertDate.millisecondsSinceEpoch}';
-      buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('${fertId}', '${id}', 'fertilizer', '${iso(fertDate)}', 'Fertilized', '${iso(fertDate)}', '${iso(fertDate)}');");
+      buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('$fertId', '$id', 'fertilizer', '${iso(fertDate)}', 'Fertilized', '${iso(fertDate)}', '${iso(fertDate)}');");
     }
 
     // vitalizer logs for some plants
     if (i % 4 == 0) {
       final vitDate = today.subtract(Duration(days: 10 + i));
       final vitId = 'log_${id}_vit_${vitDate.millisecondsSinceEpoch}';
-      buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('${vitId}', '${id}', 'vitalizer', '${iso(vitDate)}', 'Applied vitalizer', '${iso(vitDate)}', '${iso(vitDate)}');");
+      buffer.writeln("INSERT OR REPLACE INTO logs (id,plantId,type,date,note,createdAt,updatedAt) VALUES ('$vitId', '$id', 'vitalizer', '${iso(vitDate)}', 'Applied vitalizer', '${iso(vitDate)}', '${iso(vitDate)}');");
     }
   }
 
@@ -92,7 +92,7 @@ void main() {
     final createdAt = today.subtract(Duration(days: rand.nextInt(40)));
     final updatedAt = today;
 
-    buffer.writeln("INSERT OR REPLACE INTO notes (id,title,content,imagePaths,plantIds,createdAt,updatedAt) VALUES ('${noteId}', '${title.replaceAll("'", "''")}', '${content.replaceAll("'", "''")}', '${imagePaths.join('|').replaceAll("'", "''")}', '${linkedPlants.join('|')}', '${iso(createdAt)}', '${iso(updatedAt)}');");
+    buffer.writeln("INSERT OR REPLACE INTO notes (id,title,content,imagePaths,plantIds,createdAt,updatedAt) VALUES ('$noteId', '${title.replaceAll("'", "''")}', '${content.replaceAll("'", "''")}', '${imagePaths.join('|').replaceAll("'", "''")}', '${linkedPlants.join('|')}', '${iso(createdAt)}', '${iso(updatedAt)}');");
   }
 
   buffer.writeln('COMMIT;');


### PR DESCRIPTION
## 変更内容

issue #120 の追加修正。

### 問題
肥料/活力剤ログが一度もない植物で「水やりN回に1回」モードを設定している場合、予定日が過去日（最初のN回目の水やり日）になっていた。

### 原因
`dart
// 修正前: wateringsAfter[n-1] はN番目の水やり日（昔）を返す
if (wateringsAfter.length >= n) {
  return wateringsAfter[n - 1].date; // ← 過去の日付
}
`

例: N=3、水やり7回ある場合 → 3回目の水やり日（かなり昔）を返していた。

### 修正
modulo 演算で「現在のN回グループ内の残り回数」を計算し、次の区切りを正しく求める:

`dart
// 修正後: N回ごとの次の区切りを modulo 演算で計算
final completedInCurrentGroup = wateringsAfter.length % n;
final remaining = completedInCurrentGroup == 0
    ? n // ちょうど区切り済み → 次のN回目
    : n - completedInCurrentGroup;
`

例: N=3、水やり7回 → 7%3=1 → 残り2回 → 最後の水やり + 2×間隔日数

### 影響ファイル
- lib/providers/plant_provider.dart: calculateNextFertilizerDate / calculateNextVitalizerDate の N回モード修正

Closes #120