### PR TITLE
refactor: センサー画面をデバイス単位の環境ダッシュボードに再設計

### DIFF
--- a/lib/providers/sensor_log_provider.dart
+++ b/lib/providers/sensor_log_provider.dart
@@ -19,6 +19,17 @@ class SensorLogProvider with ChangeNotifier {
   List<SensorLog> get logs => _logs;
   bool get isLoading => _isLoading;
 
+  /// deviceId をキーに、そのデバイスの最新ログ1件を返すマップ。
+  ///
+  /// _logs は recordedAt DESC 順なので先頭の1件が最新になる。
+  Map<String, SensorLog> get latestLogPerDevice {
+    final result = <String, SensorLog>{};
+    for (final log in _logs) {
+      result.putIfAbsent(log.deviceId, () => log);
+    }
+    return result;
+  }
+
   /// DB からすべてのセンサーログを読み込む。
   Future<void> loadLogs() async {
     _isLoading = true;

--- a/lib/screens/sensor_log_screen.dart
+++ b/lib/screens/sensor_log_screen.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import '../models/sensor_device_mapping.dart';
 import '../models/sensor_log.dart';
-import '../providers/plant_provider.dart';
 import '../providers/sensor_log_provider.dart';
 import '../providers/settings_provider.dart';
-import '../services/iot_service.dart';
 import 'iot_settings_screen.dart';
 
-/// センサーデータの取得・閲覧画面
+/// センサー環境ダッシュボード画面
+///
+/// デバイス単位で最新の温湿度データを一覧表示する。
+/// ログの時系列履歴は植物詳細画面の「環境」タブで確認できる。
 class SensorLogScreen extends StatefulWidget {
   const SensorLogScreen({super.key});
 
@@ -27,19 +29,8 @@ class _SensorLogScreenState extends State<SensorLogScreen> {
     });
   }
 
-  String _sourceName(SensorSource source) {
-    switch (source) {
-      case SensorSource.natureRemo:
-        return 'Nature Remo';
-      case SensorSource.switchBot:
-        return 'SwitchBot';
-      case SensorSource.manual:
-        return '手動';
-    }
-  }
-
-  /// マッピングを使って一括取得・保存する（メインフロー）
-  Future<void> _fetchWithMappings() async {
+  /// マッピングを使って全デバイスのデータを一括取得・保存する
+  Future<void> _fetchNow() async {
     final settingsProvider = context.read<SettingsProvider>();
     final settings = settingsProvider.settings;
     setState(() => _isFetching = true);
@@ -52,9 +43,7 @@ class _SensorLogScreenState extends State<SensorLogScreen> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            count > 0
-                ? '$count件のセンサーログを記録しました'
-                : 'データを取得しましたが記録できたログはありませんでした',
+            count > 0 ? '$count件のセンサーログを記録しました' : 'データを取得しましたが記録できたログはありませんでした',
           ),
         ),
       );
@@ -68,220 +57,14 @@ class _SensorLogScreenState extends State<SensorLogScreen> {
     }
   }
 
-  /// マッピング未設定時の手動取得フロー（フォールバック）
-  Future<void> _startManualFetchFlow(SensorSource source) async {
-    final settings = context.read<SettingsProvider>().settings;
-    setState(() => _isFetching = true);
-
-    try {
-      final List<SensorData> data;
-      if (source == SensorSource.natureRemo) {
-        data = await context
-            .read<SensorLogProvider>()
-            .fetchNatureRemoData(settings.natureRemoToken);
-      } else {
-        data = await context.read<SensorLogProvider>().fetchSwitchBotData(
-              settings.switchBotToken,
-              settings.switchBotSecret,
-            );
-      }
-
-      if (!mounted) return;
-
-      if (data.isEmpty) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('センサーデバイスが見つかりませんでした')),
-        );
-        return;
-      }
-
-      // 複数デバイスがある場合はユーザーに選択させる
-      final SensorData selected;
-      if (data.length == 1) {
-        selected = data.first;
-      } else {
-        final picked = await _showDevicePickerDialog(data);
-        if (!mounted || picked == null) return;
-        selected = picked;
-      }
-
-      await _showRecordDialog(selected, source);
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('取得に失敗しました: $e')),
-      );
-    } finally {
-      if (mounted) setState(() => _isFetching = false);
-    }
-  }
-
-  Future<SensorData?> _showDevicePickerDialog(List<SensorData> devices) {
-    return showDialog<SensorData>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('デバイスを選択'),
-        content: SizedBox(
-          width: double.maxFinite,
-          child: ListView.builder(
-            shrinkWrap: true,
-            itemCount: devices.length,
-            itemBuilder: (ctx, i) {
-              final d = devices[i];
-              return ListTile(
-                leading: const Icon(Icons.sensors),
-                title: Text(d.deviceName),
-                subtitle: Text(_formatSensorValues(d.temperature, d.humidity)),
-                onTap: () => Navigator.of(ctx).pop(d),
-              );
-            },
-          ),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(),
-            child: const Text('キャンセル'),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _showRecordDialog(SensorData data, SensorSource source) async {
-    final plants = context.read<PlantProvider>().plants;
-    String? selectedPlantId;
-
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => StatefulBuilder(
-        builder: (ctx, setDialogState) => AlertDialog(
-          title: Text(data.deviceName),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              _buildSensorValueRow(
-                Icons.thermostat,
-                '温度',
-                data.temperature != null
-                    ? '${data.temperature!.toStringAsFixed(1)} ℃'
-                    : '--',
-              ),
-              const SizedBox(height: 8),
-              _buildSensorValueRow(
-                Icons.water_drop,
-                '湿度',
-                data.humidity != null
-                    ? '${data.humidity!.toStringAsFixed(1)} %'
-                    : '--',
-              ),
-              const SizedBox(height: 16),
-              DropdownButtonFormField<String?>(
-                initialValue: selectedPlantId,
-                decoration: const InputDecoration(
-                  labelText: '植物に紐付け（任意）',
-                  border: OutlineInputBorder(),
-                ),
-                items: [
-                  const DropdownMenuItem<String?>(
-                    value: null,
-                    child: Text('紐付けなし'),
-                  ),
-                  ...plants.map((p) => DropdownMenuItem<String?>(
-                        value: p.id,
-                        child: Text(p.name),
-                      )),
-                ],
-                onChanged: (v) => setDialogState(() => selectedPlantId = v),
-              ),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(ctx).pop(false),
-              child: const Text('キャンセル'),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.of(ctx).pop(true),
-              child: const Text('記録する'),
-            ),
-          ],
-        ),
-      ),
-    );
-
-    if (confirmed != true || !mounted) return;
-
-    try {
-      await context.read<SensorLogProvider>().saveSensorLog(
-            data: data,
-            source: source,
-            plantId: selectedPlantId,
-          );
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('センサーログを記録しました')),
-      );
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('記録に失敗しました: $e')),
-      );
-    }
-  }
-
-  Widget _buildSensorValueRow(IconData icon, String label, String value) {
-    return Row(
-      children: [
-        Icon(icon, size: 20, color: Theme.of(context).colorScheme.primary),
-        const SizedBox(width: 8),
-        Text('$label: ', style: Theme.of(context).textTheme.bodyMedium),
-        Text(
-          value,
-          style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                fontWeight: FontWeight.bold,
-              ),
-        ),
-      ],
-    );
-  }
-
-  String _formatSensorValues(double? temperature, double? humidity) {
-    final parts = <String>[];
-    if (temperature != null) parts.add('${temperature.toStringAsFixed(1)}℃');
-    if (humidity != null) parts.add('${humidity.toStringAsFixed(0)}%');
-    return parts.isEmpty ? '温湿度データなし' : parts.join(' / ');
-  }
-
-  Future<void> _deleteSensorLog(SensorLog log) async {
-    final confirm = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('ログを削除'),
-        content: const Text('このセンサーログを削除しますか？'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('キャンセル'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-            ),
-            child: const Text('削除'),
-          ),
-        ],
-      ),
-    );
-    if (confirm != true || !mounted) return;
-    try {
-      await context.read<SensorLogProvider>().deleteSensorLog(log.id);
-    } catch (e) {
-      if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('削除に失敗しました: $e')),
-      );
+  String _sourceName(SensorSource source) {
+    switch (source) {
+      case SensorSource.natureRemo:
+        return 'Nature Remo';
+      case SensorSource.switchBot:
+        return 'SwitchBot';
+      case SensorSource.manual:
+        return '手動';
     }
   }
 
@@ -295,110 +78,113 @@ class _SensorLogScreenState extends State<SensorLogScreen> {
             icon: const Icon(Icons.settings),
             tooltip: 'IoT設定',
             onPressed: () => Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (_) => const IotSettingsScreen(),
-              ),
+              MaterialPageRoute(builder: (_) => const IotSettingsScreen()),
             ),
           ),
         ],
       ),
-      body: Column(
-        children: [
-          _buildFetchArea(),
-          const Divider(height: 1),
-          Expanded(child: _buildLogList()),
-        ],
+      body: Consumer<SensorLogProvider>(
+        builder: (context, sensorProvider, _) {
+          return _buildBody(sensorProvider);
+        },
       ),
     );
   }
 
-  Widget _buildFetchArea() {
+  Widget _buildBody(SensorLogProvider sensorProvider) {
     final settings = context.watch<SettingsProvider>().settings;
-    final hasNatureRemo = settings.natureRemoToken.isNotEmpty;
-    final hasSwitchBot = settings.switchBotToken.isNotEmpty &&
-        settings.switchBotSecret.isNotEmpty;
-    final hasMappings = settings.sensorDeviceMappings.isNotEmpty;
+    final mappings = settings.sensorDeviceMappings;
+    final hasToken = settings.natureRemoToken.isNotEmpty ||
+        (settings.switchBotToken.isNotEmpty &&
+            settings.switchBotSecret.isNotEmpty);
 
     // APIトークン未設定
-    if (!hasNatureRemo && !hasSwitchBot) {
-      return Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            Icon(
-              Icons.sensors_off,
-              size: 48,
-              color: Theme.of(context)
-                  .colorScheme
-                  .onSurface
-                  .withValues(alpha: 0.3),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'センサーが設定されていません',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 8),
-            OutlinedButton.icon(
-              onPressed: () => Navigator.of(context).push(
-                MaterialPageRoute(builder: (_) => const IotSettingsScreen()),
-              ),
-              icon: const Icon(Icons.settings),
-              label: const Text('IoT設定を開く'),
-            ),
-          ],
-        ),
+    if (!hasToken) {
+      return _buildEmptyState(
+        icon: Icons.sensors_off,
+        message: 'センサーが設定されていません',
+        action: _buildIotSettingsButton(),
       );
     }
 
-    // マッピングが設定済み → 1タップ取得ボタン
-    if (hasMappings) {
-      return _buildMappingFetchArea(settings.sensorDeviceMappings.length);
+    // マッピング未設定
+    if (mappings.isEmpty) {
+      return _buildEmptyState(
+        icon: Icons.device_hub,
+        message: 'デバイスと植物が紐づけされていません',
+        subMessage: 'IoT設定でデバイスを取得し、植物を割り当ててください。',
+        action: _buildIotSettingsButton(),
+      );
     }
 
-    // マッピング未設定 → 手動取得ボタン + マッピング設定へのヒント
-    return _buildManualFetchArea(hasNatureRemo, hasSwitchBot);
+    // ダッシュボード表示
+    final latestLogs = sensorProvider.latestLogPerDevice;
+    final linked = mappings.where((m) => m.plantIds.isNotEmpty).toList();
+    final unlinked = mappings.where((m) => m.plantIds.isEmpty).toList();
+
+    return Column(
+      children: [
+        _buildFetchBar(settings.lastSensorFetchAt, mappings.length),
+        const Divider(height: 1),
+        if (sensorProvider.isLoading)
+          const Expanded(child: Center(child: CircularProgressIndicator()))
+        else
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(12),
+              children: [
+                ...linked.map((m) => _buildDeviceCard(m, latestLogs[m.deviceId])),
+                if (unlinked.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  _buildSectionLabel('植物が未設定のデバイス'),
+                  ...unlinked.map((m) => _buildDeviceCard(m, null)),
+                ],
+              ],
+            ),
+          ),
+      ],
+    );
   }
 
-  /// マッピング設定済みのときに表示する取得エリア
-  Widget _buildMappingFetchArea(int deviceCount) {
-    final settings = context.read<SettingsProvider>().settings;
-    final lastFetchStr = settings.lastSensorFetchAt;
-    String lastFetchLabel = '未取得';
-    if (lastFetchStr != null) {
-      final dt = DateTime.tryParse(lastFetchStr);
+  /// 取得ボタンと前回取得日時のバー
+  Widget _buildFetchBar(String? lastFetchAt, int deviceCount) {
+    String lastLabel = '未取得';
+    if (lastFetchAt != null) {
+      final dt = DateTime.tryParse(lastFetchAt);
       if (dt != null) {
-        lastFetchLabel =
-            '前回: ${DateFormat('MM/dd HH:mm').format(dt.toLocal())}';
+        lastLabel = DateFormat('MM/dd HH:mm').format(dt.toLocal());
       }
     }
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
         children: [
-          FilledButton.icon(
-            onPressed: _isFetching ? null : _fetchWithMappings,
-            icon: _isFetching
-                ? const SizedBox(
-                    width: 18,
-                    height: 18,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.sensors),
-            label: const Text('今すぐ取得'),
+          Expanded(
+            child: FilledButton.icon(
+              onPressed: _isFetching ? null : _fetchNow,
+              icon: _isFetching
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.sensors),
+              label: const Text('今すぐ取得'),
+            ),
           ),
-          const SizedBox(height: 4),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          const SizedBox(width: 12),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.end,
             children: [
               Text(
-                '$deviceCount台のデバイスから取得して紐づけ済み植物に記録します',
-                style: Theme.of(context).textTheme.bodySmall,
+                '前回',
+                style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.outline,
+                    ),
               ),
               Text(
-                lastFetchLabel,
+                lastLabel,
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
                       color: Theme.of(context).colorScheme.outline,
                     ),
@@ -410,198 +196,193 @@ class _SensorLogScreenState extends State<SensorLogScreen> {
     );
   }
 
-  /// マッピング未設定のときに表示する手動取得エリア
-  Widget _buildManualFetchArea(bool hasNatureRemo, bool hasSwitchBot) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // マッピング設定を促すバナー
-          Card(
-            color: Theme.of(context).colorScheme.secondaryContainer,
-            margin: const EdgeInsets.only(bottom: 12),
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.info_outline,
-                    size: 18,
-                    color: Theme.of(context).colorScheme.onSecondaryContainer,
+  /// デバイス1台分のカード
+  Widget _buildDeviceCard(SensorDeviceMapping mapping, SensorLog? latest) {
+    final hasData = latest != null;
+    final tempText = hasData && latest.temperature != null
+        ? '${latest.temperature!.toStringAsFixed(1)}℃'
+        : '--';
+    final humidText = hasData && latest.humidity != null
+        ? '${latest.humidity!.toStringAsFixed(0)}%'
+        : '--';
+    final plantCount = mapping.plantIds.length;
+    final updatedText = hasData
+        ? DateFormat('MM/dd HH:mm').format(latest.recordedAt.toLocal())
+        : null;
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // デバイス名と取得元
+            Row(
+              children: [
+                Icon(
+                  Icons.sensors,
+                  size: 18,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    mapping.deviceName,
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                          fontWeight: FontWeight.bold,
+                        ),
                   ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Text(
-                      'IoT設定でデバイスと植物を紐づけると、1タップで全デバイスのデータを取得・記録できます。',
-                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Theme.of(context)
-                                .colorScheme
-                                .onSecondaryContainer,
-                          ),
-                    ),
+                ),
+                if (updatedText != null)
+                  Text(
+                    updatedText,
+                    style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
                   ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            // 温湿度の大きな数値表示
+            Row(
+              children: [
+                _buildValueChip(Icons.thermostat, tempText, hasData),
+                const SizedBox(width: 12),
+                _buildValueChip(Icons.water_drop, humidText, hasData),
+              ],
+            ),
+            const SizedBox(height: 10),
+            // フッター: ソース名と植物数（または設定ボタン）
+            Row(
+              children: [
+                Text(
+                  _sourceName(mapping.source),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: Theme.of(context).colorScheme.outline,
+                      ),
+                ),
+                if (plantCount > 0) ...[
+                  Text(
+                    '  ·  ',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                  ),
+                  Text(
+                    '植物 $plantCount株',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.outline,
+                        ),
+                  ),
+                ] else ...[
+                  const Spacer(),
                   TextButton(
+                    style: TextButton.styleFrom(
+                      padding: EdgeInsets.zero,
+                      minimumSize: Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
                     onPressed: () => Navigator.of(context).push(
                       MaterialPageRoute(
                           builder: (_) => const IotSettingsScreen()),
                     ),
-                    child: const Text('設定'),
+                    child: const Text('植物を設定'),
                   ),
                 ],
-              ),
-            ),
-          ),
-          // 手動取得ボタン
-          if (hasNatureRemo)
-            _buildManualFetchButton(
-              label: 'Nature Remo からデータ取得',
-              source: SensorSource.natureRemo,
-            ),
-          if (hasNatureRemo && hasSwitchBot) const SizedBox(height: 8),
-          if (hasSwitchBot)
-            _buildManualFetchButton(
-              label: 'SwitchBot からデータ取得',
-              source: SensorSource.switchBot,
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildManualFetchButton({
-    required String label,
-    required SensorSource source,
-  }) {
-    return FilledButton.tonal(
-      onPressed:
-          _isFetching ? null : () => _startManualFetchFlow(source),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          if (_isFetching)
-            const SizedBox(
-              width: 18,
-              height: 18,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          else
-            const Icon(Icons.sensors),
-          const SizedBox(width: 8),
-          Text(label),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildLogList() {
-    return Consumer2<SensorLogProvider, PlantProvider>(
-      builder: (context, sensorProvider, plantProvider, _) {
-        if (sensorProvider.isLoading) {
-          return const Center(child: CircularProgressIndicator());
-        }
-
-        final logs = sensorProvider.logs;
-        if (logs.isEmpty) {
-          return Center(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.sensors,
-                  size: 64,
-                  color: Theme.of(context)
-                      .colorScheme
-                      .primary
-                      .withValues(alpha: 0.4),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  'センサーログがありません',
-                  style: Theme.of(context).textTheme.titleMedium,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  '上のボタンからIoTデバイスのデータを取得・記録できます',
-                  style: Theme.of(context).textTheme.bodySmall,
-                  textAlign: TextAlign.center,
-                ),
               ],
             ),
-          );
-        }
-
-        final plantMap = {
-          for (final p in plantProvider.plants) p.id: p.name,
-        };
-
-        return ListView.builder(
-          padding: const EdgeInsets.all(8),
-          itemCount: logs.length,
-          itemBuilder: (context, index) =>
-              _buildLogCard(logs[index], plantMap),
-        );
-      },
-    );
-  }
-
-  Widget _buildLogCard(SensorLog log, Map<String, String> plantMap) {
-    final plantName = log.plantId != null
-        ? (plantMap[log.plantId!] ?? '削除済み')
-        : null;
-
-    return Card(
-      margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-      child: ListTile(
-        leading: const Icon(Icons.thermostat),
-        title: Text(
-          _formatSensorValues(log.temperature, log.humidity),
-          style: Theme.of(context).textTheme.bodyLarge,
-        ),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(
-              '${_sourceName(log.source)} / ${log.deviceName}',
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            Text(
-              DateFormat('yyyy年MM月dd日 HH:mm').format(log.recordedAt),
-              style: Theme.of(context).textTheme.bodySmall,
-            ),
-            if (plantName != null)
-              Text(
-                '植物: $plantName',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-              ),
           ],
         ),
-        trailing: IconButton(
-          icon: const Icon(Icons.delete_outline, size: 20),
-          tooltip: '削除',
-          onPressed: () => _deleteSensorLog(log),
-        ),
-        isThreeLine: true,
       ),
     );
   }
-}
 
-/// Consumer2 ウィジェット（2種類の Provider を同時に購読する）
-class Consumer2<A extends ChangeNotifier, B extends ChangeNotifier>
-    extends StatelessWidget {
-  final Widget Function(BuildContext context, A a, B b, Widget? child) builder;
-  final Widget? child;
+  /// 温度・湿度の数値チップ
+  Widget _buildValueChip(IconData icon, String value, bool hasData) {
+    return Row(
+      children: [
+        Icon(
+          icon,
+          size: 20,
+          color: hasData
+              ? Theme.of(context).colorScheme.primary
+              : Theme.of(context).colorScheme.outline,
+        ),
+        const SizedBox(width: 4),
+        Text(
+          value,
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: hasData
+                    ? Theme.of(context).colorScheme.onSurface
+                    : Theme.of(context).colorScheme.outline,
+              ),
+        ),
+      ],
+    );
+  }
 
-  const Consumer2({super.key, required this.builder, this.child});
+  Widget _buildSectionLabel(String label) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4, bottom: 8),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(
+              color: Theme.of(context).colorScheme.outline,
+            ),
+      ),
+    );
+  }
 
-  @override
-  Widget build(BuildContext context) {
-    return Consumer<A>(
-      builder: (context, a, _) => Consumer<B>(
-        builder: (context, b, _) => builder(context, a, b, child),
+  Widget _buildIotSettingsButton() {
+    return OutlinedButton.icon(
+      onPressed: () => Navigator.of(context).push(
+        MaterialPageRoute(builder: (_) => const IotSettingsScreen()),
+      ),
+      icon: const Icon(Icons.settings),
+      label: const Text('IoT設定を開く'),
+    );
+  }
+
+  Widget _buildEmptyState({
+    required IconData icon,
+    required String message,
+    String? subMessage,
+    required Widget action,
+  }) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              icon,
+              size: 64,
+              color: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withValues(alpha: 0.3),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            if (subMessage != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                subMessage,
+                style: Theme.of(context).textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+            ],
+            const SizedBox(height: 20),
+            action,
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 変更内容

- **ログ一覧をやめ、デバイスカード形式に変更**
  - 1台ごとに最新の温度・湿度を大きく表示
  - センサー数・植物数が何百になっても画面が溢れない
- **「今すぐ取得」ボタンを上部に集約**
  - 前回取得日時をボタン横に表示
  - マッピング設定の全デバイスを1タップで一括取得
- **植物未設定デバイスを下部に分離表示**
  - 「植物を設定」リンクで IoT設定画面へ誘導
- **空状態の整備**
  - API未設定・マッピング未設定それぞれで適切なメッセージと設定ボタンを表示
- **`SensorLogProvider` に `latestLogPerDevice` ゲッターを追加**
  - 既存の logs（recordedAt DESC 順）から deviceId 別最新1件を O(n) で導出

## センサーログ履歴

ログの時系列履歴は植物詳細画面の「環境」タブで引き続き確認できます。
センサー画面は「今の環境を確認する」用途に特化しています。

## テスト手順

1. IoT設定でデバイスに植物を紐づけ → センサー画面で「今すぐ取得」→ カードに数値が表示されること
2. 植物数が多い（数十株）マッピングでもカードが1枚で表示されること
3. 植物未設定のデバイスが「植物が未設定のデバイス」セクションに表示されること
4. APIトークン未設定時・マッピング未設定時にそれぞれ適切な空状態が表示されること
5. 自動取得（アプリ起動時）後にセンサータブへ切り替えると数値が更新されていること