### PR TITLE
feat: 植物リストを全画面でソート順に統一する (#129)

### DIFF
--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'dart:io';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:image_picker/image_picker.dart';
 import '../providers/plant_provider.dart';
+import '../providers/settings_provider.dart';
 import '../models/note.dart';
 import '../providers/note_provider.dart';
 
@@ -237,13 +237,11 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   }
 
   Widget _buildImageThumb(String path) {
-    final widget = kIsWeb
-        ? Image.network(path, width: 72, height: 72, fit: BoxFit.cover)
-        : Image.file(File(path), width: 72, height: 72, fit: BoxFit.cover);
+    final image = Image.file(File(path), width: 72, height: 72, fit: BoxFit.cover);
 
     return Stack(
       children: [
-        ClipRRect(borderRadius: BorderRadius.circular(8), child: widget),
+        ClipRRect(borderRadius: BorderRadius.circular(8), child: image),
         Positioned(
           right: 0,
           top: 0,
@@ -257,10 +255,15 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   }
 
   Future<void> _selectPlants(BuildContext context, PlantProvider plantProv) async {
-    // Ensure plants are loaded
+    // 植物データが未ロードの場合は先にロードする
     if (plantProv.plants.isEmpty) await plantProv.loadPlants();
 
-    final allPlants = plantProv.plants;
+    // ソート設定に従って並べた植物リストを取得する
+    final settings = context.read<SettingsProvider>(); // ignore: use_build_context_synchronously
+    final allPlants = plantProv.getSortedPlants(
+      settings.plantSortOrder,
+      settings.customSortOrder,
+    );
     final tempSelected = List<String>.from(_selectedPlantIds);
 
     await showDialog<void>(

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
@@ -35,6 +36,10 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
 
   // PlantProviderのisLoading前回値。loadPlants()完了検知に使用する。
   bool _wasLoading = false;
+
+  // SettingsProviderのソート設定前回値。ソート変更検知に使用する。
+  PlantSortOrder? _prevSortOrder;
+  List<String> _prevCustomOrder = [];
 
   // 日付ページデータのキャッシュ。キーは '${date.ms}_$_refreshKey'。
   // _refreshKey が変わるとキーが変わり、古いエントリは自然に参照されなくなる。
@@ -90,6 +95,22 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
       _loadSelectedDateFirst(_selectedDate).ignore();
     }
     _wasLoading = isLoading;
+
+    // SettingsProvider のソート設定変更（ソート順 or カスタム順の変化）を検知して
+    // キャッシュをリセットし、新しいソート順で再プリロードする。
+    final settings = context.read<SettingsProvider>();
+    final currentSortOrder = settings.plantSortOrder;
+    final currentCustomOrder = settings.customSortOrder;
+    if (_prevSortOrder != null &&
+        (_prevSortOrder != currentSortOrder ||
+            !listEquals(_prevCustomOrder, currentCustomOrder))) {
+      setState(() {
+        _refreshKey++;
+      });
+      _loadSelectedDateFirst(_selectedDate).ignore();
+    }
+    _prevSortOrder = currentSortOrder;
+    _prevCustomOrder = List<String>.from(currentCustomOrder);
   }
 
   /// 選択日のデータを優先ロードし、その後±2日分をバックグラウンドでプリロードする。
@@ -1096,16 +1117,21 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
 
   Future<void> _showUnscheduledWateringDialog() async {
     final plantProvider = context.read<PlantProvider>();
-    final allPlants = plantProvider.plants;
+    final settings = context.read<SettingsProvider>();
+    // ソート設定に従って並べた全植物リストを取得する
+    final sortedPlants = plantProvider.getSortedPlants(
+      settings.plantSortOrder,
+      settings.customSortOrder,
+    );
     // 現在の日付データを直接DBから取得して未予定植物を判定する
     final data = await _loadDatePageData(_selectedDate);
     final plantsForDate = _getPlantsForDate(
-      allPlants, _selectedDate, data.logStatus,
+      sortedPlants, _selectedDate, data.logStatus,
       data.nextWateringDateCache, data.nextFertilizerDateCache, data.nextVitalizerDateCache,
     ).toSet();
-    
-    // Get plants not in today's list
-    final unscheduledPlants = allPlants
+
+    // ソート順を保持したまま未予定植物を抽出する
+    final unscheduledPlants = sortedPlants
         .where((plant) => !plantsForDate.contains(plant))
         .toList();
     


### PR DESCRIPTION
## 概要

Issue #129 の対応。植物をリスト表示するすべての箇所で、植物一覧画面のソート設定に統一して従うようにする。

## 変更内容

### today_watering_screen.dart
- ソート変更検知の追加: didChangeDependencies に _prevSortOrder / _prevCustomOrder フィールドを追加し、ソート設定が変わったら _refreshKey++ でキャッシュを無効化して再プリロードするよう修正（植物一覧でソート順を変更すると水やり予定画面も即座に更新される）
- 未予定植物ダイアログのソート適用: _showUnscheduledWateringDialog で unscheduledPlants を生成する際に、未ソートの plantProvider.plants ではなく getSortedPlants() を使用するよう修正

### add_edit_note_screen.dart
- 植物選択ダイアログのソート適用: _selectPlants() で plantProv.plants（未ソート）の代わりに plantProv.getSortedPlants() を使用するよう修正
- kIsWeb import を除去: PR #149 でWebコードを削除済みのため、import と関連する kIsWeb 分岐を削除。SettingsProvider import を追加

## テスト手順
1. 設定画面でソート順を変更する
2. 水やり予定画面を確認: 植物リストが新しい順で表示されること
3. 「その他の植物に水やり」ボタンのダイアログ: 設定したソート順で表示されること
4. ノート編集画面の「植物を選択」ダイアログ: 設定したソート順で表示されること