### PR TITLE
feat: 冬季の水やり・肥料間隔自動延長機能を追加 (#173)

### DIFF
--- a/.claude/designs/issue-173.md
+++ b/.claude/designs/issue-173.md
@@ -1,0 +1,63 @@
+---
+issue: 173
+title: 季節ごとの水やり・肥料間隔の自動調整
+status: approved
+---
+
+## 概要
+現在の水やり/肥料/活力剤の間隔は固定日数のみで、冬季の生育鈍化を考慮できない。植物ごとに「冬季（12〜2月）は間隔を延長する」設定を追加し、予定日計算に反映する。
+
+## 変更対象ファイル
+- `lib/utils/seasonal_interval_utils.dart`（新規）: 休眠期判定・間隔調整の純粋関数
+- `lib/models/plant.dart`: `seasonalAdjustmentEnabled` / `dormantSeasonIntervalMultiplier` フィールド追加
+- `lib/services/database_service.dart`: DBバージョン 5→6、`plants` テーブルにカラム追加
+- `lib/providers/plant_provider.dart`: `addPlant`/各種 `calculateNext*Date` / `calcNext*DateFromLogs` で季節調整を適用
+- `lib/screens/add_plant_screen.dart`: 季節調整の設定UIを追加
+
+## データモデル変更
+`Plant` に以下を追加する:
+- `seasonalAdjustmentEnabled`（`bool`, デフォルト `false`）: 非nullableのため sentinel 不要、`copyWith` は通常の `??` パターン
+- `dormantSeasonIntervalMultiplier`（`double?`）: 冬季の間隔倍率（例: 1.5 = 1.5倍に延長）。sentinel パターンを適用してnullクリア可能にする
+
+## DB変更
+- 現在のバージョン: 5 → 新バージョン: 6
+- `plants` テーブルに以下カラムを ALTER TABLE で追加（try/catchでべき等化）:
+  - `seasonalAdjustmentEnabled INTEGER NOT NULL DEFAULT 0`
+  - `dormantSeasonIntervalMultiplier REAL`
+- `_onCreate` の `plants` テーブル定義にも同カラムを追加（新規インストール向け）
+
+## UI/UX設計
+`add_plant_screen.dart` の「水やり間隔」ListTile の直後に以下を追加する:
+- `SwitchListTile`: 「冬季は間隔を延長する（12〜2月）」
+- ONの場合のみ表示: 倍率選択（`DropdownButtonFormField<double>` で 1.2倍/1.5倍/2.0倍/3.0倍から選択、デフォルト1.5倍）
+
+`plant_detail_screen.dart` 側は編集画面経由の設定のみで、詳細画面への表示は必須としない（スコープ外）。
+
+## エラーハンドリング
+- `dormantSeasonIntervalMultiplier` が null のまま `seasonalAdjustmentEnabled: true` になることを防ぐため、UIでON時は必ずデフォルト値(1.5)を設定する
+- 季節調整ロジックは `seasonalAdjustmentEnabled == false` または倍率 null の場合、常に元の間隔をそのまま返す（フェイルセーフ）
+
+## 影響範囲
+- 既存の固定間隔ロジックとは後方互換（デフォルトOFFのため既存植物の挙動は変わらない）
+- エクスポート/インポート: `Plant.toMap`/`fromMap` に追加するだけで自動的に対応
+- 通知（リマインダー）: `calculateNextWateringDate` 等の計算結果を使用しているため自動的に反映される
+- `bulkAdjustWateringInterval`/`bulkUpdateWateringInterval`: 季節調整とは独立した基準間隔の一括変更のため変更不要
+
+## テスト観点
+- [ ] 季節調整OFFの植物は従来通りの予定日で計算される（回帰なし）
+- [ ] 季節調整ONで12月に水やりを記録した場合、次回予定日が基準間隔×倍率で計算される
+- [ ] 季節調整ONで夏季（6月等）に水やりを記録した場合、基準間隔のまま計算される（倍率が適用されない）
+- [ ] 肥料/活力剤が「水やりN回に1回」モードの場合も、冬季は間隔が延長される
+- [ ] 植物編集画面でON/OFF切り替え・倍率変更が保存され、再度開いたときに復元される
+- [ ] 既存DB（バージョン5以前）からのアップグレードでエラーが出ない
+- [ ] エクスポート→インポートで設定が保持される
+
+## 実装上の注意点
+- 季節の判定は「間隔の起算日（最終ログ日または購入日）の月」を基準にする。現在月ではなく起算日基準にすることで、月をまたぐ計算でも一貫性を保つ
+- `calculateNextFertilizerDate`/`calculateNextVitalizerDate` の「水やりN回に1回」モードでは `wateringIntervalDays! * remaining` のようにベース間隔を回数分掛けているため、掛け算前の単位間隔に対して季節調整を適用すること（掛け算後に一括調整しない）
+- `plant_provider.dart` 内に重複しているロジック（DBアクセス版・ログリスト版）両方に同じ調整を適用する
+
+## レビュー結果
+- レビュー日: 2026-07-02
+- 結果: 承認
+- コメント: アーキテクチャ規約（models非依存、依存方向）に適合。DB変更は累積マイグレーション+try/catchでべき等。デフォルトOFFのため既存挙動への影響なし。

--- a/lib/models/plant.dart
+++ b/lib/models/plant.dart
@@ -33,6 +33,13 @@ class Plant {
   /// 活力剤間隔（水やりN回に1回）。[vitalizerIntervalDays] と排他
   final int? vitalizerEveryNWaterings;
 
+  /// 冬季（12〜2月）の間隔延長を有効にするか
+  final bool seasonalAdjustmentEnabled;
+
+  /// 冬季の間隔倍率（例: 1.5 = 1.5倍に延長）。
+  /// [seasonalAdjustmentEnabled] が true でもこれが null の場合は調整されない。
+  final double? dormantSeasonIntervalMultiplier;
+
   /// 登録日時
   final DateTime createdAt;
 
@@ -51,6 +58,8 @@ class Plant {
     this.fertilizerEveryNWaterings,
     this.vitalizerIntervalDays,
     this.vitalizerEveryNWaterings,
+    this.seasonalAdjustmentEnabled = false,
+    this.dormantSeasonIntervalMultiplier,
     required this.createdAt,
     required this.updatedAt,
   });
@@ -68,6 +77,8 @@ class Plant {
       'fertilizerEveryNWaterings': fertilizerEveryNWaterings,
       'vitalizerIntervalDays': vitalizerIntervalDays,
       'vitalizerEveryNWaterings': vitalizerEveryNWaterings,
+      'seasonalAdjustmentEnabled': seasonalAdjustmentEnabled ? 1 : 0,
+      'dormantSeasonIntervalMultiplier': dormantSeasonIntervalMultiplier,
       'createdAt': createdAt.toIso8601String(),
       'updatedAt': updatedAt.toIso8601String(),
     };
@@ -89,6 +100,9 @@ class Plant {
       fertilizerEveryNWaterings: map['fertilizerEveryNWaterings'] as int?,
       vitalizerIntervalDays: map['vitalizerIntervalDays'] as int?,
       vitalizerEveryNWaterings: map['vitalizerEveryNWaterings'] as int?,
+      seasonalAdjustmentEnabled: (map['seasonalAdjustmentEnabled'] as int?) == 1,
+      dormantSeasonIntervalMultiplier:
+          map['dormantSeasonIntervalMultiplier'] as double?,
       createdAt: DateTime.parse(map['createdAt'] as String),
       updatedAt: DateTime.parse(map['updatedAt'] as String),
     );
@@ -107,6 +121,8 @@ class Plant {
     Object? fertilizerEveryNWaterings = _sentinel,
     Object? vitalizerIntervalDays = _sentinel,
     Object? vitalizerEveryNWaterings = _sentinel,
+    bool? seasonalAdjustmentEnabled,
+    Object? dormantSeasonIntervalMultiplier = _sentinel,
     DateTime? updatedAt,
   }) {
     return Plant(
@@ -131,6 +147,11 @@ class Plant {
       vitalizerEveryNWaterings: vitalizerEveryNWaterings == _sentinel
           ? this.vitalizerEveryNWaterings
           : vitalizerEveryNWaterings as int?,
+      seasonalAdjustmentEnabled:
+          seasonalAdjustmentEnabled ?? this.seasonalAdjustmentEnabled,
+      dormantSeasonIntervalMultiplier: dormantSeasonIntervalMultiplier == _sentinel
+          ? this.dormantSeasonIntervalMultiplier
+          : dormantSeasonIntervalMultiplier as double?,
       createdAt: createdAt,
       updatedAt: updatedAt ?? DateTime.now(),
     );

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -4,6 +4,7 @@ import '../models/plant.dart';
 import '../models/log_entry.dart';
 import '../models/app_settings.dart';
 import '../services/database_service.dart';
+import '../utils/seasonal_interval_utils.dart';
 
 /// 植物データとログを管理する Provider。
 ///
@@ -138,6 +139,8 @@ class PlantProvider with ChangeNotifier {
     int? fertilizerEveryNWaterings,
     int? vitalizerIntervalDays,
     int? vitalizerEveryNWaterings,
+    bool seasonalAdjustmentEnabled = false,
+    double? dormantSeasonIntervalMultiplier,
   }) async {
     final now = DateTime.now();
     final plant = Plant(
@@ -152,6 +155,8 @@ class PlantProvider with ChangeNotifier {
       fertilizerEveryNWaterings: fertilizerEveryNWaterings,
       vitalizerIntervalDays: vitalizerIntervalDays,
       vitalizerEveryNWaterings: vitalizerEveryNWaterings,
+      seasonalAdjustmentEnabled: seasonalAdjustmentEnabled,
+      dormantSeasonIntervalMultiplier: dormantSeasonIntervalMultiplier,
       createdAt: now,
       updatedAt: now,
     );
@@ -280,6 +285,19 @@ class PlantProvider with ChangeNotifier {
     return false;
   }
 
+  /// [plant] の季節調整設定を踏まえた実効間隔日数を返す（Issue #173）。
+  ///
+  /// [referenceDate]（間隔の起算日）が休眠期（12〜2月）かつ季節調整が
+  /// 有効な場合、[baseIntervalDays] に倍率を乗じて延長する。
+  int _adjustedInterval(Plant plant, int baseIntervalDays, DateTime referenceDate) {
+    return applySeasonalAdjustment(
+      baseIntervalDays: baseIntervalDays,
+      seasonalAdjustmentEnabled: plant.seasonalAdjustmentEnabled,
+      dormantMultiplier: plant.dormantSeasonIntervalMultiplier,
+      referenceDate: referenceDate,
+    );
+  }
+
   /// 最終水やりログから次回水やり日を動的に計算する。
   /// 水やり間隔が未設定の場合は null を返す。
   // 動的に次回水やり日を計算（ログから算出）
@@ -293,13 +311,16 @@ class PlantProvider with ChangeNotifier {
     if (wateringLogs.isEmpty) {
       // ログなしの場合は購入日または登録日から計算
       final baseDate = plant.purchaseDate ?? plant.createdAt;
-      return baseDate.add(Duration(days: plant.wateringIntervalDays!));
+      return baseDate.add(Duration(
+          days: _adjustedInterval(plant, plant.wateringIntervalDays!, baseDate)));
     }
 
     // 最新のログから計算
     wateringLogs.sort((a, b) => b.date.compareTo(a.date));
     final lastWatering = wateringLogs.first;
-    return lastWatering.date.add(Duration(days: plant.wateringIntervalDays!));
+    return lastWatering.date.add(Duration(
+        days: _adjustedInterval(
+            plant, plant.wateringIntervalDays!, lastWatering.date)));
   }
 
   /// 最終肥料ログから次回肥料予定日を動的に計算する。
@@ -323,21 +344,25 @@ class PlantProvider with ChangeNotifier {
       if (fertLogs.isNotEmpty) {
         // 起算日1: 最後に肥料を与えた日
         final sorted = [...fertLogs]..sort((a, b) => b.date.compareTo(a.date));
-        return sorted.first.date
-            .add(Duration(days: plant.fertilizerIntervalDays!));
+        return sorted.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.fertilizerIntervalDays!, sorted.first.date)));
       }
       // 起算日2: 最後に水やりをした日
       final wateringLogs2 =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
       if (wateringLogs2.isNotEmpty) {
         final sorted2 = [...wateringLogs2]..sort((a, b) => b.date.compareTo(a.date));
-        return sorted2.first.date
-            .add(Duration(days: plant.fertilizerIntervalDays!));
+        return sorted2.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.fertilizerIntervalDays!, sorted2.first.date)));
       }
       // 起算日3: 次回水やり予定日
       final nextWatering = await calculateNextWateringDate(plantId);
       if (nextWatering != null) {
-        return nextWatering.add(Duration(days: plant.fertilizerIntervalDays!));
+        return nextWatering.add(Duration(
+            days:
+                _adjustedInterval(plant, plant.fertilizerIntervalDays!, nextWatering)));
       }
       return null;
     }
@@ -371,8 +396,9 @@ class PlantProvider with ChangeNotifier {
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
           : (lastFertDate ?? (await calculateNextWateringDate(plantId) ?? DateTime.now()));
-      return baseDate
-          .add(Duration(days: plant.wateringIntervalDays! * remaining));
+      return baseDate.add(Duration(
+          days: _adjustedInterval(plant, plant.wateringIntervalDays!, baseDate) *
+              remaining));
     }
 
     return null;
@@ -397,21 +423,25 @@ class PlantProvider with ChangeNotifier {
       if (vitLogs.isNotEmpty) {
         // 起算日1: 最後に活力剤を与えた日
         final sorted = [...vitLogs]..sort((a, b) => b.date.compareTo(a.date));
-        return sorted.first.date
-            .add(Duration(days: plant.vitalizerIntervalDays!));
+        return sorted.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.vitalizerIntervalDays!, sorted.first.date)));
       }
       // 起算日2: 最後に水やりをした日
       final wateringLogs2 =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
       if (wateringLogs2.isNotEmpty) {
         final sorted2 = [...wateringLogs2]..sort((a, b) => b.date.compareTo(a.date));
-        return sorted2.first.date
-            .add(Duration(days: plant.vitalizerIntervalDays!));
+        return sorted2.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.vitalizerIntervalDays!, sorted2.first.date)));
       }
       // 起算日3: 次回水やり予定日
       final nextWatering = await calculateNextWateringDate(plantId);
       if (nextWatering != null) {
-        return nextWatering.add(Duration(days: plant.vitalizerIntervalDays!));
+        return nextWatering.add(Duration(
+            days:
+                _adjustedInterval(plant, plant.vitalizerIntervalDays!, nextWatering)));
       }
       return null;
     }
@@ -444,8 +474,9 @@ class PlantProvider with ChangeNotifier {
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
           : (lastVitDate ?? (await calculateNextWateringDate(plantId) ?? DateTime.now()));
-      return baseDate
-          .add(Duration(days: plant.wateringIntervalDays! * remaining));
+      return baseDate.add(Duration(
+          days: _adjustedInterval(plant, plant.wateringIntervalDays!, baseDate) *
+              remaining));
     }
 
     return null;
@@ -525,10 +556,13 @@ class PlantProvider with ChangeNotifier {
     if (wateringLogs.isEmpty) {
       // ログなしの場合は購入日または登録日から計算
       final baseDate = plant.purchaseDate ?? plant.createdAt;
-      return baseDate.add(Duration(days: plant.wateringIntervalDays!));
+      return baseDate.add(Duration(
+          days: _adjustedInterval(plant, plant.wateringIntervalDays!, baseDate)));
     }
     final sorted = [...wateringLogs]..sort((a, b) => b.date.compareTo(a.date));
-    return sorted.first.date.add(Duration(days: plant.wateringIntervalDays!));
+    return sorted.first.date.add(Duration(
+        days:
+            _adjustedInterval(plant, plant.wateringIntervalDays!, sorted.first.date)));
   }
 
   /// ログリストから次回肥料予定日を計算する（DBアクセスなし・同期的）。
@@ -544,18 +578,21 @@ class PlantProvider with ChangeNotifier {
     if (plant.fertilizerIntervalDays != null) {
       if (fertLogs.isNotEmpty) {
         final sorted = [...fertLogs]..sort((a, b) => b.date.compareTo(a.date));
-        return sorted.first.date
-            .add(Duration(days: plant.fertilizerIntervalDays!));
+        return sorted.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.fertilizerIntervalDays!, sorted.first.date)));
       }
       if (wateringLogs.isNotEmpty) {
         final sorted = [...wateringLogs]
           ..sort((a, b) => b.date.compareTo(a.date));
-        return sorted.first.date
-            .add(Duration(days: plant.fertilizerIntervalDays!));
+        return sorted.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.fertilizerIntervalDays!, sorted.first.date)));
       }
       if (nextWateringDate != null) {
-        return nextWateringDate
-            .add(Duration(days: plant.fertilizerIntervalDays!));
+        return nextWateringDate.add(Duration(
+            days:
+                _adjustedInterval(plant, plant.fertilizerIntervalDays!, nextWateringDate)));
       }
       return null;
     }
@@ -579,8 +616,9 @@ class PlantProvider with ChangeNotifier {
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
           : (lastFertDate ?? (nextWateringDate ?? DateTime.now()));
-      return baseDate
-          .add(Duration(days: plant.wateringIntervalDays! * remaining));
+      return baseDate.add(Duration(
+          days: _adjustedInterval(plant, plant.wateringIntervalDays!, baseDate) *
+              remaining));
     }
     return null;
   }
@@ -598,18 +636,21 @@ class PlantProvider with ChangeNotifier {
     if (plant.vitalizerIntervalDays != null) {
       if (vitLogs.isNotEmpty) {
         final sorted = [...vitLogs]..sort((a, b) => b.date.compareTo(a.date));
-        return sorted.first.date
-            .add(Duration(days: plant.vitalizerIntervalDays!));
+        return sorted.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.vitalizerIntervalDays!, sorted.first.date)));
       }
       if (wateringLogs.isNotEmpty) {
         final sorted = [...wateringLogs]
           ..sort((a, b) => b.date.compareTo(a.date));
-        return sorted.first.date
-            .add(Duration(days: plant.vitalizerIntervalDays!));
+        return sorted.first.date.add(Duration(
+            days: _adjustedInterval(
+                plant, plant.vitalizerIntervalDays!, sorted.first.date)));
       }
       if (nextWateringDate != null) {
-        return nextWateringDate
-            .add(Duration(days: plant.vitalizerIntervalDays!));
+        return nextWateringDate.add(Duration(
+            days:
+                _adjustedInterval(plant, plant.vitalizerIntervalDays!, nextWateringDate)));
       }
       return null;
     }
@@ -633,8 +674,9 @@ class PlantProvider with ChangeNotifier {
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
           : (lastVitDate ?? (nextWateringDate ?? DateTime.now()));
-      return baseDate
-          .add(Duration(days: plant.wateringIntervalDays! * remaining));
+      return baseDate.add(Duration(
+          days: _adjustedInterval(plant, plant.wateringIntervalDays!, baseDate) *
+              remaining));
     }
     return null;
   }

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -31,6 +31,9 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
   int? _vitalizerEveryNWaterings;
   String? _imagePath;
   bool _isLoading = false;
+  // 季節調整（Issue #173）: 冬季（12〜2月）の間隔延長
+  bool _seasonalAdjustmentEnabled = false;
+  double _dormantSeasonIntervalMultiplier = 1.5;
 
   @override
   void initState() {
@@ -46,6 +49,9 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
       _vitalizerIntervalDays = widget.plant!.vitalizerIntervalDays;
       _vitalizerEveryNWaterings = widget.plant!.vitalizerEveryNWaterings;
       _imagePath = widget.plant!.imagePath;
+      _seasonalAdjustmentEnabled = widget.plant!.seasonalAdjustmentEnabled;
+      _dormantSeasonIntervalMultiplier =
+          widget.plant!.dormantSeasonIntervalMultiplier ?? 1.5;
     }
   }
 
@@ -175,6 +181,9 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
           fertilizerEveryNWaterings: _fertilizerEveryNWaterings,
           vitalizerIntervalDays: _vitalizerIntervalDays,
           vitalizerEveryNWaterings: _vitalizerEveryNWaterings,
+          seasonalAdjustmentEnabled: _seasonalAdjustmentEnabled,
+          dormantSeasonIntervalMultiplier:
+              _seasonalAdjustmentEnabled ? _dormantSeasonIntervalMultiplier : null,
         );
       } else {
         // 既存植物の更新。nullable フィールドを明示的に null にできるよう
@@ -194,6 +203,9 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
           fertilizerEveryNWaterings: _fertilizerEveryNWaterings,
           vitalizerIntervalDays: _vitalizerIntervalDays,
           vitalizerEveryNWaterings: _vitalizerEveryNWaterings,
+          seasonalAdjustmentEnabled: _seasonalAdjustmentEnabled,
+          dormantSeasonIntervalMultiplier:
+              _seasonalAdjustmentEnabled ? _dormantSeasonIntervalMultiplier : null,
         );
         await plantProvider.updatePlant(updatedPlant);
       }
@@ -437,6 +449,45 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
               }),
               wateringIntervalDays: _wateringInterval,
             ),
+            const Divider(),
+
+            // 季節調整（Issue #173）: 冬季（12〜2月）の間隔延長
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              secondary: const Icon(Icons.ac_unit),
+              title: const Text('冬季は間隔を延長する'),
+              subtitle: const Text('12〜2月は水やり・肥料・活力剤の間隔を自動で延ばす'),
+              value: _seasonalAdjustmentEnabled,
+              onChanged: (value) {
+                setState(() {
+                  _seasonalAdjustmentEnabled = value;
+                });
+              },
+            ),
+            if (_seasonalAdjustmentEnabled)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: DropdownButtonFormField<double>(
+                  initialValue: _dormantSeasonIntervalMultiplier,
+                  decoration: const InputDecoration(
+                    labelText: '冬季の延長倍率',
+                    border: OutlineInputBorder(),
+                    prefixIcon: Icon(Icons.timelapse),
+                  ),
+                  items: const [1.2, 1.5, 2.0, 3.0]
+                      .map((multiplier) => DropdownMenuItem(
+                            value: multiplier,
+                            child: Text('$multiplier倍'),
+                          ))
+                      .toList(),
+                  onChanged: (value) {
+                    if (value == null) return;
+                    setState(() {
+                      _dormantSeasonIntervalMultiplier = value;
+                    });
+                  },
+                ),
+              ),
             const Divider(),
           ],
         ),

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -33,7 +33,7 @@ class DatabaseService {
 
     return await openDatabase(
       newPath,
-      version: 5,
+      version: 6,
       onCreate: _onCreate,
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -90,6 +90,21 @@ class DatabaseService {
             )
           ''');
         }
+        if (oldVersion < 6) {
+          // plants テーブルに季節調整（冬季の間隔延長）カラムを追加
+          try {
+            await db.execute(
+                'ALTER TABLE plants ADD COLUMN seasonalAdjustmentEnabled INTEGER NOT NULL DEFAULT 0');
+          } catch (_) {
+            // 既にカラムが存在する場合は無視
+          }
+          try {
+            await db.execute(
+                'ALTER TABLE plants ADD COLUMN dormantSeasonIntervalMultiplier REAL');
+          } catch (_) {
+            // 既にカラムが存在する場合は無視
+          }
+        }
       },
     );
   }
@@ -108,6 +123,8 @@ class DatabaseService {
         fertilizerEveryNWaterings INTEGER,
         vitalizerIntervalDays INTEGER,
         vitalizerEveryNWaterings INTEGER,
+        seasonalAdjustmentEnabled INTEGER NOT NULL DEFAULT 0,
+        dormantSeasonIntervalMultiplier REAL,
         createdAt TEXT NOT NULL,
         updatedAt TEXT NOT NULL
       )

--- a/lib/utils/seasonal_interval_utils.dart
+++ b/lib/utils/seasonal_interval_utils.dart
@@ -1,0 +1,26 @@
+/// 休眠期とみなす月（北半球の冬季: 12月・1月・2月）
+const Set<int> dormantSeasonMonths = {12, 1, 2};
+
+/// 指定日が休眠期かどうかを判定する。
+bool isDormantSeason(DateTime date) => dormantSeasonMonths.contains(date.month);
+
+/// 季節調整を適用した間隔日数を返す。
+///
+/// [seasonalAdjustmentEnabled] が `false`、または [dormantMultiplier] が
+/// `null` の場合は [baseIntervalDays] をそのまま返す。
+/// [referenceDate]（間隔の起算日）が休眠期の場合のみ [dormantMultiplier] を
+/// 乗算して間隔を延長する。
+int applySeasonalAdjustment({
+  required int baseIntervalDays,
+  required bool seasonalAdjustmentEnabled,
+  required double? dormantMultiplier,
+  required DateTime referenceDate,
+}) {
+  if (!seasonalAdjustmentEnabled || dormantMultiplier == null) {
+    return baseIntervalDays;
+  }
+  if (!isDormantSeason(referenceDate)) {
+    return baseIntervalDays;
+  }
+  return (baseIntervalDays * dormantMultiplier).round();
+}


### PR DESCRIPTION
## 概要
- Issue #173 の実装。植物ごとに冬季（12〜2月）の間隔延長を設定できるようにし、水やり/肥料/活力剤の予定日計算に反映する。
- デフォルトは無効のため、既存植物の挙動には影響しない（後方互換）。

## 変更内容
- `Plant` モデルに `seasonalAdjustmentEnabled` / `dormantSeasonIntervalMultiplier` を追加
- `lib/utils/seasonal_interval_utils.dart` を新規追加（休眠期判定・間隔調整の純粋関数）
- DBバージョン 5→6（`plants` テーブルにカラム追加、累積マイグレーション + try/catchでべき等化）
- `PlantProvider` の全ての予定日計算ロジック（水やり/肥料/活力剤、DBアクセス版・ログリスト版の計6メソッド）に季節調整を適用
- `add_plant_screen.dart` に「冬季は間隔を延長する」トグルと倍率選択（1.2/1.5/2.0/3.0倍）UIを追加

## 設計書
`.claude/designs/issue-173.md`

## テスト手順
- [ ] 季節調整OFFの植物は従来通りの予定日で計算される（回帰なし）
- [ ] 季節調整ONで12月に水やりを記録した場合、次回予定日が基準間隔×倍率で計算される
- [ ] 季節調整ONで夏季（6月等）に水やりを記録した場合、基準間隔のまま計算される
- [ ] 肥料/活力剤が「水やりN回に1回」モードの場合も、冬季は間隔が延長される
- [ ] 植物編集画面でON/OFF切り替え・倍率変更が保存され、再度開いたときに復元される
- [ ] 既存DB（バージョン5以前）からのアップグレードでエラーが出ない
- [ ] エクスポート→インポートで設定が保持される

`flutter analyze`: エラーなし（既存のinfo警告10件のみ、本PRとは無関係）
`flutter test`: 既存の smoke test は baseline (main) から失敗しており本PRとは無関係（sqflite databaseFactory未初期化のため）