### PR TITLE
chore: パッケージバージョンを 1.3.0+6 に更新

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.2.0+5
+version: 1.3.0+6
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## 概要
以下10件のIssueに対応する機能をまとめてリリースするためのバージョン更新です。

- #173 季節ごとの水やり・肥料間隔の自動調整
- #174 ホーム画面ウィジェット（今日の水やり予定表示）
- #175 植え替え・剪定・葉水などケアタイプの拡張記録
- #176 天気連動ケアアラート
- #177 AI写真による病害虫診断
- #178 AI写真による植物名・品種の自動同定
- #179 植物ごとの成長写真タイムライン
- #180 置き場所（部屋・屋内外）単位の植物グループ管理
- #181 スマホセンサーによる光量メーター
- #182 ケア統計・インサイト画面

## 変更内容
- `pubspec.yaml`: `version: 1.2.0+5` → `1.3.0+6`

## リリースビルド
- ビルド済みAPK（`botanote_1.3.0_20260702.apk`、約70MB）をGoogle Drive（`Botanote/releases/`）にアップロード済み
- `flutter analyze`: エラーなし