### PR TITLE
fix: セルフチェックによるバグ修正・デッドコード除去・README更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Botanote 🌱💧
 
-植物の水やり・肥料・活力剤ログ管理アプリ。スケジュール通知・ログ記録・ノート機能を備えた Flutter 製アプリです。
+植物の水やり・肥料・活力剤ログ管理アプリ。スケジュール通知・ログ記録・ノート機能・IoTセンサー連携を備えた Flutter 製アプリです。
 
 ---
 
@@ -15,19 +15,18 @@
 | ⏱️ 間隔設定 | 水やり・肥料・活力剤それぞれに「N日ごと」または「水やりN回に1回」の間隔を設定可能 |
 | 📸 植物画像 | カメラ・ギャラリーから画像取得、トリミング対応。詳細画面で背景表示 |
 | 📝 ノート | 植物に紐付けられる自由記述ノート。タイトル・タグ・画像添付に対応 |
-| 🔔 プッシュ通知 | 指定時刻に水やりリマインダーを送信（Android / iOS） |
+| 🔔 プッシュ通知 | 指定時刻に水やりリマインダーを送信（Android / iOS）。当日に水やり予定がある場合のみ通知 |
+| 🌡️ IoTセンサー連携 | Nature Remo / SwitchBot の REST API から温湿度・照度などを自動取得。植物との紐付けで環境ダッシュボードを表示 |
 | 🎨 テーマ設定 | グリーン / ブルー / パープル / オレンジの 4 テーマ。ライト / ダーク / システム連動の 3 モード切り替え対応 |
 | 🔄 並び替え | 名前順・購入日順・ドラッグ操作によるカスタム順 |
 | 💾 ZIPバックアップ | 植物・ログ・ノート・画像ファイルをまとめて ZIP に圧縮してバックアップ・復元 |
-| 🌐 Web 対応 | SharedPreferences によりリロード後もデータを保持 |
 
 ---
 
 ## 対応プラットフォーム
 
-- Android
-- iOS
-- Web (Chrome)
+- Android（主要）
+- iOS（主要）
 
 ---
 
@@ -54,7 +53,6 @@ flutter pub get
 flutter devices
 
 # 4. アプリを起動
-flutter run -d chrome       # Web
 flutter run -d android      # Android
 flutter run -d ios          # iOS (macOS のみ)
 ```
@@ -66,17 +64,18 @@ flutter run -d ios          # iOS (macOS のみ)
 ```
 lib/
 ├── main.dart                         # エントリポイント
-├── data/
-│   └── test_data_generator.dart     # 開発用テストデータ生成
 ├── models/
 │   ├── plant.dart                   # 植物モデル
 │   ├── log_entry.dart               # 水やり/肥料/活力剤ログ
 │   ├── note.dart                    # ノートモデル
 │   ├── app_settings.dart            # アプリ設定（テーマ・通知）
-│   └── daily_log_status.dart        # 日別ログステータス
+│   ├── daily_log_status.dart        # 日別ログステータス
+│   ├── sensor_log.dart              # センサーログモデル
+│   └── sensor_device_mapping.dart   # センサーデバイス ↔ 植物マッピング
 ├── providers/
 │   ├── plant_provider.dart          # 植物データの状態管理
 │   ├── note_provider.dart           # ノートデータの状態管理
+│   ├── sensor_log_provider.dart     # センサーログの状態管理
 │   └── settings_provider.dart       # 設定の状態管理
 ├── screens/
 │   ├── home_screen.dart             # ホーム（タブナビゲーション）
@@ -85,17 +84,17 @@ lib/
 │   ├── plant_detail_screen.dart     # 植物詳細（画像背景・タブ表示）
 │   ├── add_plant_screen.dart        # 植物追加・編集
 │   ├── image_crop_screen.dart       # 画像トリミング
+│   ├── sensor_log_screen.dart       # センサーログ・環境ダッシュボード
+│   ├── iot_settings_screen.dart     # IoTセンサー連携設定
 │   ├── notes_list_screen.dart       # ノート一覧（検索・タグ絞り込み）
 │   ├── note_detail_screen.dart      # ノート詳細
 │   ├── add_edit_note_screen.dart    # ノート追加・編集
 │   └── settings_screen.dart         # 設定（テーマ・通知・データ管理）
 ├── services/
 │   ├── database_service.dart        # SQLite 操作（Android/iOS）
-│   ├── web_storage_service.dart     # SharedPreferences によるデータ永続化（Web）
-│   ├── memory_storage_service.dart  # インメモリストレージ（Web 開発用）
-│   ├── export_service.dart          # JSON エクスポート/インポート
+│   ├── export_service.dart          # JSON エクスポート/インポート・ZIPバックアップ
 │   ├── log_service.dart             # 水やりログ集計
-│   ├── notification_service.dart    # ローカルプッシュ通知
+│   ├── notification_service.dart    # ローカルプッシュ通知・スマートスケジューリング
 │   └── settings_service.dart        # 設定の永続化（SharedPreferences）
 ├── theme/
 │   └── app_themes.dart              # テーマ定義
@@ -113,12 +112,13 @@ lib/
 |---|---|---|
 | `provider` | ^6.1.1 | 状態管理 |
 | `sqflite` | ^2.3.0 | SQLite（モバイル） |
-| `shared_preferences` | ^2.2.2 | 設定永続化 / Web 永続化 |
+| `shared_preferences` | ^2.2.2 | 設定永続化 |
 | `image_picker` | ^1.0.7 | カメラ・ギャラリー取得 |
 | `crop_your_image` | ^1.0.0 | 画像トリミング |
 | `flutter_local_notifications` | ^20.1.0 | ローカルプッシュ通知 |
 | `table_calendar` | ^3.1.2 | カレンダーUI |
 | `timezone` | ^0.10.1 | タイムゾーン管理 |
+| `flutter_timezone` | ^5.0.1 | 端末タイムゾーン取得 |
 | `flutter_localizations` | SDK | カレンダー・UI の日本語ローカライゼーション |
 | `intl` | ^0.20.2 | 日付フォーマット（ja） |
 | `archive` | ^4.0.9 | ZIPバックアップ |
@@ -127,6 +127,9 @@ lib/
 | `permission_handler` | ^11.2.0 | ランタイムパーミッション |
 | `uuid` | ^4.3.3 | UUID 生成 |
 | `path_provider` | ^2.1.1 | ドキュメントディレクトリ取得 |
+| `workmanager` | ^0.9.0 | バックグラウンドタスク（通知スケジューリング） |
+| `http` | ^1.2.0 | IoTセンサー REST API 通信 |
+| `crypto` | ^3.0.3 | SwitchBot HMAC-SHA256 署名 |
 
 ---
 
@@ -145,9 +148,6 @@ flutter test
 # Android 向け実行
 flutter run -d android
 
-# Web 向け実行
-flutter run -d chrome
-
 # リリースビルド（Android APK）
 flutter build apk --release
 ```
@@ -159,11 +159,10 @@ flutter build apk --release
 - **状態管理**: Provider パターン（`ChangeNotifier`）
 - **設計パターン**: Provider + Repository パターン
   - `screens/` → `providers/` → `services/` → `models/` の一方向依存
-- **データ永続化**:
-  - モバイル: SQLite（`sqflite`）。DBバージョン管理による累積マイグレーション方式
-  - Web: SharedPreferences（`shared_preferences`）
+- **データ永続化**: SQLite（`sqflite`）。DBバージョン管理による累積マイグレーション方式
 - **サービス層**: DB 操作・通知・ファイル I/O を `lib/services/` に分離
-- **プラットフォーム分岐**: `kIsWeb` で Web / モバイルを切り替え
+- **IoTセンサー連携**: Nature Remo（Bearer トークン認証）および SwitchBot（HMAC-SHA256署名）の REST API を `http` パッケージで呼び出し。センサーログは SQLite に保存
+- **バックグラウンド処理**: `workmanager` によるバックグラウンドタスクでスマート通知をスケジューリング（当日に水やり予定がある場合のみ通知）
 - **バックアップ**: 植物・ログ・ノート・画像を ZIP に圧縮して共有シートで書き出し、ファイルピッカーで復元
 
 ---

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -644,13 +644,6 @@ class PlantProvider with ChangeNotifier {
     await _db.deleteLog(logId);
   }
 
-  /// コーチ機能用に直近30件のログを取得する。
-  Future<List<LogEntry>> getAllLogsForCoach() async {
-    final allLogs = await _db.getAllLogs();
-    allLogs.sort((a, b) => b.date.compareTo(a.date));
-    return allLogs.take(30).toList();
-  }
-
   /// すべての植物の水やり間隔を指定日数に一括設定する。
   Future<void> bulkUpdateWateringInterval(int days) async {
     for (final plant in _plants) {

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -3,7 +3,6 @@ import '../models/app_settings.dart';
 import '../models/sensor_device_mapping.dart';
 import '../services/settings_service.dart';
 import '../services/notification_service.dart';
-import 'plant_provider.dart';
 
 /// アプリ設定を管理する Provider。
 ///
@@ -34,14 +33,6 @@ class SettingsProvider with ChangeNotifier {
         minute: _settings.notificationMinute,
       );
     }
-  }
-
-  /// NotificationService に水やり予定チェック用のコールバックを設定する
-  /// PlantProvider から呼ぶ必要がある（PlantProviderの状態を参照するため）
-  void setupNotificationCallback(PlantProvider plantProvider) {
-    NotificationService().setWateringScheduleCallback(() async {
-      return await plantProvider.hasAnyWateringScheduledForToday();
-    });
   }
 
   /// 表示モードを変更する。

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -58,8 +58,10 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
   }
 
   Future<void> _showImageSourceOptions() async {
-    // 既存画像がある場合は「再トリミング」選択肢も表示
+    // async ギャップ前に context 依存の参照を取得しておく
     final hasExistingImage = _imagePath != null;
+    final navigator = Navigator.of(context);
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
 
     // 選択肢の戻り値: ImageSource か 're-crop' か null（キャンセル）
     final choice = await showModalBottomSheet<Object>(
@@ -105,7 +107,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
       if (pickedFile == null) return;
 
       // トリミング画面へ遷移
-      final cropResult = await Navigator.of(context).push<CropResult?>(
+      final cropResult = await navigator.push<CropResult?>(
         MaterialPageRoute(
           builder: (_) => ImageCropScreen(imagePath: pickedFile.path),
         ),
@@ -116,11 +118,9 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
 
       setState(() => _imagePath = cropResult.filePath);
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('画像の取得に失敗しました: $e')),
-        );
-      }
+      scaffoldMessenger.showSnackBar(
+        SnackBar(content: Text('画像の取得に失敗しました: $e')),
+      );
     }
   }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/plant_provider.dart';
 import '../providers/note_provider.dart';
-import '../providers/settings_provider.dart';
 import '../providers/sensor_log_provider.dart';
+import '../providers/settings_provider.dart';
 import 'today_watering_screen.dart';
 import 'plant_list_screen.dart';
 import 'notes_list_screen.dart';
@@ -30,9 +30,6 @@ class _HomeScreenState extends State<HomeScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      final plantProvider = context.read<PlantProvider>();
-      final settingsProvider = context.read<SettingsProvider>();
-      settingsProvider.setupNotificationCallback(plantProvider);
       // アプリ起動時にセンサー自動取得が必要か確認する
       _checkAndAutoFetch();
     });
@@ -87,16 +84,16 @@ class _HomeScreenState extends State<HomeScreen> {
             _selectedIndex = index;
           });
           // タブ切替時にデータを再読み込みする
-          if (!mounted) return;
+          if (!context.mounted) return;
           await context.read<PlantProvider>().loadPlants();
           // ノートタブ（index=2）切替時はノートも再読み込みする
           if (index == 2) {
-            if (!mounted) return;
+            if (!context.mounted) return;
             await context.read<NoteProvider>().loadNotes();
           }
           // センサータブ（index=3）切替時はセンサーログも再読み込みする
           if (index == 3) {
-            if (!mounted) return;
+            if (!context.mounted) return;
             await context.read<SensorLogProvider>().loadLogs();
           }
         },

--- a/lib/screens/iot_settings_screen.dart
+++ b/lib/screens/iot_settings_screen.dart
@@ -530,7 +530,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
             ),
             const SizedBox(height: 12),
             DropdownButtonFormField<int>(
-              value: _fetchIntervalHours,
+              initialValue: _fetchIntervalHours,
               decoration: const InputDecoration(
                 labelText: '取得間隔',
                 border: OutlineInputBorder(),

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -123,6 +123,7 @@ class NoteDetailScreen extends StatelessWidget {
                 ),
               );
               if (confirmed == true) {
+                if (!context.mounted) return;
                 await context.read<NoteProvider>().deleteNote(note.id);
                 if (context.mounted && Navigator.of(context).canPop()) {
                   Navigator.of(context).pop();

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -26,7 +26,8 @@ class _NotesListScreenState extends State<NotesListScreen> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!context.mounted) return;
       context.read<NoteProvider>().loadNotes();
       context.read<PlantProvider>().loadPlants();
     });

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -160,6 +160,10 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
   }
 
   Future<void> _deletePlant() async {
+    // async ギャップ前に context 依存の参照を取得しておく
+    final plantProvider = context.read<PlantProvider>();
+    final navigator = Navigator.of(context);
+
     final confirm = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
@@ -182,10 +186,9 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     );
 
     if (confirm == true) {
-      await context.read<PlantProvider>().deletePlant(widget.plant.id);
-      if (mounted) {
-        Navigator.of(context).pop();
-      }
+      await plantProvider.deletePlant(widget.plant.id);
+      if (!context.mounted) return;
+      navigator.pop();
     }
   }
 
@@ -546,7 +549,9 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                         initialPlantId: widget.plant.id,
                       ),
                     ),
-                  ).then((_) => context.read<NoteProvider>().loadNotes()),
+                  ).then((_) {
+                    if (context.mounted) context.read<NoteProvider>().loadNotes();
+                  }),
                   icon: const Icon(Icons.add),
                   label: const Text('ノートを追加'),
                 ),
@@ -573,7 +578,9 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                   MaterialPageRoute(
                     builder: (_) => NoteDetailScreen(note: note),
                   ),
-                ).then((_) => context.read<NoteProvider>().loadNotes()),
+                ).then((_) {
+                  if (context.mounted) context.read<NoteProvider>().loadNotes();
+                }),
               ),
             );
           },

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -23,7 +23,8 @@ class _PlantListScreenState extends State<PlantListScreen> {
   @override
   void initState() {
     super.initState();
-    Future.microtask(() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!context.mounted) return;
       context.read<PlantProvider>().loadPlants();
     });
   }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../providers/settings_provider.dart';
 import '../providers/plant_provider.dart';
 import '../providers/note_provider.dart';
+import '../providers/sensor_log_provider.dart';
 import '../models/app_settings.dart';
 import '../services/export_service.dart';
 import 'iot_settings_screen.dart';
@@ -181,7 +182,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const ListTile(
             leading: Icon(Icons.info),
             title: Text('バージョン'),
-            subtitle: Text('1.0.0'),
+            subtitle: Text('1.2.0'),
           ),
           ListTile(
             leading: const Icon(Icons.code),
@@ -191,7 +192,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               showAboutDialog(
                 context: context,
                 applicationName: 'Botanote',
-                applicationVersion: '1.0.0',
+                applicationVersion: '1.2.0',
                 applicationIcon: const Icon(Icons.eco, size: 48),
                 children: const [
                   Text('植物の水やりを管理するためのアプリです。'),
@@ -259,15 +260,15 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
     if (confirmed != true) return;
     final days = int.parse(controller.text);
-    if (!mounted) return;
+    if (!context.mounted) return;
     try {
       await context.read<PlantProvider>().bulkUpdateWateringInterval(days);
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('すべての植物の水やり間隔を $days 日に設定しました')),
       );
     } catch (e) {
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('更新に失敗しました: $e')),
       );
@@ -327,16 +328,16 @@ class _SettingsScreenState extends State<SettingsScreen> {
       ),
     );
     if (confirmed != true) return;
-    if (!mounted) return;
+    if (!context.mounted) return;
     try {
       await context.read<PlantProvider>().bulkAdjustWateringInterval(delta);
-      if (!mounted) return;
+      if (!context.mounted) return;
       final label = delta > 0 ? '+$delta' : '$delta';
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('水やり間隔を $label 日調整しました')),
       );
     } catch (e) {
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('更新に失敗しました: $e')),
       );
@@ -348,7 +349,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _isExporting = true);
     try {
       final path = await ExportService().exportToFile();
-      if (!mounted) return;
+      if (!context.mounted) return;
       if (path == null) {
         // ユーザーがキャンセル
         return;
@@ -357,12 +358,12 @@ class _SettingsScreenState extends State<SettingsScreen> {
         const SnackBar(content: Text('バックアップファイルを共有しました')),
       );
     } catch (e) {
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('エクスポートに失敗しました: $e')),
       );
     } finally {
-      if (mounted) setState(() => _isExporting = false);
+      if (context.mounted) setState(() => _isExporting = false);
     }
   }
 
@@ -394,25 +395,28 @@ class _SettingsScreenState extends State<SettingsScreen> {
     setState(() => _isImporting = true);
     try {
       final result = await ExportService().importFromFilePicker();
-      if (!mounted) return;
+      if (!context.mounted) return;
       if (result == null) {
         // キャンセル
         return;
       }
-      // PlantProvider・NoteProvider を再読み込みして反映
+      // 各Providerを再読み込みして反映
       await context.read<PlantProvider>().loadPlants();
+      if (!context.mounted) return;
       await context.read<NoteProvider>().loadNotes();
-      if (!mounted) return;
+      if (!context.mounted) return;
+      await context.read<SensorLogProvider>().loadLogs();
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('インポートしました（$result）')),
       );
     } catch (e) {
-      if (!mounted) return;
+      if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('インポートに失敗しました: $e')),
       );
     } finally {
-      if (mounted) setState(() => _isImporting = false);
+      if (context.mounted) setState(() => _isImporting = false);
     }
   }
 

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -327,14 +327,16 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
     LogType logType,
     DailyLogStatus logStatus,
   ) async {
+    // async ギャップ前にプロバイダー参照を取得しておく
+    final plantProvider = context.read<PlantProvider>();
+
     // 水やりの場合、他の記録（肥料・活力剤）があるか確認
     final hasOtherLogs = (logType == LogType.watering) &&
         logStatus.hasOtherLogs(plantId, LogType.watering);
-    
+
     final logTypesToDelete = await _confirmDeletion(hasOtherLogs, plantId, logType, logStatus);
     if (logTypesToDelete == null) return;
 
-    final plantProvider = context.read<PlantProvider>();
     await plantProvider.deleteMultipleLogsForDate(
       plantId,
       logTypesToDelete,
@@ -1124,13 +1126,13 @@ class _TodayWateringScreenState extends State<TodayWateringScreen> {
         .toList();
     
     if (unscheduledPlants.isEmpty) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('すべての植物が表示されています')),
-        );
-      }
+      if (!context.mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('すべての植物が表示されています')),
+      );
       return;
     }
+    if (!context.mounted) return;
 
     final selectedPlants = await showDialog<List<Plant>>(
       context: context,

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -78,7 +78,7 @@ class ExportService {
             if (comma >= 0) {
               final bytes = base64Decode(path.substring(comma + 1));
               const zipPath = 'images/plants/';
-              final zipFilePath = '${zipPath}${plant.id}.jpg';
+              final zipFilePath = '$zipPath${plant.id}.jpg';
               archive.addFile(ArchiveFile(zipFilePath, bytes.length, bytes));
               map['imagePath'] = zipFilePath; // ZIP 内相対パスに変換
             } else {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -7,9 +7,6 @@ import 'package:timezone/data/latest_all.dart' as tz;
 import 'dart:convert';
 import 'database_service.dart';
 
-/// 水やり予定をチェックするためのコールバック型
-typedef HasWateringScheduleCallback = Future<bool> Function();
-
 class NotificationService {
   static final NotificationService _instance = NotificationService._internal();
   factory NotificationService() => _instance;
@@ -21,8 +18,6 @@ class NotificationService {
   static const int _dailyWateringNotificationId = 1;
 
   bool _initialized = false;
-  /// 水やり予定チェック用のコールバック
-  HasWateringScheduleCallback? _hasWateringScheduleCallback;
 
   /// 初期化。main() で await して呼ぶ。
   Future<void> initialize() async {
@@ -55,12 +50,6 @@ class NotificationService {
     _initialized = true;
   }
 
-  /// 水やり予定チェック用のコールバックを設定する
-  /// SettingsProvider から呼ぶ
-  void setWateringScheduleCallback(HasWateringScheduleCallback callback) {
-    _hasWateringScheduleCallback = callback;
-  }
-
   /// 通知パーミッションをリクエストする。
   Future<bool> requestPermission() async {
     // Android 13+
@@ -89,88 +78,6 @@ class NotificationService {
     }
 
     return false;
-  }
-
-  /// 毎日 [hour]:[minute] に水やり通知をスケジュールする。
-  /// 通知時に水やり予定があるかをチェックして、ある場合のみ表示する。
-  Future<void> scheduleDailyWateringReminder({
-    required int hour,
-    required int minute,
-  }) async {
-    if (!_initialized) await initialize();
-
-    await cancelDailyWateringReminder();
-
-    // デバイスのローカルタイムゾーンを使用
-    final location = tz.local;
-    final now = tz.TZDateTime.now(location);
-    var scheduledDate = tz.TZDateTime(
-      location,
-      now.year,
-      now.month,
-      now.day,
-      hour,
-      minute,
-    );
-    // 今日の指定時刻が既に過ぎていたら翌日にする
-    if (scheduledDate.isBefore(now)) {
-      scheduledDate = scheduledDate.add(const Duration(days: 1));
-    }
-
-    const androidDetails = AndroidNotificationDetails(
-      'watering_reminder',
-      '水やりリマインダー',
-      channelDescription: '水やりが必要な植物をお知らせします',
-      importance: Importance.high,
-      priority: Priority.high,
-      icon: '@drawable/ic_notification',
-    );
-    const darwinDetails = DarwinNotificationDetails(
-      categoryIdentifier: 'watering',
-    );
-    const details = NotificationDetails(
-      android: androidDetails,
-      iOS: darwinDetails,
-      macOS: darwinDetails,
-    );
-
-    // exact alarm権限がある場合はexactAllowWhileIdle、ない場合はinexactにフォールバック
-    AndroidScheduleMode scheduleMode = AndroidScheduleMode.inexact;
-    final androidImpl = _plugin
-        .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>();
-    if (androidImpl != null) {
-      final hasExact = await androidImpl.canScheduleExactNotifications();
-      if (hasExact ?? false) {
-        scheduleMode = AndroidScheduleMode.exactAllowWhileIdle;
-      }
-    }
-
-    await _plugin.zonedSchedule(
-      id: _dailyWateringNotificationId,
-      title: '💧 水やりの時間です',
-      body: '水やりが必要な植物を確認しましょう',
-      scheduledDate: scheduledDate,
-      notificationDetails: details,
-      androidScheduleMode: scheduleMode,
-      matchDateTimeComponents: DateTimeComponents.time, // 毎日繰り返し
-    );
-
-    debugPrint(
-        'NotificationService: scheduled daily at $hour:${minute.toString().padLeft(2, '0')} (mode: $scheduleMode)');
-  }
-
-  /// 水やり予定があるかをチェックする
-  /// SettingsProviderから通知有効化時に呼ばれ、予定がない場合は通知をキャンセル
-  Future<bool> checkHasWateringScheduled() async {
-    if (_hasWateringScheduleCallback == null) {
-      // コールバックが設定されていないなら、予定があると仮定して通知を続行
-      debugPrint('NotificationService: No callback set, assuming watering scheduled');
-      return true;
-    }
-    final hasSchedule = await _hasWateringScheduleCallback!();
-    debugPrint('NotificationService: watering scheduled today = $hasSchedule');
-    return hasSchedule;
   }
 
   /// 翌日の水やり予定をDBから直接確認し、予定がある場合のみ通知を1件登録する。


### PR DESCRIPTION
## 変更内容

### デッドコード除去
- `HasWateringScheduleCallback` typedef と依存メソッド群をすべて削除
  - `NotificationService.scheduleDailyWateringReminder()` (80行超、`scheduleSmartWateringReminder` に完全移行済み)
  - `NotificationService.checkHasWateringScheduled()`
  - `NotificationService.setWateringScheduleCallback()`
  - `SettingsProvider.setupNotificationCallback()`
- `PlantProvider.getAllLogsForCoach()` 削除（AI コーチ機能は PR #166 で除去済み）

### バグ修正
- `settings_screen.dart`: バージョン表示のハードコード `'1.0.0'` → `'1.2.0'` に修正（2箇所）
- `iot_settings_screen.dart`: `DropdownButtonFormField` の非推奨 `value:` → `initialValue:` に修正
- `settings_screen.dart`: インポート後に `SensorLogProvider.loadLogs()` が呼ばれていなかった問題を修正
- `export_service.dart`: 不要な文字列補間ブレース `'${zipPath}...'` → `'$zipPath...'` を修正

### `use_build_context_synchronously` 対応
async ギャップ後のコンテキスト使用を以下のパターンで安全化（35件 → 10件）:
- `if (!context.mounted) return;` ガードを追加
- async ギャップ前に `Navigator.of(context)` / `ScaffoldMessenger.of(context)` / プロバイダー参照を取得
- `Future.microtask` → `WidgetsBinding.instance.addPostFrameCallback` に変更

**残存 10件**:
- 8件: `RadioListTile` の `groupValue`/`onChanged` 非推奨警告（`RadioGroup` 移行は別 PR で対応予定）
- 2件: `today_watering_screen.dart` — `context.mounted` ガード済みだがリンターが誤検知する既知パターン

### README 更新
- Web 対応の記述を全削除（プラットフォーム・コマンド・構成・アーキテクチャ）
- 削除済みファイル参照を除去 (`test_data_generator.dart`, `web_storage_service.dart`, `memory_storage_service.dart`)
- IoT センサー連携機能・センサー関連ファイルを追記
- パッケージ一覧に `http`, `crypto`, `workmanager`, `flutter_timezone` を追加
- バージョンを 1.2.0 に更新

## テスト手順

- [ ] `flutter analyze` で 10件のみ残ること（上記 README 参照の既知 info のみ）を確認
- [ ] 設定画面のバージョン表示が `1.2.0` であること
- [ ] バックアップ ZIP のインポート後にセンサーログも含めて正常に再読み込みされること
- [ ] 画像選択（カメラ・ギャラリー）から植物追加フローが正常動作すること
- [ ] 植物削除確認ダイアログで「削除」後に一覧画面へ戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)