### PR TITLE
feat: 植物画像をパスではなくDBにBase64で保存するよう変更 (#158)

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint;
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint, kIsWeb;
 import 'package:uuid/uuid.dart';
 import '../models/plant.dart';
 import '../models/log_entry.dart';
@@ -41,6 +43,9 @@ class PlantProvider with ChangeNotifier {
     try {
       _plants = await _db.getAllPlants();
 
+      // モバイル環境でファイルパスのままの画像をBase64に移行する（#158対応）
+      await _migrateImagePathsToBase64();
+
       // 次回水やり日キャッシュを更新
       for (var plant in _plants) {
         _nextWateringCache[plant.id] = await calculateNextWateringDate(plant.id);
@@ -56,6 +61,39 @@ class PlantProvider with ChangeNotifier {
       _isLoading = false;
       _isInitialized = true;
       notifyListeners();
+    }
+  }
+
+  /// モバイル環境で imagePath がファイルパスのままの植物を
+  /// Base64 data URL に変換してDBを更新する（一度だけ実行される移行処理）。
+  Future<void> _migrateImagePathsToBase64() async {
+    // Web環境ではファイルシステムにアクセスできないためスキップする
+    if (kIsWeb) return;
+
+    final needsMigration = _plants.where((p) {
+      final path = p.imagePath;
+      // ファイルパスが設定されており、data URL でない場合は移行対象
+      return path != null && !path.startsWith('data:');
+    }).toList();
+
+    if (needsMigration.isEmpty) return;
+
+    for (final plant in needsMigration) {
+      try {
+        final file = File(plant.imagePath!);
+        if (!file.existsSync()) continue;
+        final bytes = await file.readAsBytes();
+        final base64Str = base64Encode(bytes);
+        final dataUrl = 'data:image/jpeg;base64,$base64Str';
+        final migrated = plant.copyWith(imagePath: dataUrl);
+        await _db.updatePlant(migrated);
+        // インメモリのリストも更新する
+        final idx = _plants.indexWhere((p) => p.id == plant.id);
+        if (idx >= 0) _plants[idx] = migrated;
+        debugPrint('画像をBase64に移行しました: ${plant.name}');
+      } catch (e) {
+        debugPrint('画像移行に失敗しました（${plant.name}）: $e');
+      }
     }
   }
 

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:image_picker/image_picker.dart';
 import 'image_crop_screen.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import '../providers/plant_provider.dart';
 import '../models/plant.dart';
 import '../widgets/plant_image_widget.dart';
@@ -184,11 +185,23 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     try {
       final plantProvider = context.read<PlantProvider>();
 
-      // Web: トリミング済みバイト列を Base64 data URL に変換して imagePath として保存
+      // 画像を Base64 data URL に変換してDBへ保存する（モバイル・Web共通）。
+      // これによりスマホ変更後のバックアップ復元時も画像が失われない。
       String? effectiveImagePath = _imagePath;
-      if (kIsWeb && _imageBytes != null) {
+      if (_imageBytes != null) {
+        // Web・モバイル共通: トリミング済みバイト列を Base64 data URL に変換
         final base64 = base64Encode(_imageBytes!);
         effectiveImagePath = 'data:image/jpeg;base64,$base64';
+      } else if (!kIsWeb && _imagePath != null && !_imagePath!.startsWith('data:')) {
+        // モバイル: ファイルパスの場合はファイルを読み込んでBase64に変換する
+        try {
+          final bytes = await File(_imagePath!).readAsBytes();
+          final base64 = base64Encode(bytes);
+          effectiveImagePath = 'data:image/jpeg;base64,$base64';
+        } catch (e) {
+          // 変換失敗時はファイルパスのまま保持する（後方互換）
+          debugPrint('画像のBase64変換に失敗しました: $e');
+        }
       }
       
       if (widget.plant == null) {

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:intl/intl.dart';
@@ -302,17 +303,37 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
 
   /// 植物画像をWebとモバイルで出し分けて表示する
   Widget _buildFullImage() {
+    final path = widget.plant.imagePath!;
+
+    // Base64 data URL の場合はWeb・モバイル共通でメモリから表示する
+    if (path.startsWith('data:')) {
+      try {
+        final comma = path.indexOf(',');
+        if (comma >= 0) {
+          final bytes = base64Decode(path.substring(comma + 1));
+          return Image.memory(
+            bytes,
+            fit: BoxFit.cover,
+            errorBuilder: (context, error, stackTrace) =>
+                _buildBrokenImageIcon(context),
+          );
+        }
+      } catch (_) {
+        return _buildBrokenImageIcon(context);
+      }
+    }
+
     if (kIsWeb) {
       return Image.network(
-        widget.plant.imagePath!,
+        path,
         fit: BoxFit.cover,
         errorBuilder: (context, error, stackTrace) =>
             _buildBrokenImageIcon(context),
       );
     } else {
-      if (File(widget.plant.imagePath!).existsSync()) {
+      if (File(path).existsSync()) {
         return Image.file(
-          File(widget.plant.imagePath!),
+          File(path),
           fit: BoxFit.cover,
         );
       } else {

--- a/lib/widgets/plant_image_widget.dart
+++ b/lib/widgets/plant_image_widget.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:io';
@@ -33,10 +34,38 @@ class PlantImageWidget extends StatelessWidget {
 
     return ClipRRect(
       borderRadius: effectiveBorderRadius,
-      child: kIsWeb
-          ? _buildWebImage(context, effectiveBorderRadius)
-          : _buildMobileImage(context, effectiveBorderRadius),
+      // data URL はWeb・モバイル共通で Image.memory() で表示する
+      child: _isDataUrl(_effectiveImagePath!)
+          ? _buildDataUrlImage(context, effectiveBorderRadius)
+          : kIsWeb
+              ? _buildWebImage(context, effectiveBorderRadius)
+              : _buildMobileImage(context, effectiveBorderRadius),
     );
+  }
+
+  /// imagePath が Base64 data URL かどうか判定する。
+  bool _isDataUrl(String path) => path.startsWith('data:');
+
+  /// Base64 data URL を Image.memory() で表示する。
+  Widget _buildDataUrlImage(BuildContext context, BorderRadius borderRadius) {
+    try {
+      // "data:image/jpeg;base64,xxxxx" からbase64部分を抽出する
+      final comma = _effectiveImagePath!.indexOf(',');
+      if (comma < 0) return _buildPlaceholder(context, borderRadius);
+      final bytes = base64Decode(_effectiveImagePath!.substring(comma + 1));
+      return Image.memory(
+        bytes,
+        width: width,
+        height: height,
+        fit: BoxFit.cover,
+        cacheWidth: width.isFinite ? (width * 3).toInt() : null,
+        cacheHeight: height.isFinite ? (height * 3).toInt() : null,
+        errorBuilder: (context, error, stackTrace) =>
+            _buildPlaceholder(context, borderRadius),
+      );
+    } catch (_) {
+      return _buildPlaceholder(context, borderRadius);
+    }
   }
 
   Widget _buildWebImage(BuildContext context, BorderRadius borderRadius) {


### PR DESCRIPTION
## 概要

Issue #158 の対応。植物画像をファイルパスではなく Base64 data URL としてSQLiteに直接保存することで、スマホを変えてもバックアップから画像を復元できるようにする。

## 変更内容

### lib/widgets/plant_image_widget.dart
- \data:image/...\ で始まるパスを \Image.memory()\ で表示する \_buildDataUrlImage()\ メソッドを追加
- モバイルでも data URL を正しく表示できるよう \uild()\ の分岐を変更

### lib/screens/add_plant_screen.dart
- \_savePlant()\ でモバイル環境でもファイルを読み込んで Base64 data URL に変換してから保存するよう変更
- Web・モバイル共通で \data:image/jpeg;base64,...\ 形式で \imagePath\ に保存する

### lib/screens/plant_detail_screen.dart
- \_buildFullImage()\ で data URL を \Image.memory()\ で表示するよう対応

### lib/providers/plant_provider.dart
- \loadPlants()\ にモバイル向け移行処理 \_migrateImagePathsToBase64()\ を追加
- 既存植物で \imagePath\ がファイルパスのままの場合、起動時に自動でBase64に変換してDBを更新する
- 変換後は元のファイルは残したまま（削除しない）

## 注意点
- DBスキーマの変更なし（\imagePath TEXT\ 列に格納する内容が変わるだけ）
- 既存の ZIP バックアップは JSON にBase64が含まれるため、インポート時も画像が復元される
- 画像サイズが大きい場合はDB容量が増えるが、通常の植物写真（圧縮済み2MB以下）であれば実用上問題ない