### PR TITLE
feat: 設定画面から植物画像の手動移行を実行できるようにする (#158)

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -65,23 +65,39 @@ class PlantProvider with ChangeNotifier {
   }
 
   /// モバイル環境で imagePath がファイルパスのままの植物を
-  /// Base64 data URL に変換してDBを更新する（一度だけ実行される移行処理）。
+  /// Base64 data URL に変換してDBを更新する（loadPlants から自動実行）。
   Future<void> _migrateImagePathsToBase64() async {
-    // Web環境ではファイルシステムにアクセスできないためスキップする
-    if (kIsWeb) return;
+    await migrateImagePathsToBase64();
+  }
 
-    final needsMigration = _plants.where((p) {
+  /// ファイルパス形式の植物画像をBase64 data URLに変換してDBを更新する。
+  ///
+  /// 設定画面の手動実行ボタンからも呼び出せる。
+  /// 戻り値: [ImageMigrationResult]（変換成功・失敗・スキップ件数）
+  Future<ImageMigrationResult> migrateImagePathsToBase64() async {
+    if (kIsWeb) return const ImageMigrationResult(total: 0, success: 0, skipped: 0, failed: 0);
+
+    // 最新のDB状態を使う
+    final currentPlants = _plants.isEmpty ? await _db.getAllPlants() : _plants;
+
+    final needsMigration = currentPlants.where((p) {
       final path = p.imagePath;
       // ファイルパスが設定されており、data URL でない場合は移行対象
       return path != null && !path.startsWith('data:');
     }).toList();
 
-    if (needsMigration.isEmpty) return;
+    int success = 0;
+    int skipped = 0;
+    int failed = 0;
 
     for (final plant in needsMigration) {
       try {
         final file = File(plant.imagePath!);
-        if (!file.existsSync()) continue;
+        if (!file.existsSync()) {
+          // ファイルが存在しない場合はスキップ（消失済み）
+          skipped++;
+          continue;
+        }
         final bytes = await file.readAsBytes();
         final base64Str = base64Encode(bytes);
         final dataUrl = 'data:image/jpeg;base64,$base64Str';
@@ -91,10 +107,29 @@ class PlantProvider with ChangeNotifier {
         final idx = _plants.indexWhere((p) => p.id == plant.id);
         if (idx >= 0) _plants[idx] = migrated;
         debugPrint('画像をBase64に移行しました: ${plant.name}');
+        success++;
       } catch (e) {
         debugPrint('画像移行に失敗しました（${plant.name}）: $e');
+        failed++;
       }
     }
+
+    if (success > 0) notifyListeners();
+
+    return ImageMigrationResult(
+      total: needsMigration.length,
+      success: success,
+      skipped: skipped,
+      failed: failed,
+    );
+  }
+
+  /// ファイルパス形式の画像を持つ植物の件数を返す（移行前チェック用）。
+  int get pendingImageMigrationCount {
+    return _plants.where((p) {
+      final path = p.imagePath;
+      return path != null && !path.startsWith('data:');
+    }).length;
   }
 
   /// ソート設定に従ってソートした植物一覧を返す。
@@ -708,4 +743,26 @@ class PlantProvider with ChangeNotifier {
     }
     await loadPlants();
   }
+}
+
+/// 画像移行処理の結果
+class ImageMigrationResult {
+  /// 移行対象の総件数
+  final int total;
+
+  /// Base64変換に成功した件数
+  final int success;
+
+  /// ファイルが存在せずスキップした件数
+  final int skipped;
+
+  /// エラーにより失敗した件数
+  final int failed;
+
+  const ImageMigrationResult({
+    required this.total,
+    required this.success,
+    required this.skipped,
+    required this.failed,
+  });
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -17,6 +17,7 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _isExporting = false;
   bool _isImporting = false;
+  bool _isMigrating = false;
 
   @override
   Widget build(BuildContext context) {
@@ -159,6 +160,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: const Text('ZIP または JSON ファイルからデータを復元'),
             onTap: _isImporting ? null : () => _handleImport(context),
           ),
+          if (!kIsWeb) _buildImageMigrationTile(),
           const Divider(),
 
           // About
@@ -437,6 +439,111 @@ class _SettingsScreenState extends State<SettingsScreen> {
     } finally {
       if (mounted) setState(() => _isImporting = false);
     }
+  }
+
+  /// 画像ファイル→DB移行タイル（旧形式バックアップ復元後の手動移行用）
+  Widget _buildImageMigrationTile() {
+    return Consumer<PlantProvider>(
+      builder: (context, plantProvider, _) {
+        final pending = plantProvider.pendingImageMigrationCount;
+        return ListTile(
+          leading: _isMigrating
+              ? const SizedBox(
+                  width: 24,
+                  height: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Icon(
+                  Icons.storage,
+                  color: pending > 0
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+          title: const Text('植物画像をDBに移行'),
+          subtitle: Text(
+            pending > 0
+                ? '$pending件の画像ファイルをDBに保存できます'
+                : '移行対象なし（すべてDB保存済み）',
+          ),
+          trailing: pending > 0 ? const Icon(Icons.chevron_right) : null,
+          onTap: (_isMigrating || pending == 0)
+              ? null
+              : () => _handleImageMigration(context),
+        );
+      },
+    );
+  }
+
+  /// 画像ファイルをBase64 data URLに変換してDBに保存する
+  Future<void> _handleImageMigration(BuildContext context) async {
+    // 移行前に確認ダイアログを表示
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('植物画像をDBに移行'),
+        content: const Text(
+          'ファイルパス形式で保存されている植物画像を\n'
+          'データベース内に直接保存します。\n\n'
+          '移行後はバックアップZIPに画像が含まれるため、\n'
+          '機種変更後も画像を復元できるようになります。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('移行する'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    if (!context.mounted) return;
+
+    setState(() => _isMigrating = true);
+    try {
+      final provider = context.read<PlantProvider>();
+      final result = await provider.migrateImagePathsToBase64();
+      if (!context.mounted) return;
+      _showMigrationResultDialog(context, result);
+    } catch (e) {
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('移行に失敗しました: $e')),
+      );
+    } finally {
+      if (mounted) setState(() => _isMigrating = false);
+    }
+  }
+
+  /// 移行結果ダイアログを表示する
+  void _showMigrationResultDialog(
+    BuildContext context,
+    ImageMigrationResult result,
+  ) {
+    final lines = <String>[];
+    if (result.success > 0) lines.add('移行成功: ${result.success}件');
+    if (result.skipped > 0) {
+      lines.add('ファイル不在でスキップ: ${result.skipped}件');
+    }
+    if (result.failed > 0) lines.add('エラーで失敗: ${result.failed}件');
+    if (result.total == 0) lines.add('移行対象の画像はありませんでした');
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('移行完了'),
+        content: Text(lines.join('\n')),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   Widget _buildSectionHeader(BuildContext context, String title) {


### PR DESCRIPTION
## 概要

Issue #158 の対応（画像をDB内のBase64形式で保存）により、**既存のファイルパス形式の画像を持つユーザーへの影響**について調査した結果と、手動移行UIの追加。

### 影響分析

| ケース | 影響 |
|---|---|
| 同一デバイスでアップデート | **なし** — `loadPlants()` で自動移行済み |
| ZIPバックアップ→機種変更→インポート | **なし** — ZIPに画像が含まれ、インポート後に自動移行 |
| DBファイル直接コピーで機種変更 | **画像消失の可能性** — ファイルパスが残るが新端末にファイルがない |

### 変更内容

- `PlantProvider.migrateImagePathsToBase64()` をpublicメソッドとして公開（移行成功・スキップ・失敗件数を `ImageMigrationResult` で返す）
- `pendingImageMigrationCount` ゲッターを追加（移行前チェック用）
- `ImageMigrationResult` クラスを追加
- 設定画面の「データ管理」セクションに「植物画像をDBに移行」項目を追加
  - 移行対象件数をリアルタイム表示
  - 実行前に確認ダイアログを表示
  - 移行完了後に成功/スキップ/失敗件数を結果ダイアログで表示

## テスト手順

- [ ] 設定画面 > データ管理 に「植物画像をDBに移行」項目が表示されること
- [ ] ファイルパス形式の画像がない場合、「移行対象なし（すべてDB保存済み）」と表示されること
- [ ] タップ時に確認ダイアログが表示され、キャンセルで処理が中止されること
- [ ] 「移行する」を押すと移行が実行され、結果ダイアログが表示されること

設計書: `.claude/designs/` 参照なし（Issue #158 の補完対応）

Generated with [Claude Code](https://claude.com/claude-code)