### PR TITLE
fix: セルフレビューで発見したバグ修正とリファクタリング

### DIFF
--- a/lib/models/plant.dart
+++ b/lib/models/plant.dart
@@ -98,10 +98,10 @@ class Plant {
   /// nullable フィールドを明示的に null にしたい場合は sentinel パターンを使用する。
   Plant copyWith({
     String? name,
-    String? variety,
-    DateTime? purchaseDate,
-    String? purchaseLocation,
-    String? imagePath,
+    Object? variety = _sentinel,
+    Object? purchaseDate = _sentinel,
+    Object? purchaseLocation = _sentinel,
+    Object? imagePath = _sentinel,
     Object? wateringIntervalDays = _sentinel,
     Object? fertilizerIntervalDays = _sentinel,
     Object? fertilizerEveryNWaterings = _sentinel,
@@ -112,10 +112,10 @@ class Plant {
     return Plant(
       id: id,
       name: name ?? this.name,
-      variety: variety ?? this.variety,
-      purchaseDate: purchaseDate ?? this.purchaseDate,
-      purchaseLocation: purchaseLocation ?? this.purchaseLocation,
-      imagePath: imagePath ?? this.imagePath,
+      variety: variety == _sentinel ? this.variety : variety as String?,
+      purchaseDate: purchaseDate == _sentinel ? this.purchaseDate : purchaseDate as DateTime?,
+      purchaseLocation: purchaseLocation == _sentinel ? this.purchaseLocation : purchaseLocation as String?,
+      imagePath: imagePath == _sentinel ? this.imagePath : imagePath as String?,
       wateringIntervalDays: wateringIntervalDays == _sentinel
           ? this.wateringIntervalDays
           : wateringIntervalDays as int?,

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -360,16 +360,16 @@ class PlantProvider with ChangeNotifier {
     if (plant.fertilizerIntervalDays != null) {
       if (fertLogs.isNotEmpty) {
         // 起算日1: 最後に肥料を与えた日
-        fertLogs.sort((a, b) => b.date.compareTo(a.date));
-        return fertLogs.first.date
+        final sorted = [...fertLogs]..sort((a, b) => b.date.compareTo(a.date));
+        return sorted.first.date
             .add(Duration(days: plant.fertilizerIntervalDays!));
       }
       // 起算日2: 最後に水やりをした日
       final wateringLogs2 =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
       if (wateringLogs2.isNotEmpty) {
-        wateringLogs2.sort((a, b) => b.date.compareTo(a.date));
-        return wateringLogs2.first.date
+        final sorted2 = [...wateringLogs2]..sort((a, b) => b.date.compareTo(a.date));
+        return sorted2.first.date
             .add(Duration(days: plant.fertilizerIntervalDays!));
       }
       // 起算日3: 次回水やり予定日
@@ -385,19 +385,17 @@ class PlantProvider with ChangeNotifier {
         plant.wateringIntervalDays != null) {
       final n = plant.fertilizerEveryNWaterings!;
       // 最終肥料日以降の水やりログを数える
-      final lastFertDate =
-          fertLogs.isEmpty ? null : () {
-            fertLogs.sort((a, b) => b.date.compareTo(a.date));
-            return fertLogs.first.date;
-          }();
+      final DateTime? lastFertDate = fertLogs.isEmpty
+          ? null
+          : ([...fertLogs]..sort((a, b) => b.date.compareTo(a.date))).first.date;
 
       final wateringLogs =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
 
       // 起算日が未定（肥料ログなし）の場合は全水やりログを対象にする
       final wateringsAfter = lastFertDate == null
-          ? (wateringLogs..sort((a, b) => a.date.compareTo(b.date)))
-          : (wateringLogs
+          ? ([...wateringLogs]..sort((a, b) => a.date.compareTo(b.date)))
+          : ([...wateringLogs]
                 .where((l) => l.date.isAfter(lastFertDate))
                 .toList()
               ..sort((a, b) => a.date.compareTo(b.date)));
@@ -436,16 +434,16 @@ class PlantProvider with ChangeNotifier {
     if (plant.vitalizerIntervalDays != null) {
       if (vitLogs.isNotEmpty) {
         // 起算日1: 最後に活力剤を与えた日
-        vitLogs.sort((a, b) => b.date.compareTo(a.date));
-        return vitLogs.first.date
+        final sorted = [...vitLogs]..sort((a, b) => b.date.compareTo(a.date));
+        return sorted.first.date
             .add(Duration(days: plant.vitalizerIntervalDays!));
       }
       // 起算日2: 最後に水やりをした日
       final wateringLogs2 =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
       if (wateringLogs2.isNotEmpty) {
-        wateringLogs2.sort((a, b) => b.date.compareTo(a.date));
-        return wateringLogs2.first.date
+        final sorted2 = [...wateringLogs2]..sort((a, b) => b.date.compareTo(a.date));
+        return sorted2.first.date
             .add(Duration(days: plant.vitalizerIntervalDays!));
       }
       // 起算日3: 次回水やり予定日
@@ -460,19 +458,17 @@ class PlantProvider with ChangeNotifier {
     if (plant.vitalizerEveryNWaterings != null &&
         plant.wateringIntervalDays != null) {
       final n = plant.vitalizerEveryNWaterings!;
-      final lastVitDate =
-          vitLogs.isEmpty ? null : () {
-            vitLogs.sort((a, b) => b.date.compareTo(a.date));
-            return vitLogs.first.date;
-          }();
+      final DateTime? lastVitDate = vitLogs.isEmpty
+          ? null
+          : ([...vitLogs]..sort((a, b) => b.date.compareTo(a.date))).first.date;
 
       final wateringLogs =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
 
       // 起算日が未定（活力剤ログなし）の場合は全水やりログを対象にする
       final wateringsAfter = lastVitDate == null
-          ? (wateringLogs..sort((a, b) => a.date.compareTo(b.date)))
-          : (wateringLogs
+          ? ([...wateringLogs]..sort((a, b) => a.date.compareTo(b.date)))
+          : ([...wateringLogs]
                 .where((l) => l.date.isAfter(lastVitDate))
                 .toList()
               ..sort((a, b) => a.date.compareTo(b.date)));

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -223,13 +223,14 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
           vitalizerEveryNWaterings: _vitalizerEveryNWaterings,
         );
       } else {
-        // Update existing plant
+        // 既存植物の更新。nullable フィールドを明示的に null にできるよう
+        // sentinel パターンを用いて copyWith を呼び出す。
         final updatedPlant = widget.plant!.copyWith(
           name: _nameController.text.trim(),
-          variety: _varietyController.text.trim().isEmpty 
-              ? null 
+          variety: _varietyController.text.trim().isEmpty
+              ? null  // sentinel により null として保存される
               : _varietyController.text.trim(),
-          purchaseDate: _purchaseDate,
+          purchaseDate: _purchaseDate,  // null なら null として保存される
           purchaseLocation: _purchaseLocationController.text.trim().isEmpty
               ? null
               : _purchaseLocationController.text.trim(),

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -190,8 +190,12 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
           isActionNeeded(nextVitalizerDateCache[plant.id]);
     }).toSet();
 
+    final settings = context.read<SettingsProvider>();
     final allPlants = {...plantsWithRecords, ...plantsNeedingAction}.toList();
-    allPlants.sort((a, b) => _comparePlantsFor(a, b, logStatus, nextWateringDateCache));
+    allPlants.sort((a, b) => _comparePlantsFor(
+      a, b, logStatus, nextWateringDateCache,
+      settings.plantSortOrder, settings.customSortOrder,
+    ));
     return allPlants;
   }
 
@@ -200,6 +204,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     Plant b,
     DailyLogStatus logStatus,
     Map<String, DateTime?> nextWateringDateCache,
+    PlantSortOrder sortOrder,
+    List<String> customSortOrder,
   ) {
     final aCompleted = logStatus.isWatered(a.id);
     final bCompleted = logStatus.isWatered(b.id);
@@ -207,9 +213,6 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     // 完了済みは下に並ぶ
     if (aCompleted && !bCompleted) return 1;
     if (!aCompleted && bCompleted) return -1;
-
-    final settings = context.read<SettingsProvider>();
-    final sortOrder = settings.plantSortOrder;
     
     switch (sortOrder) {
       case PlantSortOrder.nameAsc:
@@ -231,16 +234,17 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
       case PlantSortOrder.createdAtDesc:
         return b.createdAt.compareTo(a.createdAt);
       case PlantSortOrder.custom:
-        final customOrder = settings.customSortOrder;
-        if (customOrder.isNotEmpty) {
+        if (customSortOrder.isNotEmpty) {
+          final customOrder = customSortOrder;
           final aIndex = customOrder.indexOf(a.id);
           final bIndex = customOrder.indexOf(b.id);
           if (aIndex == -1 && bIndex == -1) return 0;
           if (aIndex == -1) return 1;
           if (bIndex == -1) return -1;
           return aIndex.compareTo(bIndex);
+        } else {
+          // フォールバック：水やり予定日順
         }
-        // フォールバック：水やり予定日順
         final aNextDate = nextWateringDateCache[a.id];
         final bNextDate = nextWateringDateCache[b.id];
         if (aNextDate == null && bNextDate == null) return 0;
@@ -323,7 +327,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     LogType logType,
     DailyLogStatus logStatus,
   ) async {
-    // 水やりの場合、仙6記録があるか確認
+    // 水やりの場合、他の記録（肥料・活力剤）があるか確認
     final hasOtherLogs = (logType == LogType.watering) &&
         logStatus.hasOtherLogs(plantId, LogType.watering);
     

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -97,19 +97,37 @@ class ExportService {
     for (final plant in plants) {
       final map = plant.toMap();
       if (plant.imagePath != null) {
-        final imgFile = File(plant.imagePath!);
-        if (await imgFile.exists()) {
-          final ext = p.extension(plant.imagePath!).isNotEmpty
-              ? p.extension(plant.imagePath!)
-              : '.jpg';
-          final zipPath = 'images/plants/${plant.id}$ext';
-          archive.addFile(
-            ArchiveFile(zipPath, await imgFile.length(),
-                await imgFile.readAsBytes()),
-          );
-          map['imagePath'] = zipPath; // ZIP 内相対パスに変換
+        final path = plant.imagePath!;
+        if (path.startsWith('data:')) {
+          // #158対応: data URL（Base64）形式の場合はデコードしてZIPに格納する
+          try {
+            final comma = path.indexOf(',');
+            if (comma >= 0) {
+              final bytes = base64Decode(path.substring(comma + 1));
+              const zipPath = 'images/plants/';
+              final zipFilePath = '${zipPath}${plant.id}.jpg';
+              archive.addFile(ArchiveFile(zipFilePath, bytes.length, bytes));
+              map['imagePath'] = zipFilePath; // ZIP 内相対パスに変換
+            } else {
+              map['imagePath'] = null;
+            }
+          } catch (_) {
+            map['imagePath'] = null;
+          }
         } else {
-          map['imagePath'] = null;
+          // 旧形式: ファイルパスの場合はファイルから読み込む（後方互換）
+          final imgFile = File(path);
+          if (await imgFile.exists()) {
+            final ext = p.extension(path).isNotEmpty ? p.extension(path) : '.jpg';
+            final zipPath = 'images/plants/${plant.id}$ext';
+            archive.addFile(
+              ArchiveFile(zipPath, await imgFile.length(),
+                  await imgFile.readAsBytes()),
+            );
+            map['imagePath'] = zipPath; // ZIP 内相対パスに変換
+          } else {
+            map['imagePath'] = null;
+          }
         }
       }
       plantMaps.add(map);


### PR DESCRIPTION
## 概要

PR #160 マージ後、コードベースをセルフレビューして発見した複数の問題を一括修正する。

## 修正内容

### 致命的バグ修正
- `lib/services/export_service.dart`: `imagePath` が `data:image/...` 形式（PR #160 以降のデフォルト）の場合、Base64をデコードしてZIPに格納するよう修正
  - これまでZIPバックアップから植物画像が全て欠落していたバグを修正

### 重大バグ修正
- `lib/models/plant.dart`: `Plant.copyWith()` の `variety` / `purchaseDate` / `purchaseLocation` / `imagePath` をセンチネルパターンに変更
  - これまでこれらのフィールドを `null` にクリアできなかった

### 軽微バグ修正
- `lib/screens/today_watering_screen.dart`: `_deleteLog` のコメント誤字を修正（仙6記録 → 他の記録）
- 未使用になった `_recordLog` メソッドを削除

### リファクタリング
- `lib/screens/today_watering_screen.dart`: `_comparePlantsFor` から `context.read` 依存を排除し、引数で `sortOrder` / `customOrder` を受け取る純粋関数に変更
- `lib/providers/plant_provider.dart`: `calculateNextFertilizerDate` / `calculateNextVitalizerDate` の破壊的ソートを `[...list]..sort()` のコピー方式に統一