### PR TITLE
feat: 植物ごとの成長写真タイムラインを追加 (#179)

### DIFF
--- a/.claude/designs/issue-179.md
+++ b/.claude/designs/issue-179.md
@@ -1,0 +1,47 @@
+---
+issue: 179
+title: 植物ごとの成長写真タイムライン
+status: approved
+---
+
+## 概要
+植物詳細画面から、その植物に紐付くノート画像（＋登録時の植物写真）を時系列に並べた成長タイムラインを表示する。既存データ（ノートの `imagePaths`/`plantIds`、植物の `imagePath`）のみを使用し、新規テーブルは追加しない。
+
+## 変更対象ファイル
+- `lib/screens/plant_growth_timeline_screen.dart`（新規）: タイムライン表示画面
+- `lib/screens/plant_detail_screen.dart`: AppBarアクションにタイムラインへの導線を追加
+
+## データモデル変更
+なし。
+
+## DB変更
+なし。既存の `Note.imagePaths`/`Note.plantIds`、`Plant.imagePath`/`Plant.purchaseDate` のみを使用する。
+
+## UI/UX設計
+- `plant_detail_screen.dart` のSliverAppBar `actions` に `Icons.auto_awesome_motion`（タイムライン）アイコンボタンを追加し、`PlantGrowthTimelineScreen` へ遷移する
+- `PlantGrowthTimelineScreen`:
+  - `Consumer<NoteProvider>` でその植物に紐付くノートを取得し、各ノートの `imagePaths` を `note.createdAt` とともにフラット化する
+  - 植物の `imagePath`（登録時の写真）があれば `purchaseDate ?? createdAt` を日付として先頭候補に加える
+  - 日付昇順でソートし、`GridView`（正方形サムネイル、日付キャプション付き）で表示する
+  - 写真が2枚以上ある場合、AppBarに「比較」ボタンを表示し、最初の写真と最新の写真を左右に並べた「ビフォーアフター」ビューをダイアログで表示する
+  - 写真が0枚の場合は空状態（アイコン＋「まだ成長記録がありません。ノートに写真を追加すると、ここに時系列で表示されます」）を表示する
+  - サムネイルタップで既存の画像ビューア相当の拡大表示（`InteractiveViewer` を使ったシンプルなダイアログ）を行う
+
+## エラーハンドリング
+- 画像ファイルが存在しない/読み込みに失敗した場合は `PlantImageWidget` 側の既存エラーハンドリングに委譲する（新規のエラーハンドリングは不要）
+
+## 影響範囲
+- 既存のノート・植物データの読み取りのみで、書き込み処理は行わないためバックアップ・エクスポート・通知には影響しない
+- `plant_detail_screen.dart` への変更はAppBarアクション追加のみで、既存の4タブ構成（情報/ログ/ノート/環境）は変更しない
+
+## テスト観点
+- [ ] ノートに画像がある植物でタイムライン画面を開くと、時系列順に写真が表示される
+- [ ] 植物の登録時写真がタイムラインの先頭（購入日 or 登録日基準）に含まれる
+- [ ] 写真が1枚以下の場合、「比較」ボタンが表示されない
+- [ ] 写真が2枚以上の場合、「比較」ボタンで最初と最新の写真が並んで表示される
+- [ ] 写真が1枚もない植物では空状態メッセージが表示される
+- [ ] サムネイルタップで拡大表示できる
+
+## 実装上の注意点
+- CLAUDE.mdの依存方向規約（screens→providers→models）に従い、DB直接アクセスは行わずNoteProvider/Plantモデル経由でデータ取得する
+- 画像表示は既存の `PlantImageWidget`（Web/ネイティブ両対応）を再利用し、パス形式の差異を意識しない

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -16,6 +16,7 @@ import 'add_plant_screen.dart';
 import 'add_edit_note_screen.dart';
 import 'iot_settings_screen.dart';
 import 'note_detail_screen.dart';
+import 'plant_growth_timeline_screen.dart';
 
 /// SliverPersistentHeaderDelegate: TabBarを固定表示するためのデリゲート
 class _StickyTabBarDelegate extends SliverPersistentHeaderDelegate {
@@ -216,6 +217,15 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
             forceElevated: innerBoxIsScrolled,
             actions: [
               if (widget.plant.imagePath != null)
+                _buildImageOverlayAction(
+                    Icons.auto_awesome_motion, _navigateToGrowthTimeline)
+              else
+                IconButton(
+                  icon: const Icon(Icons.auto_awesome_motion),
+                  tooltip: '成長タイムライン',
+                  onPressed: _navigateToGrowthTimeline,
+                ),
+              if (widget.plant.imagePath != null)
                 _buildImageOverlayAction(Icons.edit, _navigateToEdit)
               else
                 IconButton(
@@ -376,6 +386,15 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     if (mounted) {
       Navigator.of(context).pop(true);
     }
+  }
+
+  /// 成長タイムライン画面へ遷移する（Issue #179）。
+  void _navigateToGrowthTimeline() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => PlantGrowthTimelineScreen(plant: widget.plant),
+      ),
+    );
   }
 
   Widget _buildInfoTab() {

--- a/lib/screens/plant_growth_timeline_screen.dart
+++ b/lib/screens/plant_growth_timeline_screen.dart
@@ -1,0 +1,239 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:intl/intl.dart';
+import '../models/plant.dart';
+import '../models/note.dart';
+import '../providers/note_provider.dart';
+import '../widgets/plant_image_widget.dart';
+
+/// タイムライン上の1枚の写真エントリ
+class _TimelinePhoto {
+  final String imagePath;
+  final DateTime date;
+  final String caption;
+
+  const _TimelinePhoto({
+    required this.imagePath,
+    required this.date,
+    required this.caption,
+  });
+}
+
+/// 植物ごとの成長写真タイムライン画面（Issue #179）。
+///
+/// ノートに添付された画像と植物の登録時写真を時系列に並べて表示する。
+/// 新規データを持たず、既存のノート・植物データのみから構成する。
+class PlantGrowthTimelineScreen extends StatelessWidget {
+  final Plant plant;
+
+  const PlantGrowthTimelineScreen({super.key, required this.plant});
+
+  List<_TimelinePhoto> _buildTimeline(List<Note> notes) {
+    final entries = <_TimelinePhoto>[];
+
+    if (plant.imagePath != null) {
+      entries.add(_TimelinePhoto(
+        imagePath: plant.imagePath!,
+        date: plant.purchaseDate ?? plant.createdAt,
+        caption: '登録時の写真',
+      ));
+    }
+
+    for (final note in notes) {
+      for (final path in note.imagePaths) {
+        entries.add(_TimelinePhoto(
+          imagePath: path,
+          date: note.createdAt,
+          caption: note.title,
+        ));
+      }
+    }
+
+    entries.sort((a, b) => a.date.compareTo(b.date));
+    return entries;
+  }
+
+  void _showFullImage(BuildContext context, _TimelinePhoto photo) {
+    showDialog<void>(
+      context: context,
+      builder: (context) => Dialog(
+        backgroundColor: Colors.black,
+        insetPadding: const EdgeInsets.all(12),
+        child: Stack(
+          children: [
+            InteractiveViewer(
+              child: PlantImageWidget(
+                imagePath: photo.imagePath,
+                width: double.infinity,
+                height: double.infinity,
+                borderRadius: BorderRadius.zero,
+              ),
+            ),
+            Positioned(
+              top: 4,
+              right: 4,
+              child: IconButton(
+                icon: const Icon(Icons.close, color: Colors.white),
+                onPressed: () => Navigator.of(context).pop(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showBeforeAfter(BuildContext context, List<_TimelinePhoto> entries) {
+    final before = entries.first;
+    final after = entries.last;
+    showDialog<void>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('ビフォーアフター'),
+        content: Row(
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(DateFormat('yyyy/MM/dd').format(before.date),
+                      style: Theme.of(context).textTheme.bodySmall),
+                  const SizedBox(height: 4),
+                  AspectRatio(
+                    aspectRatio: 1,
+                    child: PlantImageWidget(
+                      imagePath: before.imagePath,
+                      width: double.infinity,
+                      height: double.infinity,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(DateFormat('yyyy/MM/dd').format(after.date),
+                      style: Theme.of(context).textTheme.bodySmall),
+                  const SizedBox(height: 4),
+                  AspectRatio(
+                    aspectRatio: 1,
+                    child: PlantImageWidget(
+                      imagePath: after.imagePath,
+                      width: double.infinity,
+                      height: double.infinity,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('閉じる'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<NoteProvider>(
+      builder: (context, noteProvider, _) {
+        final plantNotes = noteProvider.notes
+            .where((n) => n.plantIds.contains(plant.id))
+            .toList();
+        final entries = _buildTimeline(plantNotes);
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text('${plant.name}の成長タイムライン'),
+            actions: [
+              if (entries.length >= 2)
+                IconButton(
+                  icon: const Icon(Icons.compare),
+                  tooltip: 'ビフォーアフターを比較',
+                  onPressed: () => _showBeforeAfter(context, entries),
+                ),
+            ],
+          ),
+          body: entries.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(
+                        Icons.auto_awesome_motion_outlined,
+                        size: 64,
+                        color: Theme.of(context)
+                            .colorScheme
+                            .primary
+                            .withValues(alpha: 0.5),
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'まだ成長記録がありません',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      const SizedBox(height: 8),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 32),
+                        child: Text(
+                          'ノートに写真を追加すると、ここに時系列で表示されます',
+                          textAlign: TextAlign.center,
+                          style: Theme.of(context).textTheme.bodySmall,
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              : GridView.builder(
+                  padding: const EdgeInsets.all(8),
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    crossAxisSpacing: 8,
+                    mainAxisSpacing: 8,
+                    childAspectRatio: 0.85,
+                  ),
+                  itemCount: entries.length,
+                  itemBuilder: (context, index) {
+                    final photo = entries[index];
+                    return GestureDetector(
+                      onTap: () => _showFullImage(context, photo),
+                      child: Tooltip(
+                        message: photo.caption,
+                        child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          Expanded(
+                            child: PlantImageWidget(
+                              imagePath: photo.imagePath,
+                              width: double.infinity,
+                              height: double.infinity,
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            DateFormat('yyyy/MM/dd').format(photo.date),
+                            style: Theme.of(context).textTheme.bodySmall,
+                            textAlign: TextAlign.center,
+                          ),
+                          ],
+                        ),
+                      ),
+                    );
+                  },
+                ),
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## 概要
- Issue #179 の実装。ノートに添付した画像と植物の登録時写真を時系列に並べたタイムライン画面を追加する。
- 新規テーブル・新規フィールドは不要で、既存のノート（`imagePaths`/`plantIds`）・植物（`imagePath`/`purchaseDate`）データのみから構成する。

## 変更内容
- `lib/screens/plant_growth_timeline_screen.dart`（新規）
  - ノートの添付画像＋植物登録時写真を日付昇順のGridViewで表示
  - サムネイルタップで拡大表示（`InteractiveViewer`）
  - 写真が2枚以上ある場合、「比較」ボタンで最初と最新の写真を並べたビフォーアフター表示
  - 写真がない場合は空状態メッセージを表示
- `lib/screens/plant_detail_screen.dart`: AppBarにタイムラインへの導線アイコン（`Icons.auto_awesome_motion`）を追加

## 設計書
`.claude/designs/issue-179.md`

## テスト手順
- [ ] ノートに画像がある植物でタイムライン画面を開くと、時系列順に写真が表示される
- [ ] 植物の登録時写真がタイムラインの先頭に含まれる
- [ ] 写真が1枚以下の場合、「比較」ボタンが表示されない
- [ ] 写真が2枚以上の場合、「比較」ボタンで最初と最新の写真が並んで表示される
- [ ] 写真が1枚もない植物では空状態メッセージが表示される
- [ ] サムネイルタップで拡大表示できる

`flutter analyze`: エラーなし（既存のinfo警告10件のみ、本PRとは無関係）