### PR TITLE
feat: 未予定の水やり画面でも複数選択できるように (#156)

### DIFF
--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -1146,31 +1146,33 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
       return;
     }
 
-    final selectedPlant = await showDialog<Plant>(
+    final selectedPlants = await showDialog<List<Plant>>(
       context: context,
       builder: (context) => _UnscheduledWateringDialog(
         plants: unscheduledPlants,
       ),
     );
 
-    if (selectedPlant != null && mounted) {
-      // Show log type selection dialog
+    if (selectedPlants != null && selectedPlants.isNotEmpty && mounted) {
+      // ログ種別選択ダイアログを表示（選択した全植物に同じ種別を適用）
       final selectedLogTypes = await showDialog<Set<LogType>>(
         context: context,
         builder: (context) => _LogTypeSelectionDialog(),
       );
 
       if (selectedLogTypes != null && selectedLogTypes.isNotEmpty && mounted) {
-        // Record selected log types for the plant
-        for (final logType in selectedLogTypes) {
-          await _recordLog(plantProvider, selectedPlant.id, logType);
+        // 選択した全植物に対してログを一括記録
+        for (final plant in selectedPlants) {
+          for (final logType in selectedLogTypes) {
+            await _recordLog(plantProvider, plant.id, logType);
+          }
         }
         await _refreshAfterLogChange();
-        
+
         final logTypeNames = selectedLogTypes
             .map((type) => _getLogTypeName(type))
             .join('・');
-        _showSuccessMessage('${selectedPlant.name}に$logTypeNamesを記録しました');
+        _showSuccessMessage('${selectedPlants.length}件の植物に$logTypeNamesを記録しました');
       }
     }
   }
@@ -1537,7 +1539,7 @@ class _LogTypeSelectionDialogState extends State<_LogTypeSelectionDialog> {
   }
 }
 
-/// Dialog for selecting unscheduled plants to water
+/// 予定外植物への記録ダイアログ（複数選択対応）
 class _UnscheduledWateringDialog extends StatefulWidget {
   final List<Plant> plants;
 
@@ -1549,6 +1551,8 @@ class _UnscheduledWateringDialog extends StatefulWidget {
 
 class _UnscheduledWateringDialogState extends State<_UnscheduledWateringDialog> {
   String _searchQuery = '';
+  // 検索フィルタをまたいで選択状態を保持する
+  final Set<String> _selectedIds = {};
 
   @override
   Widget build(BuildContext context) {
@@ -1587,11 +1591,22 @@ class _UnscheduledWateringDialogState extends State<_UnscheduledWateringDialog> 
                       itemCount: filteredPlants.length,
                       itemBuilder: (context, index) {
                         final plant = filteredPlants[index];
-                        return ListTile(
-                          leading: PlantImageWidget(plant: plant, width: 40, height: 40),
+                        final isSelected = _selectedIds.contains(plant.id);
+                        return CheckboxListTile(
+                          value: isSelected,
+                          onChanged: (value) {
+                            setState(() {
+                              if (value == true) {
+                                _selectedIds.add(plant.id);
+                              } else {
+                                _selectedIds.remove(plant.id);
+                              }
+                            });
+                          },
+                          secondary: PlantImageWidget(plant: plant, width: 40, height: 40),
                           title: Text(plant.name),
                           subtitle: plant.variety != null ? Text(plant.variety!) : null,
-                          onTap: () => Navigator.of(context).pop(plant),
+                          controlAffinity: ListTileControlAffinity.trailing,
                         );
                       },
                     ),
@@ -1603,6 +1618,20 @@ class _UnscheduledWateringDialogState extends State<_UnscheduledWateringDialog> 
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
           child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          // 0件選択中は disabled
+          onPressed: _selectedIds.isEmpty
+              ? null
+              : () {
+                  final selectedPlants = widget.plants
+                      .where((p) => _selectedIds.contains(p.id))
+                      .toList();
+                  Navigator.of(context).pop(selectedPlants);
+                },
+          child: Text(
+            _selectedIds.isEmpty ? '記録する' : '記録する（${_selectedIds.length}件）',
+          ),
         ),
       ],
     );

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -280,24 +280,6 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     _showSuccessMessage(_buildLogMessage(count));
   }
 
-  Future<void> _recordLog(
-    PlantProvider provider,
-    String plantId,
-    LogType logType,
-  ) async {
-    switch (logType) {
-      case LogType.watering:
-        await provider.recordWatering(plantId, _selectedDate, null);
-        break;
-      case LogType.fertilizer:
-        await provider.recordFertilizer(plantId, _selectedDate, null);
-        break;
-      case LogType.vitalizer:
-        await provider.recordVitalizer(plantId, _selectedDate, null);
-        break;
-    }
-  }
-
   String _buildLogMessage(int count) {
     final actionNames = _selectedBulkLogTypes
         .map((type) => _getLogTypeName(type))
@@ -1161,18 +1143,19 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
       );
 
       if (selectedLogTypes != null && selectedLogTypes.isNotEmpty && mounted) {
-        // 選択した全植物に対してログを一括記録
-        for (final plant in selectedPlants) {
-          for (final logType in selectedLogTypes) {
-            await _recordLog(plantProvider, plant.id, logType);
-          }
-        }
+        // 選択した全植物 × 全ログ種別を一括登録する
+        final plantIds = selectedPlants.map((p) => p.id).toList();
+        await plantProvider.bulkRecordLogs(plantIds, selectedLogTypes.toList(), _selectedDate);
         await _refreshAfterLogChange();
 
         final logTypeNames = selectedLogTypes
             .map((type) => _getLogTypeName(type))
             .join('・');
-        _showSuccessMessage('${selectedPlants.length}件の植物に$logTypeNamesを記録しました');
+        // 1件の場合は植物名、複数の場合はN件で表示する
+        final plantLabel = selectedPlants.length == 1
+            ? selectedPlants.first.name
+            : '${selectedPlants.length}件の植物';
+        _showSuccessMessage('$plantLabelに$logTypeNamesを記録しました');
       }
     }
   }


### PR DESCRIPTION
## 変更内容

- 「その他の植物」（水やり間隔未設定の植物）の水やり画面でも複数選択が可能になりました
- `bulkRecordLogs` メソッドに統一し、未使用の `_recordLog` を削除しました

## 変更ファイル

- `lib/screens/today_watering_screen.dart` — 複数選択UIの追加・`bulkRecordLogs` への統一

## テスト手順

1. 水やり間隔が未設定の植物を複数登録する
2. 「今日の水やり」画面の「その他の植物」セクションを開く
3. 複数の植物にチェックを入れて一括で水やり記録できることを確認する
4. 通常の水やり予定がある植物の複数選択も引き続き動作することを確認する

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)