### PR TITLE
fix: バグ修正・UI改善バッチ (#124/#125/#127/#129/#130/#131)

### DIFF
--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -24,6 +24,8 @@ enum PlantSortOrder {
   createdAtDesc,     // 登録日が新しい順
   createdAtAsc,      // 登録日が古い順
   custom,            // ユーザー指定
+  varietyAsc,        // 品種名昇順
+  varietyDesc,       // 品種名降順
 }
 
 class LogTypeColors {

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -104,6 +104,24 @@ class PlantProvider with ChangeNotifier {
           });
         }
         break;
+      case PlantSortOrder.varietyAsc:
+        // 品種名昇順（品種なしは末尾）
+        plantsCopy.sort((a, b) {
+          if (a.variety == null && b.variety == null) return 0;
+          if (a.variety == null) return 1;
+          if (b.variety == null) return -1;
+          return a.variety!.compareTo(b.variety!);
+        });
+        break;
+      case PlantSortOrder.varietyDesc:
+        // 品種名降順（品種なしは末尾）
+        plantsCopy.sort((a, b) {
+          if (a.variety == null && b.variety == null) return 0;
+          if (a.variety == null) return 1;
+          if (b.variety == null) return -1;
+          return b.variety!.compareTo(a.variety!);
+        });
+        break;
     }
     
     return plantsCopy;

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -5,6 +5,7 @@ import '../models/note.dart';
 import '../models/plant.dart';
 import '../providers/note_provider.dart';
 import '../providers/plant_provider.dart';
+import '../providers/settings_provider.dart';
 import 'add_edit_note_screen.dart';
 import 'note_detail_screen.dart';
 import 'settings_screen.dart';
@@ -165,6 +166,27 @@ class _NotesListScreenState extends State<NotesListScreen> {
               });
             },
           ),
+          // 植物フィルタ
+          Consumer2<PlantProvider, SettingsProvider>(
+            builder: (context, plantProvider, settingsProvider, _) {
+              final hasFilter = _filterPlantId != null;
+              // ソート設定に従ったソート済みリストをフィルタシートに渡す
+              final sortedPlants = plantProvider.getSortedPlants(
+                settingsProvider.plantSortOrder,
+                settingsProvider.customSortOrder,
+              );
+              return IconButton(
+                icon: Badge(
+                  isLabelVisible: hasFilter,
+                  child: const Icon(Icons.filter_list),
+                ),
+                tooltip: '植物で絞り込む',
+                onPressed: plantProvider.plants.isEmpty
+                    ? null
+                    : () => _showPlantFilterSheet(context, sortedPlants),
+              );
+            },
+          ),
           // 設定画面へ遷移 (#104)
           if (!_isSearching)
             IconButton(
@@ -176,22 +198,6 @@ class _NotesListScreenState extends State<NotesListScreen> {
                 ),
               ),
             ),
-          // 植物フィルタ
-          Consumer<PlantProvider>(
-            builder: (context, plantProvider, _) {
-              final hasFilter = _filterPlantId != null;
-              return IconButton(
-                icon: Badge(
-                  isLabelVisible: hasFilter,
-                  child: const Icon(Icons.filter_list),
-                ),
-                tooltip: '植物で絞り込む',
-                onPressed: plantProvider.plants.isEmpty
-                    ? null
-                    : () => _showPlantFilterSheet(context, plantProvider.plants),
-              );
-            },
-          ),
         ],
       ),
       body: Consumer2<NoteProvider, PlantProvider>(

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -40,8 +40,14 @@ class _StickyTabBarDelegate extends SliverPersistentHeaderDelegate {
 
 class PlantDetailScreen extends StatefulWidget {
   final Plant plant;
+  /// 初期表示タブインデックス（0:詳細, 1:ログ, 2:ノート）
+  final int initialTabIndex;
 
-  const PlantDetailScreen({super.key, required this.plant});
+  const PlantDetailScreen({
+    super.key,
+    required this.plant,
+    this.initialTabIndex = 0,
+  });
 
   @override
   State<PlantDetailScreen> createState() => _PlantDetailScreenState();
@@ -58,7 +64,11 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(
+      length: 3,
+      vsync: this,
+      initialIndex: widget.initialTabIndex,
+    );
     _loadData();
   }
 

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -289,6 +289,10 @@ class _PlantListScreenState extends State<PlantListScreen> {
         return '登録日が新しい順';
       case PlantSortOrder.custom:
         return 'カスタム（ドラッグで並び替え）';
+      case PlantSortOrder.varietyAsc:
+        return '品種名（あ→ん）';
+      case PlantSortOrder.varietyDesc:
+        return '品種名（ん→あ）';
     }
   }
 
@@ -305,6 +309,9 @@ class _PlantListScreenState extends State<PlantListScreen> {
         return Icons.access_time;
       case PlantSortOrder.custom:
         return Icons.reorder;
+      case PlantSortOrder.varietyAsc:
+      case PlantSortOrder.varietyDesc:
+        return Icons.local_florist;
     }
   }
 }

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -230,13 +230,25 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
           if (bIndex == -1) return -1;
           return aIndex.compareTo(bIndex);
         }
-        // Fallback to watering date
+        // フォールバック：水やり予定日順
         final aNextDate = nextWateringDateCache[a.id];
         final bNextDate = nextWateringDateCache[b.id];
         if (aNextDate == null && bNextDate == null) return 0;
         if (aNextDate == null) return 1;
         if (bNextDate == null) return -1;
         return aNextDate.compareTo(bNextDate);
+      case PlantSortOrder.varietyAsc:
+        // 品種名昇順（品種なしは末尾）
+        if (a.variety == null && b.variety == null) return 0;
+        if (a.variety == null) return 1;
+        if (b.variety == null) return -1;
+        return a.variety!.compareTo(b.variety!);
+      case PlantSortOrder.varietyDesc:
+        // 品種名降順（品種なしは末尾）
+        if (a.variety == null && b.variety == null) return 0;
+        if (a.variety == null) return 1;
+        if (b.variety == null) return -1;
+        return b.variety!.compareTo(a.variety!);
     }
   }
 
@@ -1050,13 +1062,16 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     final hasAnyLog = logStatus.hasAnyLog(plant.id);
     final isSelected = _selectedPlantIds.contains(plant.id);
     final selectedDay = AppDateUtils.getDateOnly(date);
+    // 赤字判定は選択日に関わらず「今日」を基準にする (#124)
+    final today = AppDateUtils.getDateOnly(DateTime.now());
     final nextWateringDate = nextWateringDateCache[plant.id];
     final nextFertilizerDate = nextFertilizerDateCache[plant.id];
     final nextVitalizerDate = nextVitalizerDateCache[plant.id];
     final nextDay = nextWateringDate != null
         ? AppDateUtils.getDateOnly(nextWateringDate)
         : null;
-    final isOverdue = nextDay != null && nextDay.isBefore(selectedDay);
+    // 水やり超過: 予定日 ≦ 今日
+    final isOverdue = nextDay != null && !nextDay.isAfter(today);
 
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
@@ -1119,72 +1134,45 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     bool isFertilized,
     bool isVitalized,
   ) {
+    // 肥料・活力剤の超過判定も今日基準で統一する (#124)
+    final today = AppDateUtils.getDateOnly(DateTime.now());
     bool isDateDue(DateTime? d) =>
-        d != null && !AppDateUtils.getDateOnly(d).isAfter(selectedDay);
+        d != null && !AppDateUtils.getDateOnly(d).isAfter(today);
 
+    // 水やり・肥料・活力剤の予定を横並び1行でまとめて表示する (#125)
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (plant.variety != null) Text(plant.variety!),
-        if (nextWateringDate != null)
-          Row(
+        // 予定がある項目を Wrap で横並びにまとめる
+        if (nextWateringDate != null ||
+            nextFertilizerDate != null ||
+            nextVitalizerDate != null)
+          Wrap(
+            spacing: 8,
+            runSpacing: 2,
             children: [
-              Icon(
-                Icons.water_drop,
-                size: 14,
-                color: isOverdue
-                    ? Theme.of(context).colorScheme.error
-                    : Theme.of(context).colorScheme.primary,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                AppDateUtils.formatDateDifference(nextWateringDate),
-                style: TextStyle(
-                  color: isOverdue ? Theme.of(context).colorScheme.error : null,
+              if (nextWateringDate != null)
+                _buildScheduleChip(
+                  icon: Icons.water_drop,
+                  label: AppDateUtils.formatDateDifference(nextWateringDate),
+                  isOverdue: isOverdue,
+                  normalColor: Theme.of(context).colorScheme.primary,
                 ),
-              ),
-            ],
-          ),
-        if (nextFertilizerDate != null)
-          Row(
-            children: [
-              Icon(
-                Icons.grass,
-                size: 14,
-                color: isDateDue(nextFertilizerDate)
-                    ? Theme.of(context).colorScheme.error
-                    : Theme.of(context).colorScheme.secondary,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                AppDateUtils.formatDateDifference(nextFertilizerDate),
-                style: TextStyle(
-                  color: isDateDue(nextFertilizerDate)
-                      ? Theme.of(context).colorScheme.error
-                      : null,
+              if (nextFertilizerDate != null)
+                _buildScheduleChip(
+                  icon: Icons.grass,
+                  label: AppDateUtils.formatDateDifference(nextFertilizerDate),
+                  isOverdue: isDateDue(nextFertilizerDate),
+                  normalColor: Theme.of(context).colorScheme.secondary,
                 ),
-              ),
-            ],
-          ),
-        if (nextVitalizerDate != null)
-          Row(
-            children: [
-              Icon(
-                Icons.favorite,
-                size: 14,
-                color: isDateDue(nextVitalizerDate)
-                    ? Theme.of(context).colorScheme.error
-                    : Theme.of(context).colorScheme.tertiary,
-              ),
-              const SizedBox(width: 4),
-              Text(
-                AppDateUtils.formatDateDifference(nextVitalizerDate),
-                style: TextStyle(
-                  color: isDateDue(nextVitalizerDate)
-                      ? Theme.of(context).colorScheme.error
-                      : null,
+              if (nextVitalizerDate != null)
+                _buildScheduleChip(
+                  icon: Icons.favorite,
+                  label: AppDateUtils.formatDateDifference(nextVitalizerDate),
+                  isOverdue: isDateDue(nextVitalizerDate),
+                  normalColor: Theme.of(context).colorScheme.tertiary,
                 ),
-              ),
             ],
           ),
         if (hasAnyLog)
@@ -1200,6 +1188,24 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
               ],
             ),
           ),
+      ],
+    );
+  }
+
+  /// 予定日チップ（アイコン＋テキスト）を構築する (#125)
+  Widget _buildScheduleChip({
+    required IconData icon,
+    required String label,
+    required bool isOverdue,
+    required Color normalColor,
+  }) {
+    final color = isOverdue ? Theme.of(context).colorScheme.error : normalColor;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon, size: 14, color: color),
+        const SizedBox(width: 3),
+        Text(label, style: TextStyle(color: isOverdue ? color : null, fontSize: 12)),
       ],
     );
   }
@@ -1270,7 +1276,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
   Future<void> _navigateToPlantDetail(Plant plant) async {
     await Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => PlantDetailScreen(plant: plant),
+        // 水やりログ画面からの遷移はログタブ（index=1）を直接開く (#127)
+        builder: (context) => PlantDetailScreen(plant: plant, initialTabIndex: 1),
       ),
     );
     if (mounted) {


### PR DESCRIPTION
## 変更概要

### #124 肥料・活力剤の予定日赤字バグ修正
- isOverdue（水やり）と isDateDue（肥料・活力剤）をいずれも **今日基準** に統一
- 修正前: 選択中の日付と比較していたため、過去の日付を表示中に誤って赤くならなかった
- 修正後: 「予定日 ≦ 今日」なら常に赤字（選択日に無関係）

### #125 水やり予定の表示を1行にまとめる
- _buildPlantSubtitle で水やり・肥料・活力剤を縦3行の Row から Wrap 横並び1行に変更
- _buildScheduleChip ヘルパーメソッドを追加

### #127 ログ画面から植物タップ時にログタブを開く
- PlantDetailScreen に initialTabIndex パラメータを追加（デフォルト: 0 = 詳細タブ）
- 水やり予定画面からの遷移時に initialTabIndex: 1（ログタブ）を渡すよう変更

### #129 ソート順の統一
- 水やり予定画面の _comparePlantsFor に arietyAsc/arietyDesc ケースを追加
- ノート画面の植物フィルタシートをソート設定に従ったリスト順で表示

### #130 ノート画面の設定ボタンを右端に移動
- AppBar actions の順序を 検索 → 設定 → フィルタ から **検索 → フィルタ → 設定** に変更

### #131 品種名ソートを追加
- PlantSortOrder enum に arietyAsc（品種名昇順）・arietyDesc（品種名降順）を追加
- getSortedPlants、_comparePlantsFor、_getSortOrderName、_getSortOrderIcon に対応ケースを追加

## テスト手順
1. 水やり予定画面で過去の予定日がある植物が赤字になることを確認
2. 未来日を表示中でも今日が期日の植物が赤字になることを確認
3. 水やり予定画面で予定が1行横並びになることを確認
4. 水やり予定画面で植物タップ → ログタブが開くことを確認
5. ノート画面で設定アイコンが最右端にあることを確認
6. 植物リストのソートメニューに「品種名（あ→ん）」「品種名（ん→あ）」が表示されることを確認