### PR TITLE
fix: 水やりログ画面に予定・記録が表示されない問題を修正 (#138)

### DIFF
--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -50,6 +50,12 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     _pageController = PageController(initialPage: _initialPage);
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await context.read<PlantProvider>().loadPlants();
+      if (!mounted) return;
+      // loadPlants() 完了後にキャッシュをリセットして FutureBuilder を再実行させる。
+      // loadPlants() 中に空の植物リストでキャッシュが作られることを防ぐ。
+      setState(() {
+        _refreshKey++;
+      });
       // 初期表示時に今日を中心に±2日分をプリロード
       _preloadRange(_selectedDate);
     });
@@ -583,6 +589,21 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
 
     final plantProvider = context.read<PlantProvider>();
     final plants = plantProvider.plants;
+
+    // 植物リストがロード中の場合はキャッシュせずに空データを返す。
+    // loadPlants() 完了前にキャッシュされると空データが表示され続けるため。
+    if (plantProvider.isLoading) {
+      return _DatePageData(
+        logStatus: DailyLogStatus(
+          watered: {},
+          fertilized: {},
+          vitalized: {},
+        ),
+        nextWateringDateCache: {},
+        nextFertilizerDateCache: {},
+        nextVitalizerDateCache: {},
+      );
+    }
     final wateredMap = <String, bool>{};
     final fertilizedMap = <String, bool>{};
     final vitalizedMap = <String, bool>{};


### PR DESCRIPTION
## 概要

Closes #138

PR #137（プリロード機構）のマージ後から、水やりログ画面に予定も記録も表示されなくなる問題を修正します。

## 原因

loadPlants() の処理中に _isLoading = true → 
otifyListeners() が呼ばれることで Consumer<PlantProvider> がリビルドされ、FutureBuilder が起動します。この時点で _loadDatePageData が実行されますが、plants はまだ空リスト（[]）であるため、空データがキャッシュに保存されてしまいます。

その後 loadPlants() が完了して 
otifyListeners() が再度呼ばれても、FutureBuilder のキーは変わらないためキャッシュヒットし、空データが表示され続けていました。

## 修正内容

1. **isLoading 中はキャッシュしない**: _loadDatePageData で plantProvider.isLoading == true のときはキャッシュに保存せず空データを返す
2. **loadPlants() 完了後に _refreshKey++**: initState で loadPlants() 完了後に setState(() { _refreshKey++; }) を呼び、FutureBuilder のキーを変えて確実に再実行させる