### PR TITLE
refactor: Web プラットフォーム向け実装をすべて除去

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
-import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint, kIsWeb;
+import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint;
 import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 import '../models/plant.dart';
@@ -78,8 +78,6 @@ class PlantProvider with ChangeNotifier {
   /// 設定画面の手動実行ボタンからも呼び出せる。
   /// 戻り値: [ImageMigrationResult]（変換成功・失敗・スキップ件数）
   Future<ImageMigrationResult> migrateBase64ToFiles() async {
-    if (kIsWeb) return const ImageMigrationResult(total: 0, success: 0, skipped: 0, failed: 0);
-
     // ID のみ取得（imagePath列を読まないので CursorWindow 制限を受けない）
     final ids = await _db.getPlantIdsWithBase64Images();
     if (ids.isEmpty) return const ImageMigrationResult(total: 0, success: 0, skipped: 0, failed: 0);

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' show ChangeNotifier;
 import '../models/app_settings.dart';
 import '../services/settings_service.dart';
 import '../services/notification_service.dart';
@@ -27,7 +27,7 @@ class SettingsProvider with ChangeNotifier {
     notifyListeners();
     // アプリ起動時に通知設定が有効ならスマートスケジュールを実行する
     // （OSが再起動するとスケジュール済み通知が消えるため）
-    if (_settings.notificationEnabled && !kIsWeb) {
+    if (_settings.notificationEnabled) {
       await NotificationService.scheduleSmartWateringReminder(
         hour: _settings.notificationHour,
         minute: _settings.notificationMinute,
@@ -73,7 +73,7 @@ class SettingsProvider with ChangeNotifier {
     await _settingsService.saveSettings(_settings);
     notifyListeners();
     // 通知が有効なら再スケジュール
-    if (_settings.notificationEnabled && !kIsWeb) {
+    if (_settings.notificationEnabled) {
       await NotificationService.scheduleSmartWateringReminder(
         hour: hour,
         minute: minute,
@@ -87,24 +87,22 @@ class SettingsProvider with ChangeNotifier {
     _settings = _settings.copyWith(notificationEnabled: enabled);
     await _settingsService.saveSettings(_settings);
     notifyListeners();
-    if (!kIsWeb) {
-      if (enabled) {
-        // パーミッション確認してからスケジュール
-        final granted = await NotificationService().requestPermission();
-        if (granted) {
-          await NotificationService.scheduleSmartWateringReminder(
-            hour: _settings.notificationHour,
-            minute: _settings.notificationMinute,
-          );
-        } else {
-          // パーミッション拒否時は設定を元に戻す
-          _settings = _settings.copyWith(notificationEnabled: false);
-          await _settingsService.saveSettings(_settings);
-          notifyListeners();
-        }
+    if (enabled) {
+      // パーミッション確認してからスケジュール
+      final granted = await NotificationService().requestPermission();
+      if (granted) {
+        await NotificationService.scheduleSmartWateringReminder(
+          hour: _settings.notificationHour,
+          minute: _settings.notificationMinute,
+        );
       } else {
-        await NotificationService().cancelDailyWateringReminder();
+        // パーミッション拒否時は設定を元に戻す
+        _settings = _settings.copyWith(notificationEnabled: false);
+        await _settingsService.saveSettings(_settings);
+        notifyListeners();
       }
+    } else {
+      await NotificationService().cancelDailyWateringReminder();
     }
   }
 

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -7,7 +7,6 @@ import 'package:image_picker/image_picker.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 import 'image_crop_screen.dart';
-import 'package:flutter/foundation.dart' show debugPrint, kIsWeb;
 import '../providers/plant_provider.dart';
 import '../models/plant.dart';
 import '../widgets/plant_image_widget.dart';
@@ -36,7 +35,6 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
   int? _vitalizerIntervalDays;
   int? _vitalizerEveryNWaterings;
   String? _imagePath;
-  Uint8List? _imageBytes; // Web用: トリミング後のバイト列
   bool _isLoading = false;
 
   @override
@@ -66,7 +64,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
 
   Future<void> _showImageSourceOptions() async {
     // 既存画像がある場合は「再トリミング」選択肢も表示
-    final hasExistingImage = _imagePath != null || _imageBytes != null;
+    final hasExistingImage = _imagePath != null;
 
     // 選択肢の戻り値: ImageSource か 're-crop' か null（キャンセル）
     final choice = await showModalBottomSheet<Object>(
@@ -111,28 +109,17 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
       final pickedFile = await picker.pickImage(source: source, maxWidth: 2048, maxHeight: 2048);
       if (pickedFile == null) return;
 
-      // Web・モバイル共通でトリミング画面へ遷移
+      // トリミング画面へ遷移
       final cropResult = await Navigator.of(context).push<CropResult?>(
         MaterialPageRoute(
-          builder: (_) => kIsWeb
-              ? ImageCropScreen.web(xFile: pickedFile)
-              : ImageCropScreen.mobile(imagePath: pickedFile.path),
+          builder: (_) => ImageCropScreen(imagePath: pickedFile.path),
         ),
       );
 
       // ユーザーが「戻る」を押した場合はキャンセル扱い
       if (cropResult == null) return;
 
-      if (kIsWeb && cropResult.bytes != null) {
-        // Web: バイト列をメモリに保持。表示はUint8Listから行う
-        setState(() {
-          _imagePath = pickedFile.path; // XFileのpathはBlob URLとして使用可
-          _imageBytes = cropResult.bytes;
-        });
-      } else if (cropResult.filePath != null) {
-        // モバイル: 保存済みファイルパスを使用
-        setState(() => _imagePath = cropResult.filePath);
-      }
+      setState(() => _imagePath = cropResult.filePath);
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -144,29 +131,15 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
 
   /// 登録済み画像をそのままトリミング画面に渡して再トリミングする
   Future<void> _reCropExistingImage() async {
+    if (_imagePath == null) return;
     try {
-      CropResult? cropResult;
-      if (kIsWeb && _imageBytes != null) {
-        // Web: メモリ上のバイト列を XFile 経由で渡す
-        final tmpFile = XFile.fromData(_imageBytes!, mimeType: 'image/jpeg');
-        cropResult = await Navigator.of(context).push<CropResult?>(
-          MaterialPageRoute(
-            builder: (_) => ImageCropScreen.web(xFile: tmpFile),
-          ),
-        );
-        if (cropResult?.bytes != null) {
-          setState(() => _imageBytes = cropResult!.bytes);
-        }
-      } else if (_imagePath != null) {
-        // モバイル: 既存ファイルパスを渡す
-        cropResult = await Navigator.of(context).push<CropResult?>(
-          MaterialPageRoute(
-            builder: (_) => ImageCropScreen.mobile(imagePath: _imagePath!),
-          ),
-        );
-        if (cropResult?.filePath != null) {
-          setState(() => _imagePath = cropResult!.filePath);
-        }
+      final cropResult = await Navigator.of(context).push<CropResult?>(
+        MaterialPageRoute(
+          builder: (_) => ImageCropScreen(imagePath: _imagePath!),
+        ),
+      );
+      if (cropResult != null) {
+        setState(() => _imagePath = cropResult.filePath);
       }
     } catch (e) {
       if (mounted) {
@@ -198,20 +171,9 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     try {
       final plantProvider = context.read<PlantProvider>();
 
-      // 画像をドキュメントディレクトリにファイルとして保存し、パスをDBに記録する。
-      // Web環境のみ Base64 data URL で保存する（ファイルシステムが使えないため）。
+      // 旧 Base64 data URL 形式の画像をファイルに変換する（レガシーデータの移行）。
       String? effectiveImagePath = _imagePath;
-      if (_imageBytes != null) {
-        if (kIsWeb) {
-          // Web: ファイルシステムがないため Base64 data URL のまま保存
-          final base64 = base64Encode(_imageBytes!);
-          effectiveImagePath = 'data:image/jpeg;base64,$base64';
-        } else {
-          // モバイル: トリミング済みバイト列をファイルとして保存
-          effectiveImagePath = await _saveImageToFile(_imageBytes!);
-        }
-      } else if (!kIsWeb && _imagePath != null && _imagePath!.startsWith('data:')) {
-        // 既存の Base64 data URL 画像をファイルに変換（編集時の逆移行）
+      if (_imagePath != null && _imagePath!.startsWith('data:')) {
         try {
           final comma = _imagePath!.indexOf(',');
           if (comma >= 0) {
@@ -220,7 +182,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
           }
         } catch (e) {
           debugPrint('Base64→ファイル変換失敗: $e');
-          effectiveImagePath = null; // 変換失敗時は画像なしにフォールバック
+          effectiveImagePath = null;
         }
       }
       
@@ -330,23 +292,15 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
                       width: 2,
                     ),
                   ),
-                  child: (_imageBytes != null || _imagePath != null)
+                  child: _imagePath != null
                       ? ClipRRect(
                           borderRadius: BorderRadius.circular(10),
-                          child: _imageBytes != null
-                              // Web: トリミング済みバイト列から直接表示
-                              ? Image.memory(
-                                  _imageBytes!,
-                                  width: 150,
-                                  height: 150,
-                                  fit: BoxFit.cover,
-                                )
-                              : PlantImageWidget(
-                                  imagePath: _imagePath,
-                                  width: 150,
-                                  height: 150,
-                                  borderRadius: BorderRadius.zero,
-                                ),
+                          child: PlantImageWidget(
+                            imagePath: _imagePath,
+                            width: 150,
+                            height: 150,
+                            borderRadius: BorderRadius.zero,
+                          ),
                         )
                       : Column(
                           mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/screens/image_crop_screen.dart
+++ b/lib/screens/image_crop_screen.dart
@@ -1,32 +1,20 @@
 import 'dart:io';
 import 'dart:typed_data';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:crop_your_image/crop_your_image.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
 
-/// トリミング結果を表すシールドクラス。
-/// Web では [bytes] のみ、モバイルでは [filePath] のみ使用。
+/// トリミング結果のファイルパスを保持するクラス。
 class CropResult {
-  final String? filePath;
-  final Uint8List? bytes;
-  const CropResult.path(this.filePath) : bytes = null;
-  const CropResult.web(this.bytes) : filePath = null;
+  final String filePath;
+  const CropResult(this.filePath);
 }
 
 class ImageCropScreen extends StatefulWidget {
-  /// モバイル用: 画像のファイルパス
-  final String? imagePath;
-  /// Web用: ImagePickerで取得したXFile
-  final XFile? xFile;
+  final String imagePath;
 
-  const ImageCropScreen.mobile({super.key, required this.imagePath})
-      : xFile = null;
-
-  const ImageCropScreen.web({super.key, required this.xFile})
-      : imagePath = null;
+  const ImageCropScreen({super.key, required this.imagePath});
 
   @override
   State<ImageCropScreen> createState() => _ImageCropScreenState();
@@ -44,31 +32,18 @@ class _ImageCropScreenState extends State<ImageCropScreen> {
   }
 
   Future<void> _loadImage() async {
-    Uint8List bytes;
-    if (kIsWeb && widget.xFile != null) {
-      bytes = await widget.xFile!.readAsBytes();
-    } else if (widget.imagePath != null) {
-      bytes = await File(widget.imagePath!).readAsBytes();
-    } else {
-      return;
-    }
+    final bytes = await File(widget.imagePath).readAsBytes();
     if (mounted) setState(() => _imageBytes = bytes);
   }
 
   Future<void> _onCropped(Uint8List cropped) async {
     setState(() => _isCropping = true);
     try {
-      if (kIsWeb) {
-        // Web: バイト列をそのまま返す
-        if (mounted) Navigator.of(context).pop(CropResult.web(cropped));
-      } else {
-        // モバイル: アプリドキュメントディレクトリに保存してパスを返す
-        final dir = await getApplicationDocumentsDirectory();
-        final fileName = 'crop_${path.basename(widget.imagePath!)}';
-        final outFile = File('${dir.path}/$fileName');
-        await outFile.writeAsBytes(cropped);
-        if (mounted) Navigator.of(context).pop(CropResult.path(outFile.path));
-      }
+      final dir = await getApplicationDocumentsDirectory();
+      final fileName = 'crop_${path.basename(widget.imagePath)}';
+      final outFile = File('${dir.path}/$fileName');
+      await outFile.writeAsBytes(cropped);
+      if (mounted) Navigator.of(context).pop(CropResult(outFile.path));
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/note.dart';
@@ -56,25 +55,23 @@ class _FullScreenImageViewerState extends State<_FullScreenImageViewer> {
         itemBuilder: (context, index) {
           final p = widget.imagePaths[index];
           final heroTag = 'note_image_${widget.noteId}_$index';
-          final img = kIsWeb
-              ? Image.network(p, fit: BoxFit.contain)
-              : Image.file(
-                  File(p),
-                  fit: BoxFit.contain,
-                  errorBuilder: (context, error, stackTrace) =>
-                      const Center(
-                        child: Column(
-                          mainAxisSize: MainAxisSize.min,
-                          children: [
-                            Icon(Icons.broken_image_outlined,
-                                color: Colors.white54, size: 64),
-                            SizedBox(height: 8),
-                            Text('画像を読み込めませんでした',
-                                style: TextStyle(color: Colors.white54)),
-                          ],
-                        ),
-                      ),
-                );
+          final img = Image.file(
+            File(p),
+            fit: BoxFit.contain,
+            errorBuilder: (context, error, stackTrace) =>
+                const Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.broken_image_outlined,
+                          color: Colors.white54, size: 64),
+                      SizedBox(height: 8),
+                      Text('画像を読み込めませんでした',
+                          style: TextStyle(color: Colors.white54)),
+                    ],
+                  ),
+                ),
+          );
           return InteractiveViewer(
             minScale: 0.5,
             maxScale: 5.0,
@@ -178,29 +175,26 @@ class NoteDetailScreen extends StatelessWidget {
                   final index = entry.key;
                   final p = entry.value;
                   final heroTag = 'note_image_${note.id}_$index';
-                  final img = kIsWeb
-                      ? Image.network(p,
-                          width: 120, height: 120, fit: BoxFit.cover)
-                      : Image.file(
-                          File(p),
+                  final img = Image.file(
+                    File(p),
+                    width: 120,
+                    height: 120,
+                    fit: BoxFit.cover,
+                    errorBuilder: (context, error, stackTrace) =>
+                        Container(
                           width: 120,
                           height: 120,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) =>
-                              Container(
-                                width: 120,
-                                height: 120,
-                                decoration: BoxDecoration(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .surfaceContainerHighest,
-                                  borderRadius: BorderRadius.circular(8),
-                                ),
-                                child: const Icon(
-                                    Icons.broken_image_outlined,
-                                    size: 40),
-                              ),
-                        );
+                          decoration: BoxDecoration(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: const Icon(
+                              Icons.broken_image_outlined,
+                              size: 40),
+                        ),
+                  );
                   return GestureDetector(
                     onTap: () => Navigator.of(context).push(
                       MaterialPageRoute(

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -11,7 +11,6 @@ import '../utils/date_utils.dart';
 import 'add_plant_screen.dart';
 import 'add_edit_note_screen.dart';
 import 'note_detail_screen.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 
 /// SliverPersistentHeaderDelegate: TabBarを固定表示するためのデリゲート
 class _StickyTabBarDelegate extends SliverPersistentHeaderDelegate {
@@ -301,11 +300,11 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     }
   }
 
-  /// 植物画像をWebとモバイルで出し分けて表示する
+  /// 植物画像を表示する
   Widget _buildFullImage() {
     final path = widget.plant.imagePath!;
 
-    // Base64 data URL の場合はWeb・モバイル共通でメモリから表示する
+    // Base64 data URL の場合はメモリから表示する（レガシーデータ互換）
     if (path.startsWith('data:')) {
       try {
         final comma = path.indexOf(',');
@@ -323,22 +322,13 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
       }
     }
 
-    if (kIsWeb) {
-      return Image.network(
-        path,
+    if (File(path).existsSync()) {
+      return Image.file(
+        File(path),
         fit: BoxFit.cover,
-        errorBuilder: (context, error, stackTrace) =>
-            _buildBrokenImageIcon(context),
       );
     } else {
-      if (File(path).existsSync()) {
-        return Image.file(
-          File(path),
-          fit: BoxFit.cover,
-        );
-      } else {
-        return _buildBrokenImageIcon(context);
-      }
+      return _buildBrokenImageIcon(context);
     }
   }
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:provider/provider.dart';
 import '../providers/settings_provider.dart';
 import '../providers/plant_provider.dart';
@@ -160,7 +159,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: const Text('ZIP または JSON ファイルからデータを復元'),
             onTap: _isImporting ? null : () => _handleImport(context),
           ),
-          if (!kIsWeb) _buildImageMigrationTile(),
+          _buildImageMigrationTile(),
           const Divider(),
 
           // About
@@ -332,44 +331,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
   /// エクスポート処理
   Future<void> _handleExport(BuildContext context) async {
-    if (kIsWeb) {
-      // Web 環境: JSON テキストをダイアログで表示（コピー可）
-      setState(() => _isExporting = true);
-      try {
-        final json = await ExportService().exportToJson();
-        if (!mounted) return;
-        await showDialog<void>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: const Text('エクスポートJSON'),
-            content: SizedBox(
-              width: double.maxFinite,
-              height: 300,
-              child: SingleChildScrollView(
-                child: SelectableText(json,
-                    style: const TextStyle(fontFamily: 'monospace', fontSize: 12)),
-              ),
-            ),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(),
-                child: const Text('閉じる'),
-              ),
-            ],
-          ),
-        );
-      } catch (e) {
-        if (!mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エクスポートに失敗しました: $e')),
-        );
-      } finally {
-        if (mounted) setState(() => _isExporting = false);
-      }
-      return;
-    }
-
-    // モバイル環境: ファイルに保存
     setState(() => _isExporting = true);
     try {
       final path = await ExportService().exportToFile();

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:archive/archive_io.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -14,15 +13,13 @@ import 'database_service.dart';
 
 /// データのエクスポート / インポートを担うサービス
 ///
-/// モバイル: 画像を含む ZIP アーカイブとして保存・復元する。
+/// 画像を含む ZIP アーカイブとして保存・復元する。
 /// ZIP 構成:
-///   waterme_backup_XXXXXX.zip
+///   botanote_backup_XXXXXX.zip
 ///   ├── data.json          # Plants / Logs / Notes (imagePath は ZIP 内相対パス)
 ///   └── images/
 ///       ├── plants/`plant_id`.jpg
 ///       └── notes/`note_id`_`index`.jpg
-///
-/// Web: テキスト JSON のみ（画像なし）。
 class ExportService {
   static final ExportService _instance = ExportService._internal();
   factory ExportService() => _instance;
@@ -32,35 +29,10 @@ class ExportService {
 
   // ── エクスポート ──────────────────────────────────────────
 
-  /// 全データを JSON 文字列に変換して返す（Web 用・画像パスは絶対パスのまま）
-  Future<String> exportToJson() async {
-    final plants = await _db.getAllPlants();
-    final allLogs = <LogEntry>[];
-    for (final plant in plants) {
-      final logs = await _db.getLogsByPlant(plant.id);
-      allLogs.addAll(logs);
-    }
-    final notes = await _db.getAllNotes();
-
-    final data = {
-      'version': 1,
-      'exportedAt': DateTime.now().toIso8601String(),
-      'plants': plants.map((pl) => pl.toMap()).toList(),
-      'logs': allLogs.map((l) => l.toMap()).toList(),
-      'notes': notes.map((n) => n.toMap()).toList(),
-    };
-
-    return const JsonEncoder.withIndent('  ').convert(data);
-  }
-
-  /// ZIP を一時ディレクトリに生成し、OS のシェアシートで共有する（モバイル専用）
+  /// ZIP を一時ディレクトリに生成し、OS のシェアシートで共有する。
   ///
-  /// キャンセル時は null を返す。Web 環境では [UnsupportedError] をスローする。
+  /// キャンセル時は null を返す。
   Future<String?> exportToFile() async {
-    if (kIsWeb) {
-      throw UnsupportedError('Web 環境ではファイル保存に対応していません。');
-    }
-
     final ts = DateTime.now().millisecondsSinceEpoch;
     final fileName = 'botanote_backup_$ts.zip';
 
@@ -183,24 +155,12 @@ class ExportService {
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['zip', 'json'],
-      withData: kIsWeb,
+      withData: false,
     );
 
     if (result == null || result.files.isEmpty) return null;
 
     final file = result.files.first;
-
-    if (kIsWeb) {
-      final bytes = file.bytes;
-      if (bytes == null) return null;
-      if (_isZipBytes(bytes)) {
-        // Web では一時パスがないため ZIP 展開はサポート外
-        throw const FormatException('WebブラウザではZIPインポートはサポートされていません');
-      }
-      // BOM付きUTF-8も考慮してデコード
-      return _importFromJson(_decodeUtf8(bytes));
-    }
-
     final path = file.path;
     if (path == null) return null;
 

--- a/lib/widgets/plant_image_widget.dart
+++ b/lib/widgets/plant_image_widget.dart
@@ -1,11 +1,10 @@
 import 'dart:convert';
-import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
 import 'dart:io';
+import 'package:flutter/material.dart';
 import '../models/plant.dart';
 
-/// Reusable widget for displaying plant images
-/// Can accept either a Plant object or a direct imagePath string
+/// 植物画像を表示する共通ウィジェット。
+/// [plant] または [imagePath] のどちらか一方を指定する。
 class PlantImageWidget extends StatelessWidget {
   final Plant? plant;
   final String? imagePath;
@@ -34,22 +33,15 @@ class PlantImageWidget extends StatelessWidget {
 
     return ClipRRect(
       borderRadius: effectiveBorderRadius,
-      // data URL はWeb・モバイル共通で Image.memory() で表示する
-      child: _isDataUrl(_effectiveImagePath!)
+      child: _effectiveImagePath!.startsWith('data:')
           ? _buildDataUrlImage(context, effectiveBorderRadius)
-          : kIsWeb
-              ? _buildWebImage(context, effectiveBorderRadius)
-              : _buildMobileImage(context, effectiveBorderRadius),
+          : _buildFileImage(context, effectiveBorderRadius),
     );
   }
-
-  /// imagePath が Base64 data URL かどうか判定する。
-  bool _isDataUrl(String path) => path.startsWith('data:');
 
   /// Base64 data URL を Image.memory() で表示する。
   Widget _buildDataUrlImage(BuildContext context, BorderRadius borderRadius) {
     try {
-      // "data:image/jpeg;base64,xxxxx" からbase64部分を抽出する
       final comma = _effectiveImagePath!.indexOf(',');
       if (comma < 0) return _buildPlaceholder(context, borderRadius);
       final bytes = base64Decode(_effectiveImagePath!.substring(comma + 1));
@@ -68,42 +60,26 @@ class PlantImageWidget extends StatelessWidget {
     }
   }
 
-  Widget _buildWebImage(BuildContext context, BorderRadius borderRadius) {
-    return Image.network(
-      _effectiveImagePath!,
-      width: width,
-      height: height,
-      fit: BoxFit.cover,
-      errorBuilder: (context, error, stackTrace) =>
-          _buildPlaceholder(context, borderRadius),
-    );
-  }
-
-  Widget _buildMobileImage(BuildContext context, BorderRadius borderRadius) {
+  /// ファイルパスから画像を表示する。
+  Widget _buildFileImage(BuildContext context, BorderRadius borderRadius) {
     final file = File(_effectiveImagePath!);
     if (!file.existsSync()) {
       return _buildPlaceholder(context, borderRadius);
     }
 
-    // cacheWidth/cacheHeightで縮小デコードし、frameBuilderでフェードイン表示する。
-    // プレースホルダーを先に出してテキスト表示をブロックしないようにする。
     return Image.file(
       file,
       width: width,
       height: height,
       fit: BoxFit.cover,
-      // リスト表示サイズに合わせて縮小デコードし、メモリ・描画負荷を削減。
-      // double.infinity など有限値以外の場合はキャッシュサイズを省略する。
       cacheWidth: width.isFinite ? (width * 3).toInt() : null,
       cacheHeight: height.isFinite ? (height * 3).toInt() : null,
       errorBuilder: (context, error, stackTrace) =>
           _buildPlaceholder(context, borderRadius),
       frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
         if (wasSynchronouslyLoaded || frame != null) {
-          // キャッシュ済みまたは読み込み完了: そのまま表示
           return child;
         }
-        // 読み込み中: プレースホルダーを表示
         return _buildPlaceholder(context, borderRadius);
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -140,9 +140,3 @@ flutter_launcher_icons:
   # iOS
   ios: true
   image_path_ios: "assets/icons/icon.png"
-  # Web
-  web:
-    generate: true
-    image_path: "assets/icons/icon.png"
-    background_color: "#FFFFFF"
-    theme_color: "#4CAF50"


### PR DESCRIPTION
## Summary

- `kIsWeb` を使った Web/モバイル分岐コードを全削除し、Android/iOS 専用構成に整理
- Web 専用コンストラクタ・メソッド・ダイアログ・設定をすべて除去

## 変更内容（10ファイル）

| ファイル | 変更内容 |
|---|---|
| `image_crop_screen.dart` | `ImageCropScreen.web()` / `CropResult.web()` を削除、モバイル専用に簡略化 |
| `plant_image_widget.dart` | `_buildWebImage()` 削除、常に `Image.file()` を使用 |
| `settings_provider.dart` | `!kIsWeb` 条件3箇所を削除（通知スケジュールは常時実行） |
| `plant_provider.dart` | `migrateBase64ToFiles()` の `kIsWeb` 早期リターンを削除 |
| `export_service.dart` | `exportToJson()`（Web専用）・Web インポート分岐・Web ガードを削除 |
| `settings_screen.dart` | Web エクスポートダイアログを削除 |
| `add_plant_screen.dart` | `_imageBytes` フィールド削除、`ImageCropScreen.web()` 呼び出しを統一 |
| `note_detail_screen.dart` | `Image.network()` → `Image.file()` に統一 |
| `plant_detail_screen.dart` | `kIsWeb` 分岐削除、常にファイル表示 |
| `pubspec.yaml` | `flutter_launcher_icons` の `web:` セクションを削除 |

## Test plan

- [ ] `flutter analyze` でエラーがないことを確認
- [ ] 植物登録画面で画像選択→トリミング→保存が正常に動作すること
- [ ] 植物詳細画面で画像が正常に表示されること
- [ ] ノート詳細画面で画像が正常に表示されること
- [ ] 設定画面でデータエクスポート（ZIP）が正常に動作すること
- [ ] 設定画面でデータインポートが正常に動作すること
- [ ] 通知の有効/無効切り替えが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)