### PR TITLE
feat: Claude APIを使ったAI機能を追加 (#67)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:workmanager/workmanager.dart';
 import 'providers/plant_provider.dart';
 import 'providers/settings_provider.dart';
 import 'providers/note_provider.dart';
+import 'providers/ai_provider.dart';
 import 'screens/home_screen.dart';
 import 'theme/app_themes.dart';
 import 'models/app_settings.dart';
@@ -69,6 +70,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => PlantProvider()),
         ChangeNotifierProvider(create: (_) => SettingsProvider()..loadSettings()),
         ChangeNotifierProvider(create: (_) => NoteProvider()),
+        ChangeNotifierProvider(create: (_) => AiProvider()),
       ],
       child: Consumer<SettingsProvider>(
         builder: (context, settingsProvider, _) {

--- a/lib/models/ai_chat_message.dart
+++ b/lib/models/ai_chat_message.dart
@@ -1,0 +1,28 @@
+import 'package:uuid/uuid.dart';
+
+/// AIチャットのメッセージデータモデル
+class AiChatMessage {
+  /// メッセージの一意識別子（UUID v4）
+  final String id;
+
+  /// true=ユーザー発言, false=AI応答
+  final bool isUser;
+
+  /// メッセージ本文
+  final String text;
+
+  /// ユーザーが添付した画像（Base64エンコード済み）
+  final String? imageBase64;
+
+  /// 作成日時
+  final DateTime createdAt;
+
+  AiChatMessage({
+    String? id,
+    required this.isUser,
+    required this.text,
+    this.imageBase64,
+    DateTime? createdAt,
+  })  : id = id ?? const Uuid().v4(),
+        createdAt = createdAt ?? DateTime.now();
+}

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -96,6 +96,8 @@ class AppSettings {
   final LogTypeColors logTypeColors;
   final PlantSortOrder plantSortOrder;
   final List<String> customSortOrder;
+  /// Gemini API キー（AI機能で使用）
+  final String geminiApiKey;
 
   AppSettings({
     this.viewMode = ViewMode.card,
@@ -107,6 +109,7 @@ class AppSettings {
     LogTypeColors? logTypeColors,
     this.plantSortOrder = PlantSortOrder.createdAtAsc,
     this.customSortOrder = const [],
+    this.geminiApiKey = '',
   }) : logTypeColors = logTypeColors ?? LogTypeColors();
 
   Map<String, dynamic> toMap() {
@@ -120,6 +123,7 @@ class AppSettings {
       'logTypeColors': logTypeColors.toMap(),
       'plantSortOrder': plantSortOrder.name,
       'customSortOrder': customSortOrder,
+      'geminiApiKey': geminiApiKey,
     };
   }
 
@@ -152,6 +156,7 @@ class AppSettings {
       customSortOrder: map['customSortOrder'] != null
           ? List<String>.from(map['customSortOrder'])
           : [],
+      geminiApiKey: map['geminiApiKey'] ?? '',
     );
   }
 
@@ -165,6 +170,7 @@ class AppSettings {
     LogTypeColors? logTypeColors,
     PlantSortOrder? plantSortOrder,
     List<String>? customSortOrder,
+    String? geminiApiKey,
   }) {
     return AppSettings(
       viewMode: viewMode ?? this.viewMode,
@@ -176,6 +182,7 @@ class AppSettings {
       logTypeColors: logTypeColors ?? this.logTypeColors,
       plantSortOrder: plantSortOrder ?? this.plantSortOrder,
       customSortOrder: customSortOrder ?? this.customSortOrder,
+      geminiApiKey: geminiApiKey ?? this.geminiApiKey,
     );
   }
 }

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -97,6 +97,9 @@ class AppSettings {
   final PlantSortOrder plantSortOrder;
   final List<String> customSortOrder;
 
+  /// Claude APIキー（空文字列 = 未設定）
+  final String claudeApiKey;
+
   AppSettings({
     this.viewMode = ViewMode.card,
     this.theme = AppTheme.green,
@@ -107,6 +110,7 @@ class AppSettings {
     LogTypeColors? logTypeColors,
     this.plantSortOrder = PlantSortOrder.createdAtAsc,
     this.customSortOrder = const [],
+    this.claudeApiKey = '',
   }) : logTypeColors = logTypeColors ?? LogTypeColors();
 
   Map<String, dynamic> toMap() {
@@ -120,6 +124,7 @@ class AppSettings {
       'logTypeColors': logTypeColors.toMap(),
       'plantSortOrder': plantSortOrder.name,
       'customSortOrder': customSortOrder,
+      'claudeApiKey': claudeApiKey,
     };
   }
 
@@ -152,6 +157,7 @@ class AppSettings {
       customSortOrder: map['customSortOrder'] != null
           ? List<String>.from(map['customSortOrder'])
           : [],
+      claudeApiKey: map['claudeApiKey'] as String? ?? '',
     );
   }
 
@@ -165,6 +171,7 @@ class AppSettings {
     LogTypeColors? logTypeColors,
     PlantSortOrder? plantSortOrder,
     List<String>? customSortOrder,
+    String? claudeApiKey,
   }) {
     return AppSettings(
       viewMode: viewMode ?? this.viewMode,
@@ -176,6 +183,7 @@ class AppSettings {
       logTypeColors: logTypeColors ?? this.logTypeColors,
       plantSortOrder: plantSortOrder ?? this.plantSortOrder,
       customSortOrder: customSortOrder ?? this.customSortOrder,
+      claudeApiKey: claudeApiKey ?? this.claudeApiKey,
     );
   }
 }

--- a/lib/providers/ai_provider.dart
+++ b/lib/providers/ai_provider.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/foundation.dart';
+import '../models/ai_chat_message.dart';
+import '../models/log_entry.dart';
+import '../models/plant.dart';
+import '../services/ai_service.dart';
+
+/// AI機能の状態を管理する Provider。
+///
+/// チャット履歴はセッション内のみ保持し、画面を閉じるとリセットされる。
+class AiProvider with ChangeNotifier {
+  final AiService _aiService = AiService();
+
+  List<AiChatMessage> _messages = [];
+  bool _isLoading = false;
+  String? _error;
+
+  List<AiChatMessage> get messages => List.unmodifiable(_messages);
+  bool get isLoading => _isLoading;
+  String? get error => _error;
+
+  /// チャット履歴をリセットする。
+  void clearMessages() {
+    _messages = [];
+    _error = null;
+    notifyListeners();
+  }
+
+  /// ユーザーメッセージを送信し、AIの応答を取得する。
+  Future<void> sendMessage({
+    required String apiKey,
+    required String text,
+    String? imageBase64,
+    required List<Plant> plants,
+    required List<LogEntry> recentLogs,
+  }) async {
+    _error = null;
+
+    final userMessage = AiChatMessage(
+      isUser: true,
+      text: text,
+      imageBase64: imageBase64,
+    );
+    _messages = [..._messages, userMessage];
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      final systemPrompt = _buildSystemPrompt(plants, recentLogs);
+      // 最大20往復（40メッセージ）にトリミング
+      final trimmedHistory = _messages.length > 40
+          ? _messages.sublist(_messages.length - 40)
+          : _messages;
+
+      final responseText = await _aiService.sendMessage(
+        apiKey: apiKey,
+        systemPrompt: systemPrompt,
+        history: trimmedHistory,
+      );
+
+      final aiMessage = AiChatMessage(isUser: false, text: responseText);
+      _messages = [..._messages, aiMessage];
+    } on AiServiceException catch (e) {
+      _error = e.message;
+    } catch (e) {
+      _error = 'エラーが発生しました: $e';
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  /// 植物の健康診断を実行し、診断結果を返す。
+  Future<String> diagnoseHealth({
+    required String apiKey,
+    required String plantName,
+    required String? variety,
+    required String? symptomText,
+    required int? wateringIntervalDays,
+    required DateTime? lastWateredAt,
+    required String? imageBase64,
+  }) async {
+    return _aiService.diagnoseHealth(
+      apiKey: apiKey,
+      plantName: plantName,
+      variety: variety,
+      symptomText: symptomText,
+      wateringIntervalDays: wateringIntervalDays,
+      lastWateredAt: lastWateredAt,
+      imageBase64: imageBase64,
+    );
+  }
+
+  /// 写真から植物を識別し、名前と品種を返す。
+  Future<Map<String, String?>> identifyPlant({
+    required String apiKey,
+    required String imageBase64,
+  }) async {
+    return _aiService.identifyPlant(
+      apiKey: apiKey,
+      imageBase64: imageBase64,
+    );
+  }
+
+  /// コーチ機能用のシステムプロンプトを生成する。
+  String _buildSystemPrompt(List<Plant> plants, List<LogEntry> recentLogs) {
+    final buffer = StringBuffer();
+    buffer.writeln('あなたは親切な植物ケアのコーチです。ユーザーの植物の状況を踏まえて、'
+        '具体的で実践的なアドバイスを日本語でしてください。');
+
+    if (plants.isNotEmpty) {
+      buffer.writeln('\n## ユーザーの植物一覧');
+      for (final plant in plants) {
+        buffer.write('- ${plant.name}');
+        if (plant.variety != null) buffer.write('（${plant.variety}）');
+        if (plant.wateringIntervalDays != null) {
+          buffer.write('：水やり${plant.wateringIntervalDays}日ごと');
+        }
+        buffer.writeln();
+      }
+    }
+
+    if (recentLogs.isNotEmpty) {
+      buffer.writeln('\n## 直近のケア記録（最新${recentLogs.length}件）');
+      for (final log in recentLogs) {
+        final plant = plants.where((p) => p.id == log.plantId).firstOrNull;
+        final plantName = plant?.name ?? '不明な植物';
+        final logTypeName = switch (log.type) {
+          LogType.watering => '水やり',
+          LogType.fertilizer => '肥料',
+          LogType.vitalizer => '活力剤',
+        };
+        final dateStr =
+            '${log.date.year}/${log.date.month}/${log.date.day}';
+        buffer.writeln('- $dateStr: $plantName に $logTypeName');
+      }
+    }
+
+    return buffer.toString();
+  }
+}

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -733,6 +733,13 @@ class PlantProvider with ChangeNotifier {
     await _db.deleteLog(logId);
   }
 
+  /// コーチ機能用に直近30件のログを取得する。
+  Future<List<LogEntry>> getAllLogsForCoach() async {
+    final allLogs = await _db.getAllLogs();
+    allLogs.sort((a, b) => b.date.compareTo(a.date));
+    return allLogs.take(30).toList();
+  }
+
   /// すべての植物の水やり間隔を指定日数に一括設定する。
   Future<void> bulkUpdateWateringInterval(int days) async {
     for (final plant in _plants) {

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -19,6 +19,7 @@ class SettingsProvider with ChangeNotifier {
   LogTypeColors get logTypeColors => _settings.logTypeColors;
   PlantSortOrder get plantSortOrder => _settings.plantSortOrder;
   List<String> get customSortOrder => _settings.customSortOrder;
+  String get geminiApiKey => _settings.geminiApiKey;
 
   /// 保存済み設定を読み込む。
   /// 通知が有効な場合はアプリ起動時に再スケジュールする。
@@ -125,6 +126,13 @@ class SettingsProvider with ChangeNotifier {
   /// カスタム並び順（ユーザー指定）を変更する。
   Future<void> setCustomSortOrder(List<String> order) async {
     _settings = _settings.copyWith(customSortOrder: order);
+    await _settingsService.saveSettings(_settings);
+    notifyListeners();
+  }
+
+  /// Gemini API キーを変更する。
+  Future<void> setGeminiApiKey(String key) async {
+    _settings = _settings.copyWith(geminiApiKey: key);
     await _settingsService.saveSettings(_settings);
     notifyListeners();
   }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -128,4 +128,11 @@ class SettingsProvider with ChangeNotifier {
     await _settingsService.saveSettings(_settings);
     notifyListeners();
   }
+
+  /// Claude APIキーを変更する。
+  Future<void> setClaudeApiKey(String key) async {
+    _settings = _settings.copyWith(claudeApiKey: key);
+    await _settingsService.saveSettings(_settings);
+    notifyListeners();
+  }
 }

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -6,8 +7,10 @@ import 'package:image_picker/image_picker.dart';
 import 'image_crop_screen.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import '../providers/plant_provider.dart';
+import '../providers/settings_provider.dart';
 import '../models/plant.dart';
 import '../widgets/plant_image_widget.dart';
+import '../services/ai_service.dart';
 
 class AddPlantScreen extends StatefulWidget {
   final Plant? plant;
@@ -174,6 +177,103 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     }
   }
 
+  /// 現在選択中の画像をAIに送り植物名・品種名を識別して入力欄に反映する。
+  Future<void> _identifyWithAi() async {
+    // 画像バイト列を取得する
+    Uint8List? bytes;
+    if (_imageBytes != null) {
+      bytes = _imageBytes;
+    } else if (_imagePath != null && !kIsWeb) {
+      try {
+        bytes = await File(_imagePath!).readAsBytes();
+      } catch (_) {
+        bytes = null;
+      }
+    }
+
+    if (bytes == null) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('識別する画像がありません')),
+        );
+      }
+      return;
+    }
+
+    final apiKey = context.read<SettingsProvider>().geminiApiKey;
+    setState(() => _isLoading = true);
+    try {
+      final result = await AiService().identifyPlant(
+        imageBytes: bytes,
+        apiKey: apiKey,
+      );
+      if (!mounted) return;
+      if (result.isSuccessful) {
+        // 識別結果をフォームに反映（上書き確認あり）
+        final apply = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: const Text('AI識別結果'),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('植物名: ${result.name}'),
+                if (result.variety.isNotEmpty) Text('品種: ${result.variety}'),
+                Text('信頼度: ${result.confidenceLabel}'),
+                if (result.notes.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  Text(result.notes,
+                      style: Theme.of(ctx).textTheme.bodySmall),
+                ],
+                const SizedBox(height: 8),
+                const Text('この結果をフォームに反映しますか？'),
+              ],
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(false),
+                child: const Text('キャンセル'),
+              ),
+              FilledButton(
+                onPressed: () => Navigator.of(ctx).pop(true),
+                child: const Text('反映する'),
+              ),
+            ],
+          ),
+        );
+        if (apply == true && mounted) {
+          setState(() {
+            _nameController.text = result.name;
+            if (result.variety.isNotEmpty) {
+              _varietyController.text = result.variety;
+            }
+          });
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(result.notes.isNotEmpty ? result.notes : '植物を識別できませんでした')),
+          );
+        }
+      }
+    } on AiServiceException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(e.message)),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('識別中にエラーが発生しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
   Future<void> _savePlant() async {
     if (!_formKey.currentState!.validate()) return;
 
@@ -332,6 +432,17 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
                 ),
               ),
             ),
+            // 画像が設定されている場合はAI識別ボタンを表示する
+            if (_imageBytes != null || _imagePath != null) ...[
+              const SizedBox(height: 8),
+              Center(
+                child: OutlinedButton.icon(
+                  onPressed: _isLoading ? null : _identifyWithAi,
+                  icon: const Icon(Icons.auto_awesome, size: 18),
+                  label: const Text('AIで植物を識別'),
+                ),
+              ),
+            ],
             const SizedBox(height: 24),
             
             // Plant name

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -9,7 +9,10 @@ import 'package:uuid/uuid.dart';
 import 'image_crop_screen.dart';
 import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import '../providers/plant_provider.dart';
+import '../providers/ai_provider.dart';
+import '../providers/settings_provider.dart';
 import '../models/plant.dart';
+import '../services/ai_service.dart';
 import '../widgets/plant_image_widget.dart';
 
 class AddPlantScreen extends StatefulWidget {
@@ -38,6 +41,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
   String? _imagePath;
   Uint8List? _imageBytes; // Web用: トリミング後のバイト列
   bool _isLoading = false;
+  bool _isIdentifying = false; // AI識別中フラグ
 
   @override
   void initState() {
@@ -186,6 +190,90 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     final file = File('${imagesDir.path}/$fileName');
     await file.writeAsBytes(bytes);
     return file.path;
+  }
+
+  /// 現在の画像をAIに送信して植物名・品種を識別し、フォームに自動入力する。
+  Future<void> _identifyPlantWithAi() async {
+    final apiKey =
+        context.read<SettingsProvider>().settings.claudeApiKey;
+    if (apiKey.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('設定からClaude APIキーを設定してください')),
+      );
+      return;
+    }
+
+    // 送信用Base64を取得（_imageBytes優先、なければ_imagePathのファイルから読み込み）
+    String? imageBase64;
+    if (_imageBytes != null) {
+      imageBase64 = base64Encode(_imageBytes!);
+    } else if (_imagePath != null && !kIsWeb) {
+      try {
+        final bytes = await File(_imagePath!).readAsBytes();
+        imageBase64 = base64Encode(bytes);
+      } catch (_) {}
+    }
+
+    if (imageBase64 == null) return;
+
+    setState(() => _isIdentifying = true);
+    try {
+      final result = await context.read<AiProvider>().identifyPlant(
+            apiKey: apiKey,
+            imageBase64: imageBase64,
+          );
+
+      if (!mounted) return;
+
+      // 識別結果をダイアログで確認してからフォームに入力
+      final confirmed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('識別結果'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('植物名: ${result['name'] ?? '不明'}'),
+              if (result['variety'] != null) Text('品種: ${result['variety']}'),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('この内容で入力する'),
+            ),
+          ],
+        ),
+      );
+
+      if (confirmed == true) {
+        if (result['name'] != null) {
+          _nameController.text = result['name']!;
+        }
+        if (result['variety'] != null) {
+          _varietyController.text = result['variety']!;
+        }
+      }
+    } on AiServiceException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(e.message)),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('識別に失敗しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isIdentifying = false);
+    }
   }
 
   Future<void> _savePlant() async {
@@ -366,8 +454,24 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
                 ),
               ),
             ),
+            // 画像設定後にAI識別ボタンを表示
+            if (_imagePath != null || _imageBytes != null) ...[
+              const SizedBox(height: 12),
+              OutlinedButton.icon(
+                onPressed: _isIdentifying ? null : _identifyPlantWithAi,
+                icon: _isIdentifying
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.auto_awesome),
+                label:
+                    Text(_isIdentifying ? '識別中...' : 'AIで植物を識別'),
+              ),
+            ],
             const SizedBox(height: 24),
-            
+
             // Plant name
             TextFormField(
               controller: _nameController,

--- a/lib/screens/ai_chat_screen.dart
+++ b/lib/screens/ai_chat_screen.dart
@@ -1,0 +1,333 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+import '../models/ai_chat_message.dart';
+import '../providers/ai_provider.dart';
+import '../providers/plant_provider.dart';
+import '../providers/settings_provider.dart';
+
+/// パーソナル植物コーチのチャット画面
+class AiChatScreen extends StatefulWidget {
+  const AiChatScreen({super.key});
+
+  @override
+  State<AiChatScreen> createState() => _AiChatScreenState();
+}
+
+class _AiChatScreenState extends State<AiChatScreen> {
+  final _textController = TextEditingController();
+  final _scrollController = ScrollController();
+  String? _pendingImageBase64;
+
+  @override
+  void initState() {
+    super.initState();
+    // 画面表示時にチャット履歴をクリア
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<AiProvider>().clearMessages();
+    });
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 1024,
+      imageQuality: 80,
+    );
+    if (picked == null) return;
+
+    final bytes = await picked.readAsBytes();
+    setState(() => _pendingImageBase64 = base64Encode(bytes));
+  }
+
+  Future<void> _send() async {
+    final text = _textController.text.trim();
+    if (text.isEmpty && _pendingImageBase64 == null) return;
+
+    final apiKey =
+        context.read<SettingsProvider>().settings.claudeApiKey;
+    if (apiKey.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('設定からClaude APIキーを設定してください')),
+      );
+      return;
+    }
+
+    final imageBase64 = _pendingImageBase64;
+    _textController.clear();
+    setState(() => _pendingImageBase64 = null);
+
+    final plantProvider = context.read<PlantProvider>();
+    final allLogs = await plantProvider.getAllLogsForCoach();
+
+    if (!mounted) return;
+    await context.read<AiProvider>().sendMessage(
+          apiKey: apiKey,
+          text: text.isEmpty ? '（画像を送りました）' : text,
+          imageBase64: imageBase64,
+          plants: plantProvider.plants,
+          recentLogs: allLogs,
+        );
+
+    // 最下部にスクロール
+    if (_scrollController.hasClients) {
+      await _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('植物コーチ'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.delete_outline),
+            tooltip: '会話をリセット',
+            onPressed: () => context.read<AiProvider>().clearMessages(),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(child: _buildMessageList()),
+          _buildInputArea(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageList() {
+    return Consumer<AiProvider>(
+      builder: (context, aiProvider, _) {
+        final messages = aiProvider.messages;
+
+        if (messages.isEmpty && !aiProvider.isLoading) {
+          return _buildEmptyState();
+        }
+
+        return ListView.builder(
+          controller: _scrollController,
+          padding: const EdgeInsets.all(16),
+          itemCount: messages.length +
+              (aiProvider.isLoading ? 1 : 0) +
+              (aiProvider.error != null ? 1 : 0),
+          itemBuilder: (context, index) {
+            if (index < messages.length) {
+              return _buildMessageBubble(messages[index]);
+            }
+            if (aiProvider.isLoading) {
+              return _buildTypingIndicator();
+            }
+            if (aiProvider.error != null) {
+              return _buildErrorBubble(aiProvider.error!);
+            }
+            return const SizedBox.shrink();
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.eco_outlined,
+              size: 64,
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.4)),
+          const SizedBox(height: 16),
+          Text(
+            '植物のことを何でも相談してください',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageBubble(AiChatMessage message) {
+    final isUser = message.isUser;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.75,
+        ),
+        decoration: BoxDecoration(
+          color: isUser
+              ? colorScheme.primaryContainer
+              : colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              if (message.imageBase64 != null)
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.memory(
+                    base64Decode(message.imageBase64!),
+                    height: 160,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              if (message.imageBase64 != null && message.text.isNotEmpty)
+                const SizedBox(height: 8),
+              if (message.text.isNotEmpty)
+                SelectableText(
+                  message.text,
+                  style: TextStyle(
+                    color: isUser
+                        ? colorScheme.onPrimaryContainer
+                        : colorScheme.onSurfaceVariant,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTypingIndicator() {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: const Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SizedBox(
+              width: 8, height: 8,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            SizedBox(width: 8),
+            Text('考え中...'),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildErrorBubble(String error) {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Text(
+        error,
+        style: TextStyle(
+          color: Theme.of(context).colorScheme.onErrorContainer,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInputArea() {
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.fromLTRB(8, 8, 8, 8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          border: Border(
+            top: BorderSide(
+              color: Theme.of(context).colorScheme.outlineVariant,
+            ),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (_pendingImageBase64 != null) _buildPendingImage(),
+            Row(
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.photo_library_outlined),
+                  onPressed: _pickImage,
+                  tooltip: '画像を添付',
+                ),
+                Expanded(
+                  child: TextField(
+                    controller: _textController,
+                    maxLines: null,
+                    decoration: const InputDecoration(
+                      hintText: 'メッセージを入力...',
+                      border: InputBorder.none,
+                      contentPadding: EdgeInsets.symmetric(horizontal: 8),
+                    ),
+                    onSubmitted: (_) => _send(),
+                  ),
+                ),
+                Consumer<AiProvider>(
+                  builder: (context, ai, _) => IconButton(
+                    icon: const Icon(Icons.send),
+                    onPressed: ai.isLoading ? null : _send,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPendingImage() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Stack(
+        alignment: Alignment.topRight,
+        children: [
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.memory(
+              base64Decode(_pendingImageBase64!),
+              height: 80,
+              fit: BoxFit.cover,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, size: 18),
+            style: IconButton.styleFrom(
+              backgroundColor:
+                  Theme.of(context).colorScheme.surface.withValues(alpha: 0.8),
+              padding: EdgeInsets.zero,
+              minimumSize: const Size(24, 24),
+            ),
+            onPressed: () => setState(() => _pendingImageBase64 = null),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/ai_coach_screen.dart
+++ b/lib/screens/ai_coach_screen.dart
@@ -1,0 +1,400 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/plant_provider.dart';
+import '../providers/settings_provider.dart';
+import '../services/ai_service.dart';
+
+/// AI パーソナルコーチ画面。
+///
+/// チャット形式で植物育成に関する質問ができる。
+/// ユーザーが育てている植物情報をコンテキストとして Gemini API に渡す。
+class AiCoachScreen extends StatefulWidget {
+  const AiCoachScreen({super.key});
+
+  @override
+  State<AiCoachScreen> createState() => _AiCoachScreenState();
+}
+
+class _AiCoachScreenState extends State<AiCoachScreen> {
+  final List<ChatMessage> _history = [];
+  final List<_UiMessage> _uiMessages = [];
+  final TextEditingController _inputController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  bool _isLoading = false;
+
+  @override
+  void dispose() {
+    _inputController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  /// 育てている植物のコンテキスト文字列を生成する。
+  String _buildPlantContext() {
+    final plants = context.read<PlantProvider>().plants;
+    if (plants.isEmpty) return '';
+    final lines = plants.map((p) {
+      final parts = <String>[p.name];
+      if (p.variety != null) parts.add('（${p.variety}）');
+      if (p.wateringIntervalDays != null) {
+        parts.add('水やり${p.wateringIntervalDays}日ごと');
+      }
+      return parts.join(' ');
+    });
+    return lines.join('\n');
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _inputController.text.trim();
+    if (text.isEmpty) return;
+
+    final apiKey = context.read<SettingsProvider>().geminiApiKey;
+    if (apiKey.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Gemini APIキーが設定されていません。設定画面で入力してください。'),
+        ),
+      );
+      return;
+    }
+
+    // UIにユーザーメッセージを追加する
+    setState(() {
+      _uiMessages.add(_UiMessage(text: text, isUser: true));
+      _history.add(ChatMessage(role: 'user', text: text));
+      _isLoading = true;
+    });
+    _inputController.clear();
+    _scrollToBottom();
+
+    try {
+      final plantContext = _buildPlantContext();
+      final response = await AiService().chat(
+        messages: List.from(_history)..removeLast(), // 送信前の履歴
+        userMessage: text,
+        plantContext: plantContext.isNotEmpty ? plantContext : null,
+        apiKey: apiKey,
+      );
+
+      if (mounted) {
+        setState(() {
+          _uiMessages.add(_UiMessage(text: response, isUser: false));
+          _history.add(ChatMessage(role: 'model', text: response));
+        });
+        _scrollToBottom();
+      }
+    } on AiServiceException catch (e) {
+      if (mounted) {
+        setState(() {
+          _uiMessages.add(_UiMessage(
+            text: 'エラー: ${e.message}',
+            isUser: false,
+            isError: true,
+          ));
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _uiMessages.add(_UiMessage(
+            text: 'エラーが発生しました: $e',
+            isUser: false,
+            isError: true,
+          ));
+        });
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  /// 会話をリセットする。
+  void _clearConversation() {
+    setState(() {
+      _history.clear();
+      _uiMessages.clear();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Row(
+          children: [
+            Icon(Icons.auto_awesome,
+                color: Theme.of(context).colorScheme.primary, size: 20),
+            const SizedBox(width: 8),
+            const Text('AIコーチ'),
+          ],
+        ),
+        actions: [
+          if (_uiMessages.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.delete_sweep),
+              tooltip: '会話をリセット',
+              onPressed: _clearConversation,
+            ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: _uiMessages.isEmpty
+                ? _buildWelcomeView()
+                : ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.all(16),
+                    itemCount: _uiMessages.length,
+                    itemBuilder: (context, index) {
+                      return _MessageBubble(message: _uiMessages[index]);
+                    },
+                  ),
+          ),
+          if (_isLoading)
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+              child: Row(
+                children: [
+                  SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text('考え中...',
+                      style: Theme.of(context).textTheme.bodySmall),
+                ],
+              ),
+            ),
+          // 入力エリア
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: TextField(
+                      controller: _inputController,
+                      minLines: 1,
+                      maxLines: 4,
+                      textInputAction: TextInputAction.send,
+                      onSubmitted: (_) => _isLoading ? null : _sendMessage(),
+                      decoration: InputDecoration(
+                        hintText: '植物の育て方を聞いてみよう...',
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(24),
+                        ),
+                        contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16,
+                          vertical: 8,
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: _isLoading ? null : _sendMessage,
+                    style: FilledButton.styleFrom(
+                      shape: const CircleBorder(),
+                      padding: const EdgeInsets.all(12),
+                    ),
+                    child: const Icon(Icons.send, size: 20),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 会話が空の場合に表示するウェルカムビュー
+  Widget _buildWelcomeView() {
+    final plants = context.watch<PlantProvider>().plants;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.auto_awesome,
+              size: 72,
+              color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'AIパーソナルコーチ',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '植物の育て方、水やりのタイミング、病気の対処法など\n何でも聞いてみてください。',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            if (plants.isNotEmpty) ...[
+              const SizedBox(height: 16),
+              Text(
+                'あなたの植物 ${plants.length} 件の情報をもとにアドバイスします。',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            ],
+            const SizedBox(height: 24),
+            // サジェスト質問チップ
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              alignment: WrapAlignment.center,
+              children: [
+                _SuggestChip(
+                  label: '水やりの頻度は？',
+                  onTap: () {
+                    _inputController.text = '水やりの適切な頻度を教えてください';
+                    _sendMessage();
+                  },
+                ),
+                _SuggestChip(
+                  label: '葉が黄色くなった',
+                  onTap: () {
+                    _inputController.text = '葉が黄色くなってきました。原因と対処法を教えてください';
+                    _sendMessage();
+                  },
+                ),
+                _SuggestChip(
+                  label: '肥料のタイミング',
+                  onTap: () {
+                    _inputController.text = '肥料を与えるタイミングと量を教えてください';
+                    _sendMessage();
+                  },
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// チャットメッセージのUIデータクラス。
+class _UiMessage {
+  final String text;
+  final bool isUser;
+  final bool isError;
+
+  const _UiMessage({
+    required this.text,
+    required this.isUser,
+    this.isError = false,
+  });
+}
+
+/// チャットバブルウィジェット。
+class _MessageBubble extends StatelessWidget {
+  final _UiMessage message;
+
+  const _MessageBubble({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isUser = message.isUser;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment:
+            isUser ? MainAxisAlignment.end : MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (!isUser) ...[
+            CircleAvatar(
+              radius: 16,
+              backgroundColor: colorScheme.primaryContainer,
+              child: Icon(Icons.auto_awesome,
+                  size: 16, color: colorScheme.onPrimaryContainer),
+            ),
+            const SizedBox(width: 8),
+          ],
+          Flexible(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: message.isError
+                    ? colorScheme.errorContainer
+                    : isUser
+                        ? colorScheme.primaryContainer
+                        : colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.only(
+                  topLeft: const Radius.circular(16),
+                  topRight: const Radius.circular(16),
+                  bottomLeft: Radius.circular(isUser ? 16 : 4),
+                  bottomRight: Radius.circular(isUser ? 4 : 16),
+                ),
+              ),
+              child: Text(
+                message.text,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: message.isError
+                      ? colorScheme.onErrorContainer
+                      : isUser
+                          ? colorScheme.onPrimaryContainer
+                          : colorScheme.onSurface,
+                ),
+              ),
+            ),
+          ),
+          if (isUser) ...[
+            const SizedBox(width: 8),
+            CircleAvatar(
+              radius: 16,
+              backgroundColor: colorScheme.secondaryContainer,
+              child: Icon(Icons.person,
+                  size: 16, color: colorScheme.onSecondaryContainer),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// サジェスト質問チップウィジェット。
+class _SuggestChip extends StatelessWidget {
+  final String label;
+  final VoidCallback onTap;
+
+  const _SuggestChip({required this.label, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ActionChip(
+      label: Text(label),
+      onPressed: onTap,
+      avatar: const Icon(Icons.chat_bubble_outline, size: 16),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../providers/settings_provider.dart';
 import 'today_watering_screen.dart';
 import 'plant_list_screen.dart';
 import 'notes_list_screen.dart';
+import 'ai_coach_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -21,6 +22,7 @@ class _HomeScreenState extends State<HomeScreen> {
     const TodayWateringScreen(),
     const PlantListScreen(),
     const NotesListScreen(),
+    const AiCoachScreen(),
   ];
 
   @override
@@ -69,6 +71,11 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icon(Icons.note_outlined),
             selectedIcon: Icon(Icons.note),
             label: 'ノート',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.auto_awesome_outlined),
+            selectedIcon: Icon(Icons.auto_awesome),
+            label: 'AIコーチ',
           ),
         ],
       ),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../providers/settings_provider.dart';
 import 'today_watering_screen.dart';
 import 'plant_list_screen.dart';
 import 'notes_list_screen.dart';
+import 'ai_chat_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -21,6 +22,7 @@ class _HomeScreenState extends State<HomeScreen> {
     const TodayWateringScreen(),
     const PlantListScreen(),
     const NotesListScreen(),
+    const AiChatScreen(),
   ];
 
   @override
@@ -50,7 +52,7 @@ class _HomeScreenState extends State<HomeScreen> {
           // タブ切替時にデータを再読み込みする
           await context.read<PlantProvider>().loadPlants();
           // ノートタブ（index=2）切替時はノートも再読み込みする
-          if (index == 2) {
+          if (index == 3) {
             await context.read<NoteProvider>().loadNotes();
           }
         },
@@ -69,6 +71,11 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icon(Icons.note_outlined),
             selectedIcon: Icon(Icons.note),
             label: 'ノート',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.smart_toy_outlined),
+            selectedIcon: Icon(Icons.smart_toy),
+            label: 'AI',
           ),
         ],
       ),

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -6,11 +6,13 @@ import '../models/plant.dart';
 import '../models/log_entry.dart';
 import '../providers/plant_provider.dart';
 import '../providers/note_provider.dart';
+import '../providers/settings_provider.dart';
 import '../utils/date_utils.dart';
 import 'add_plant_screen.dart';
 import 'add_edit_note_screen.dart';
 import 'note_detail_screen.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
+import '../services/ai_service.dart';
 
 /// SliverPersistentHeaderDelegate: TabBarを固定表示するためのデリゲート
 class _StickyTabBarDelegate extends SliverPersistentHeaderDelegate {
@@ -358,6 +360,9 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
           const SizedBox(height: 16),
           _buildFertilizerInfoCard(),
         ],
+        const SizedBox(height: 16),
+        // AI健康診断ボタン
+        _AiHealthDiagnosisCard(plant: widget.plant),
       ],
     );
   }
@@ -722,3 +727,130 @@ class _InfoRow extends StatelessWidget {
   }
 }
 
+/// AI健康診断カードウィジェット。
+///
+/// 症状をテキストで入力し、Gemini APIで診断結果を取得して表示する。
+class _AiHealthDiagnosisCard extends StatefulWidget {
+  final Plant plant;
+
+  const _AiHealthDiagnosisCard({required this.plant});
+
+  @override
+  State<_AiHealthDiagnosisCard> createState() => _AiHealthDiagnosisCardState();
+}
+
+class _AiHealthDiagnosisCardState extends State<_AiHealthDiagnosisCard> {
+  final _symptomController = TextEditingController();
+  bool _isLoading = false;
+  String? _diagnosisResult;
+
+  @override
+  void dispose() {
+    _symptomController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _diagnose() async {
+    if (_symptomController.text.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('症状を入力してください')),
+      );
+      return;
+    }
+
+    final apiKey = context.read<SettingsProvider>().geminiApiKey;
+    setState(() {
+      _isLoading = true;
+      _diagnosisResult = null;
+    });
+
+    try {
+      final result = await AiService().diagnoseHealth(
+        plantName: widget.plant.name,
+        symptomDescription: _symptomController.text.trim(),
+        apiKey: apiKey,
+      );
+      if (mounted) {
+        setState(() => _diagnosisResult = result);
+      }
+    } on AiServiceException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(e.message)),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('診断中にエラーが発生しました: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.auto_awesome,
+                    color: Theme.of(context).colorScheme.primary, size: 20),
+                const SizedBox(width: 8),
+                Text(
+                  'AI健康診断',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _symptomController,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                hintText: '例: 葉が黄色くなってきた、元気がない、葉先が枯れている',
+                labelText: '症状を入力',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              width: double.infinity,
+              child: FilledButton.icon(
+                onPressed: _isLoading ? null : _diagnose,
+                icon: _isLoading
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                            strokeWidth: 2, color: Colors.white),
+                      )
+                    : const Icon(Icons.search, size: 18),
+                label: Text(_isLoading ? '診断中...' : '診断する'),
+              ),
+            ),
+            if (_diagnosisResult != null) ...[
+              const SizedBox(height: 12),
+              const Divider(),
+              const SizedBox(height: 8),
+              Text(
+                '診断結果',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(_diagnosisResult!),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -11,6 +11,7 @@ import '../utils/date_utils.dart';
 import 'add_plant_screen.dart';
 import 'add_edit_note_screen.dart';
 import 'note_detail_screen.dart';
+import 'plant_health_screen.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 
 /// SliverPersistentHeaderDelegate: TabBarを固定表示するためのデリゲート
@@ -379,7 +380,34 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
           const SizedBox(height: 16),
           _buildFertilizerInfoCard(),
         ],
+        const SizedBox(height: 24),
+        _buildHealthDiagnoseButton(),
       ],
+    );
+  }
+
+  /// 健康診断ボタン
+  Widget _buildHealthDiagnoseButton() {
+    return FilledButton.tonalIcon(
+      onPressed: () async {
+        // 最終水やり日を取得してから画面遷移する
+        final logs = await context
+            .read<PlantProvider>()
+            .getAllLogsForPlantAndType(widget.plant.id, LogType.watering);
+        logs.sort((a, b) => b.date.compareTo(a.date));
+        final lastWateredAt = logs.isNotEmpty ? logs.first.date : null;
+        if (!mounted) return;
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => PlantHealthScreen(
+              plant: widget.plant,
+              lastWateredAt: lastWateredAt,
+            ),
+          ),
+        );
+      },
+      icon: const Icon(Icons.medical_services_outlined),
+      label: const Text('健康診断する'),
     );
   }
 

--- a/lib/screens/plant_health_screen.dart
+++ b/lib/screens/plant_health_screen.dart
@@ -1,0 +1,240 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+import '../models/plant.dart';
+import '../providers/ai_provider.dart';
+import '../providers/settings_provider.dart';
+import '../services/ai_service.dart';
+
+/// 植物の健康診断画面
+class PlantHealthScreen extends StatefulWidget {
+  final Plant plant;
+
+  /// 最終水やり日（PlantDetailScreenから渡す）
+  final DateTime? lastWateredAt;
+
+  const PlantHealthScreen({
+    super.key,
+    required this.plant,
+    this.lastWateredAt,
+  });
+
+  @override
+  State<PlantHealthScreen> createState() => _PlantHealthScreenState();
+}
+
+class _PlantHealthScreenState extends State<PlantHealthScreen> {
+  final _symptomController = TextEditingController();
+  String? _imageBase64;
+  bool _isLoading = false;
+  String? _result;
+  String? _error;
+
+  @override
+  void dispose() {
+    _symptomController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickImage() async {
+    final picker = ImagePicker();
+    final picked = await picker.pickImage(
+      source: ImageSource.gallery,
+      maxWidth: 1024,
+      imageQuality: 80,
+    );
+    if (picked == null) return;
+
+    final bytes = await picked.readAsBytes();
+    setState(() {
+      _imageBase64 = base64Encode(bytes);
+    });
+  }
+
+  Future<void> _diagnose() async {
+    final apiKey =
+        context.read<SettingsProvider>().settings.claudeApiKey;
+    if (apiKey.isEmpty) {
+      _showApiKeyNotSetError();
+      return;
+    }
+
+    setState(() {
+      _isLoading = true;
+      _result = null;
+      _error = null;
+    });
+
+    try {
+      final result = await context.read<AiProvider>().diagnoseHealth(
+            apiKey: apiKey,
+            plantName: widget.plant.name,
+            variety: widget.plant.variety,
+            symptomText: _symptomController.text,
+            wateringIntervalDays: widget.plant.wateringIntervalDays,
+            lastWateredAt: widget.lastWateredAt,
+            imageBase64: _imageBase64,
+          );
+      setState(() => _result = result);
+    } on AiServiceException catch (e) {
+      setState(() => _error = e.message);
+    } catch (e) {
+      setState(() => _error = 'エラーが発生しました: $e');
+    } finally {
+      setState(() => _isLoading = false);
+    }
+  }
+
+  void _showApiKeyNotSetError() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('設定からClaude APIキーを設定してください')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('健康診断'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _buildPlantInfo(),
+            const SizedBox(height: 16),
+            _buildSymptomInput(),
+            const SizedBox(height: 16),
+            _buildImageSection(),
+            const SizedBox(height: 24),
+            _buildDiagnoseButton(),
+            if (_isLoading) ...[
+              const SizedBox(height: 24),
+              const Center(child: CircularProgressIndicator()),
+              const SizedBox(height: 8),
+              const Center(child: Text('診断中...')),
+            ],
+            if (_error != null) ...[
+              const SizedBox(height: 16),
+              _buildErrorCard(),
+            ],
+            if (_result != null) ...[
+              const SizedBox(height: 16),
+              _buildResultCard(),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPlantInfo() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.plant.name,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            if (widget.plant.variety != null)
+              Text(
+                widget.plant.variety!,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSymptomInput() {
+    return TextField(
+      controller: _symptomController,
+      maxLines: 4,
+      decoration: const InputDecoration(
+        labelText: '症状・気になること',
+        hintText: '例: 葉が黄色くなってきた、元気がなさそう',
+        border: OutlineInputBorder(),
+      ),
+    );
+  }
+
+  Widget _buildImageSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('写真（任意）',
+            style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 8),
+        if (_imageBase64 != null)
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.memory(
+              Uint8List.fromList(base64Decode(_imageBase64!)),
+              height: 160,
+              fit: BoxFit.cover,
+            ),
+          ),
+        const SizedBox(height: 8),
+        OutlinedButton.icon(
+          onPressed: _pickImage,
+          icon: const Icon(Icons.photo_library_outlined),
+          label: Text(_imageBase64 == null ? '写真を選択' : '写真を変更'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildDiagnoseButton() {
+    return FilledButton.icon(
+      onPressed: _isLoading ? null : _diagnose,
+      icon: const Icon(Icons.medical_services_outlined),
+      label: const Text('診断する'),
+    );
+  }
+
+  Widget _buildErrorCard() {
+    return Card(
+      color: Theme.of(context).colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Text(
+          _error!,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.onErrorContainer,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildResultCard() {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.check_circle_outline,
+                    color: Theme.of(context).colorScheme.primary, size: 20),
+                const SizedBox(width: 8),
+                Text('診断結果',
+                    style: Theme.of(context).textTheme.titleSmall),
+              ],
+            ),
+            const SizedBox(height: 12),
+            SelectableText(_result!),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -159,6 +159,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: const Text('ZIP または JSON ファイルからデータを復元'),
             onTap: _isImporting ? null : () => _handleImport(context),
           ),
+          // AI機能設定
+          _buildSectionHeader(context, 'AI機能'),
+          Consumer<SettingsProvider>(
+            builder: (context, settings, _) {
+              return _AiApiKeyTile(
+                initialValue: settings.geminiApiKey,
+                onSaved: (key) => settings.setGeminiApiKey(key),
+              );
+            },
+          ),
           const Divider(),
 
           // About
@@ -476,5 +486,106 @@ class _SettingsScreenState extends State<SettingsScreen> {
       case AppTheme.orange:
         return Colors.orange;
     }
+  }
+}
+
+/// APIキーの入力・保存を行う独立ウィジェット。
+class _AiApiKeyTile extends StatefulWidget {
+  final String initialValue;
+  final Future<void> Function(String) onSaved;
+
+  const _AiApiKeyTile({required this.initialValue, required this.onSaved});
+
+  @override
+  State<_AiApiKeyTile> createState() => _AiApiKeyTileState();
+}
+
+class _AiApiKeyTileState extends State<_AiApiKeyTile> {
+  late final TextEditingController _controller;
+  bool _obscure = true;
+  bool _isSaving = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.initialValue);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    setState(() => _isSaving = true);
+    try {
+      await widget.onSaved(_controller.text.trim());
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('APIキーを保存しました')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSaving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 説明文
+          Text(
+            'Gemini APIキーを入力すると、植物の自動識別・健康診断・パーソナルコーチ機能が利用できます。',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  obscureText: _obscure,
+                  decoration: InputDecoration(
+                    labelText: 'Gemini APIキー',
+                    hintText: 'AIza...',
+                    border: const OutlineInputBorder(),
+                    suffixIcon: IconButton(
+                      icon: Icon(_obscure ? Icons.visibility : Icons.visibility_off),
+                      onPressed: () => setState(() => _obscure = !_obscure),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              _isSaving
+                  ? const SizedBox(
+                      width: 40,
+                      height: 40,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : FilledButton.tonal(
+                      onPressed: _save,
+                      child: const Text('保存'),
+                    ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          // Google AI Studioへのヒント
+          Text(
+            'APIキーは Google AI Studio (aistudio.google.com) で取得できます。',
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -134,6 +134,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ),
           const Divider(),
 
+          // AI設定
+          _buildSectionHeader(context, 'AI設定（Claude API）'),
+          _buildApiKeyTile(),
+          const Divider(),
+
           // Data management
           _buildSectionHeader(context, 'データ管理'),
           ListTile(
@@ -474,6 +479,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
   }
 
+  /// Claude APIキー設定タイル
+  Widget _buildApiKeyTile() {
+    return Consumer<SettingsProvider>(
+      builder: (context, settings, _) {
+        final currentKey = settings.settings.claudeApiKey;
+        final isSet = currentKey.isNotEmpty;
+        return ListTile(
+          leading: Icon(
+            Icons.key,
+            color: isSet
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          title: const Text('Claude APIキー'),
+          subtitle: Text(isSet ? '設定済み（タップして変更）' : '未設定'),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () => _showApiKeyDialog(context, settings, currentKey),
+        );
+      },
+    );
+  }
+
   /// DB内のBase64画像をファイルに変換する
   Future<void> _handleImageMigration(BuildContext context) async {
     // 変換前に確認ダイアログを表示
@@ -543,6 +570,70 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ],
       ),
     );
+  }
+
+  /// APIキー入力ダイアログを表示する。
+  Future<void> _showApiKeyDialog(
+    BuildContext context,
+    SettingsProvider settings,
+    String currentKey,
+  ) async {
+    final controller = TextEditingController(text: currentKey);
+    bool obscure = true;
+
+    final newKey = await showDialog<String>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('Claude APIキー'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: controller,
+                obscureText: obscure,
+                decoration: InputDecoration(
+                  hintText: 'sk-ant-...',
+                  border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    icon: Icon(
+                        obscure ? Icons.visibility : Icons.visibility_off),
+                    onPressed: () =>
+                        setDialogState(() => obscure = !obscure),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Anthropicのコンソールから取得できます。\nAPIキーはこのデバイスにのみ保存されます。',
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+          actions: [
+            if (currentKey.isNotEmpty)
+              TextButton(
+                onPressed: () => Navigator.of(ctx).pop(''),
+                child: const Text('削除'),
+              ),
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(null),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () =>
+                  Navigator.of(ctx).pop(controller.text.trim()),
+              child: const Text('保存'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    controller.dispose();
+    if (newKey == null || !context.mounted) return;
+    await settings.setClaudeApiKey(newKey);
   }
 
   Widget _buildSectionHeader(BuildContext context, String title) {

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,0 +1,255 @@
+import 'dart:typed_data';
+import 'package:google_generative_ai/google_generative_ai.dart';
+
+/// AI機能を提供するサービスクラス。
+///
+/// Gemini API を利用して植物の自動識別・健康診断・パーソナルコーチ機能を提供する。
+class AiService {
+  /// Gemini APIキーが未設定の場合にスローする例外メッセージ
+  static const String _noApiKeyMessage =
+      'Gemini APIキーが設定されていません。設定画面でAPIキーを入力してください。';
+
+  /// 植物の写真から植物名と品種を識別する。
+  ///
+  /// [imageBytes] にトリミング済みの画像バイト列を渡す。
+  /// [apiKey] はGemini APIキー。
+  /// 識別結果として `{'name': '...', 'variety': '...'}` を返す。
+  /// エラー時は [AiServiceException] をスローする。
+  Future<PlantIdentificationResult> identifyPlant({
+    required Uint8List imageBytes,
+    required String apiKey,
+  }) async {
+    _validateApiKey(apiKey);
+
+    final model = GenerativeModel(
+      model: 'gemini-1.5-flash',
+      apiKey: apiKey,
+    );
+
+    const prompt = '''
+あなたは植物識別の専門家です。この画像に写っている植物を識別してください。
+
+以下の形式で回答してください（必ずJSONで返してください）:
+{
+  "name": "植物の一般的な日本語名称",
+  "variety": "品種名や学名（不明な場合は空文字）",
+  "confidence": "high/medium/low のいずれか",
+  "notes": "補足情報（任意）"
+}
+
+植物以外が写っている場合は:
+{
+  "name": "",
+  "variety": "",
+  "confidence": "low",
+  "notes": "植物を識別できませんでした"
+}
+''';
+
+    try {
+      final response = await model.generateContent([
+        Content.multi([
+          TextPart(prompt),
+          DataPart('image/jpeg', imageBytes),
+        ]),
+      ]);
+
+      final text = response.text ?? '';
+      return _parsePlantIdentification(text);
+    } on GenerativeAIException catch (e) {
+      throw AiServiceException('植物の識別に失敗しました: ${e.message}');
+    } catch (e) {
+      throw AiServiceException('植物の識別中にエラーが発生しました: $e');
+    }
+  }
+
+  /// 植物の健康状態を診断する。
+  ///
+  /// [plantName] 植物名、[symptomDescription] ユーザーが入力した症状の説明。
+  /// [imageBytes] に症状の写真バイト列を渡せる（null可）。
+  Future<String> diagnoseHealth({
+    required String plantName,
+    required String symptomDescription,
+    Uint8List? imageBytes,
+    required String apiKey,
+  }) async {
+    _validateApiKey(apiKey);
+
+    final model = GenerativeModel(
+      model: 'gemini-1.5-flash',
+      apiKey: apiKey,
+    );
+
+    final prompt = '''
+あなたは植物の健康管理の専門家です。以下の植物の症状を診断してアドバイスしてください。
+
+植物名: $plantName
+症状の説明: $symptomDescription
+
+以下の構成で回答してください:
+1. **考えられる原因**（箇条書き）
+2. **対処法**（具体的な手順）
+3. **予防策**
+4. **注意点**（重篤な場合や専門家への相談が必要な場合は明記）
+
+日本語で回答してください。
+''';
+
+    try {
+      final parts = <Part>[TextPart(prompt)];
+      if (imageBytes != null) {
+        parts.add(DataPart('image/jpeg', imageBytes));
+      }
+
+      final response = await model.generateContent([Content.multi(parts)]);
+      return response.text ?? '診断結果を取得できませんでした。';
+    } on GenerativeAIException catch (e) {
+      throw AiServiceException('健康診断に失敗しました: ${e.message}');
+    } catch (e) {
+      throw AiServiceException('健康診断中にエラーが発生しました: $e');
+    }
+  }
+
+  /// パーソナルコーチとチャット形式で対話する。
+  ///
+  /// [messages] はこれまでの会話履歴（ロール: 'user' / 'model'）。
+  /// [userMessage] はユーザーの新しいメッセージ。
+  /// [plantContext] は育てている植物情報の要約文字列（任意）。
+  Future<String> chat({
+    required List<ChatMessage> messages,
+    required String userMessage,
+    String? plantContext,
+    required String apiKey,
+  }) async {
+    _validateApiKey(apiKey);
+
+    final model = GenerativeModel(
+      model: 'gemini-1.5-flash',
+      apiKey: apiKey,
+      systemInstruction: Content.system(
+        '''あなたは植物育成のパーソナルコーチです。ユーザーが育てている植物のケアについて、
+わかりやすく親切にアドバイスします。
+
+${plantContext != null ? '【ユーザーが育てている植物】\n$plantContext\n' : ''}
+- 専門用語は避け、初心者にもわかりやすい言葉で説明する
+- 具体的なアドバイスを心がける
+- 質問には丁寧に答える
+- 日本語で回答する''',
+      ),
+    );
+
+    // 会話履歴を変換
+    final history = messages.map((m) {
+      return Content(m.role, [TextPart(m.text)]);
+    }).toList();
+
+    final chat = model.startChat(history: history);
+
+    try {
+      final response = await chat.sendMessage(Content.text(userMessage));
+      return response.text ?? 'メッセージを取得できませんでした。';
+    } on GenerativeAIException catch (e) {
+      throw AiServiceException('チャットに失敗しました: ${e.message}');
+    } catch (e) {
+      throw AiServiceException('チャット中にエラーが発生しました: $e');
+    }
+  }
+
+  /// APIキーが設定されているか検証する。
+  void _validateApiKey(String apiKey) {
+    if (apiKey.trim().isEmpty) {
+      throw AiServiceException(_noApiKeyMessage);
+    }
+  }
+
+  /// Gemini の応答テキストから植物識別結果をパースする。
+  PlantIdentificationResult _parsePlantIdentification(String text) {
+    // JSONブロックを抽出する
+    final jsonMatch = RegExp(r'\{[\s\S]*\}').firstMatch(text);
+    if (jsonMatch == null) {
+      return PlantIdentificationResult(
+        name: '',
+        variety: '',
+        confidence: 'low',
+        notes: '識別結果のパースに失敗しました',
+      );
+    }
+
+    try {
+      final jsonStr = jsonMatch.group(0)!;
+      // 簡易パース（jsonパッケージ不使用で抽出）
+      final name = _extractJsonString(jsonStr, 'name');
+      final variety = _extractJsonString(jsonStr, 'variety');
+      final confidence = _extractJsonString(jsonStr, 'confidence');
+      final notes = _extractJsonString(jsonStr, 'notes');
+      return PlantIdentificationResult(
+        name: name,
+        variety: variety,
+        confidence: confidence,
+        notes: notes,
+      );
+    } catch (_) {
+      return PlantIdentificationResult(
+        name: '',
+        variety: '',
+        confidence: 'low',
+        notes: '識別結果のパースに失敗しました',
+      );
+    }
+  }
+
+  /// JSONオブジェクト文字列から指定キーの文字列値を抽出する。
+  String _extractJsonString(String json, String key) {
+    final match = RegExp('"$key"\\s*:\\s*"([^"]*)"').firstMatch(json);
+    return match?.group(1) ?? '';
+  }
+}
+
+/// 植物識別結果を保持するデータクラス。
+class PlantIdentificationResult {
+  final String name;
+  final String variety;
+  final String confidence;
+  final String notes;
+
+  const PlantIdentificationResult({
+    required this.name,
+    required this.variety,
+    required this.confidence,
+    required this.notes,
+  });
+
+  /// 識別に成功したかどうか（植物名が取得できたか）
+  bool get isSuccessful => name.isNotEmpty;
+
+  /// 信頼度の日本語表現
+  String get confidenceLabel {
+    switch (confidence) {
+      case 'high':
+        return '高';
+      case 'medium':
+        return '中';
+      default:
+        return '低';
+    }
+  }
+}
+
+/// チャットメッセージを保持するデータクラス。
+class ChatMessage {
+  /// 'user' または 'model'
+  final String role;
+  final String text;
+
+  const ChatMessage({required this.role, required this.text});
+}
+
+/// AIサービスで発生するエラーを表す例外クラス。
+class AiServiceException implements Exception {
+  final String message;
+
+  const AiServiceException(this.message);
+
+  @override
+  String toString() => 'AiServiceException: $message';
+}

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,0 +1,206 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/ai_chat_message.dart';
+
+/// Claude API との通信を担うサービス
+class AiService {
+  static const String _apiUrl =
+      'https://api.anthropic.com/v1/messages';
+  static const String _modelDefault = 'claude-haiku-4-5-20251001';
+  static const Duration _timeout = Duration(seconds: 30);
+
+  /// テキスト・画像を含むメッセージをClaude APIに送信し、応答テキストを返す。
+  ///
+  /// [apiKey] が空の場合は [ArgumentError] をスローする。
+  /// APIエラー時は [AiServiceException] をスローする。
+  Future<String> sendMessage({
+    required String apiKey,
+    required String systemPrompt,
+    required List<AiChatMessage> history,
+    String model = _modelDefault,
+  }) async {
+    if (apiKey.isEmpty) {
+      throw ArgumentError('APIキーが設定されていません');
+    }
+
+    final messages = _buildMessages(history);
+
+    final body = jsonEncode({
+      'model': model,
+      'max_tokens': 1024,
+      'system': systemPrompt,
+      'messages': messages,
+    });
+
+    final http.Response response;
+    try {
+      response = await http
+          .post(
+            Uri.parse(_apiUrl),
+            headers: {
+              'Content-Type': 'application/json',
+              'x-api-key': apiKey,
+              'anthropic-version': '2023-06-01',
+            },
+            body: body,
+          )
+          .timeout(_timeout);
+    } on Exception catch (e) {
+      throw AiServiceException('ネットワークエラー: $e');
+    }
+
+    return _parseResponse(response);
+  }
+
+  /// 植物の写真から植物名・品種をJSON形式で返す。
+  ///
+  /// 戻り値: `{"name": "...", "variety": "..."}`
+  Future<Map<String, String?>> identifyPlant({
+    required String apiKey,
+    required String imageBase64,
+  }) async {
+    const systemPrompt =
+        '植物識別の専門家です。送られた画像から植物名と品種を特定し、必ずJSON形式のみで返してください。'
+        '例: {"name": "モンステラ", "variety": "デリシオサ"}'
+        '品種が不明な場合は "variety" を null にしてください。';
+
+    final message = AiChatMessage(
+      isUser: true,
+      text: 'この植物の名前と品種を教えてください。',
+      imageBase64: imageBase64,
+    );
+
+    final raw = await sendMessage(
+      apiKey: apiKey,
+      systemPrompt: systemPrompt,
+      history: [message],
+    );
+
+    // JSONブロックを抽出してパース
+    try {
+      final jsonStr = _extractJson(raw);
+      final map = jsonDecode(jsonStr) as Map<String, dynamic>;
+      return {
+        'name': map['name'] as String?,
+        'variety': map['variety'] as String?,
+      };
+    } catch (_) {
+      throw AiServiceException('植物を識別できませんでした');
+    }
+  }
+
+  /// 植物の健康診断を行い、診断結果テキストを返す。
+  Future<String> diagnoseHealth({
+    required String apiKey,
+    required String plantName,
+    required String? variety,
+    required String? symptomText,
+    required int? wateringIntervalDays,
+    required DateTime? lastWateredAt,
+    required String? imageBase64,
+  }) async {
+    const systemPrompt =
+        'あなたは植物の健康アドバイザーです。ユーザーから植物の情報と症状を受け取り、'
+        '考えられる原因と対処法を丁寧に日本語で説明してください。';
+
+    final buffer = StringBuffer();
+    buffer.writeln('植物名: $plantName');
+    if (variety != null) buffer.writeln('品種: $variety');
+    if (wateringIntervalDays != null) {
+      buffer.writeln('水やり間隔: $wateringIntervalDays日ごと');
+    }
+    if (lastWateredAt != null) {
+      final days = DateTime.now().difference(lastWateredAt).inDays;
+      buffer.writeln('前回の水やりから: $days日経過');
+    }
+    if (symptomText != null && symptomText.isNotEmpty) {
+      buffer.writeln('症状: $symptomText');
+    }
+
+    final message = AiChatMessage(
+      isUser: true,
+      text: buffer.toString(),
+      imageBase64: imageBase64,
+    );
+
+    return sendMessage(
+      apiKey: apiKey,
+      systemPrompt: systemPrompt,
+      history: [message],
+    );
+  }
+
+  /// [AiChatMessage] のリストをClaude API用のメッセージ形式に変換する。
+  List<Map<String, dynamic>> _buildMessages(List<AiChatMessage> history) {
+    return history.map((msg) {
+      final List<Map<String, dynamic>> content = [];
+
+      // 画像がある場合は先にコンテンツブロックに追加
+      if (msg.imageBase64 != null) {
+        content.add({
+          'type': 'image',
+          'source': {
+            'type': 'base64',
+            'media_type': 'image/jpeg',
+            'data': msg.imageBase64,
+          },
+        });
+      }
+
+      content.add({'type': 'text', 'text': msg.text});
+
+      return {
+        'role': msg.isUser ? 'user' : 'assistant',
+        'content': content,
+      };
+    }).toList();
+  }
+
+  /// APIレスポンスをパースしてテキストを返す。
+  String _parseResponse(http.Response response) {
+    if (response.statusCode == 401) {
+      throw AiServiceException('APIキーが無効です。設定を確認してください。');
+    }
+    if (response.statusCode == 429) {
+      throw AiServiceException('リクエストが多すぎます。しばらく待ってから再試行してください。');
+    }
+    if (response.statusCode != 200) {
+      throw AiServiceException('APIエラー (${response.statusCode})');
+    }
+
+    try {
+      final json = jsonDecode(response.body) as Map<String, dynamic>;
+      final content = json['content'] as List<dynamic>;
+      final text = (content.first as Map<String, dynamic>)['text'] as String;
+      return text;
+    } catch (_) {
+      throw AiServiceException('レスポンスの解析に失敗しました');
+    }
+  }
+
+  /// レスポンス文字列からJSONブロックを抽出する。
+  String _extractJson(String text) {
+    // ```json ... ``` ブロックがあれば抽出
+    final jsonBlockRegex = RegExp(r'```(?:json)?\s*(\{.*?\})\s*```', dotAll: true);
+    final match = jsonBlockRegex.firstMatch(text);
+    if (match != null) return match.group(1)!;
+
+    // { ... } を直接探す
+    final start = text.indexOf('{');
+    final end = text.lastIndexOf('}');
+    if (start != -1 && end != -1 && end > start) {
+      return text.substring(start, end + 1);
+    }
+
+    return text;
+  }
+}
+
+/// AI サービスのエラー
+class AiServiceException implements Exception {
+  final String message;
+  const AiServiceException(this.message);
+
+  @override
+  String toString() => message;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -293,6 +293,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_generative_ai:
+    dependency: "direct main"
+    description:
+      name: google_generative_ai
+      sha256: "71f613d0247968992ad87a0eb21650a566869757442ba55a31a81be6746e0d1f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.7"
   hooks:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -302,7 +302,7 @@ packages:
     source: hosted
     version: "1.0.1"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,7 @@ dependencies:
 
   # バックグラウンドタスク（通知スケジューリング）
   workmanager: ^0.9.0
+  google_generative_ai: ^0.4.7
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -68,6 +68,9 @@ dependencies:
   uuid: ^4.3.3
   flutter_timezone: ^5.0.1
 
+  # HTTP通信（Claude API呼び出し用）
+  http: ^1.2.0
+
   # バックグラウンドタスク（通知スケジューリング）
   workmanager: ^0.9.0
 


### PR DESCRIPTION
## 変更内容

- **植物健康診断**: 植物詳細画面から症状テキスト・写真をClaudeに送信し、診断結果を表示
- **AI自動識別**: 植物追加時に写真からClaudeが植物名・品種を識別してフォームに自動入力
- **植物コーチ**: ケアログ・植物一覧をコンテキストにしたチャット形式AIアドバイザー（BottomNavに「AI」タブ追加）
- **APIキー管理**: 設定画面にClaude APIキーの入力・保存UIを追加

## 設計書

`.claude/designs/issue-67.md`

## テスト手順

### 正常系
- [ ] 設定画面でClaude APIキーを入力・保存し、アプリ再起動後も保持されること
- [ ] 植物詳細画面から健康診断を開き、症状テキストのみで診断結果が返ること
- [ ] 健康診断で画像を添付して送信すると、画像を考慮した診断結果が返ること
- [ ] 植物追加画面で画像選択後に「AIで識別」ボタンが表示され、識別結果がフォームに入力されること
- [ ] コーチ画面でメッセージを送ると返答が返り、会話を継続できること
- [ ] コーチ画面で画像を添付して送信できること

### 異常系
- [ ] APIキー未設定の状態でAI機能を使おうとするとSnackBarが表示されること
- [ ] 不正なAPIキーを設定した場合にエラーメッセージが表示されること
- [ ] 機内モードでAI機能を使おうとするとネットワークエラーが表示されること

### 境界値
- [ ] 植物が0件の状態でコーチ画面を開いてもクラッシュしないこと
- [ ] 長い診断結果テキストが正しくスクロール表示されること
- [ ] コーチの会話が20往復を超えてもクラッシュしないこと

## スクリーンショット

スクリーンショット: 要添付（AIタブ・健康診断画面・識別ダイアログ）

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)