### PR TITLE
feat: 管理場所と植物・センサーの連携機能を追加 (#195)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,6 +12,8 @@ import 'screens/home_screen.dart';
 import 'theme/app_themes.dart';
 import 'models/app_settings.dart';
 import 'services/notification_service.dart';
+import 'services/sensor_auto_fetch_service.dart';
+import 'services/settings_service.dart';
 
 /// バックグラウンドタスクのタスク名
 const _kSmartNotifyTask = 'smart_notify_task';
@@ -27,6 +29,16 @@ void callbackDispatcher() {
       await NotificationService.scheduleSmartWateringReminder();
       // 翌日の天気予報を確認し、屋外植物のケアアラートが必要ならスケジュール
       await NotificationService.scheduleWeatherAlert();
+    }
+    if (taskName == SensorAutoFetchService.taskName ||
+        taskName == Workmanager.iOSBackgroundTask) {
+      // センサーデータを自動取得してDBに保存する（取得間隔はWorkmanagerが管理）
+      try {
+        final settings = await SettingsService().loadSettings();
+        await SensorAutoFetchService.run(settings, forceRun: true);
+      } catch (e) {
+        debugPrint('バックグラウンドセンサー自動取得エラー: $e');
+      }
     }
     return Future.value(true);
   });
@@ -58,6 +70,15 @@ void main() async {
     // 既存タスクがあれば上書き
     existingWorkPolicy: ExistingPeriodicWorkPolicy.replace,
   );
+
+  // 保存済み設定に応じてセンサー自動取得のバックグラウンドタスクを登録する
+  // （アプリ起動時のみに依存せず、開かなくても定期的にデータを更新するため）
+  try {
+    final settings = await SettingsService().loadSettings();
+    await SensorAutoFetchService.reschedule(settings);
+  } catch (e) {
+    debugPrint('センサー自動取得タスクの登録に失敗しました: $e');
+  }
 
   runApp(const MyApp());
 }

--- a/lib/models/sensor_device_mapping.dart
+++ b/lib/models/sensor_device_mapping.dart
@@ -11,14 +11,18 @@ class SensorDeviceMapping {
   /// データ取得元
   final SensorSource source;
 
-  /// 紐づける植物IDリスト
+  /// 紐づける植物IDリスト（[locationId] が設定されている場合は無視される）
   final List<String> plantIds;
+
+  /// 紐づける管理場所ID（設定されている場合、この場所に属する植物全員に自動追従する）
+  final String? locationId;
 
   const SensorDeviceMapping({
     required this.deviceId,
     required this.deviceName,
     required this.source,
     required this.plantIds,
+    this.locationId,
   });
 
   Map<String, dynamic> toMap() => {
@@ -26,6 +30,7 @@ class SensorDeviceMapping {
         'deviceName': deviceName,
         'source': source.name,
         'plantIds': plantIds,
+        'locationId': locationId,
       };
 
   factory SensorDeviceMapping.fromMap(Map<String, dynamic> map) =>
@@ -37,5 +42,24 @@ class SensorDeviceMapping {
           orElse: () => SensorSource.manual,
         ),
         plantIds: List<String>.from(map['plantIds'] as List? ?? []),
+        locationId: map['locationId'] as String?,
       );
+
+  /// フィールドを部分的に更新した新しい SensorDeviceMapping を返す。
+  /// [locationId] を明示的に null にしたい場合は sentinel パターンを使用する。
+  SensorDeviceMapping copyWith({
+    List<String>? plantIds,
+    Object? locationId = _sentinel,
+  }) {
+    return SensorDeviceMapping(
+      deviceId: deviceId,
+      deviceName: deviceName,
+      source: source,
+      plantIds: plantIds ?? this.plantIds,
+      locationId: locationId == _sentinel ? this.locationId : locationId as String?,
+    );
+  }
 }
+
+/// copyWith で locationId を null クリアするための sentinel 値
+const Object _sentinel = Object();

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -192,6 +192,30 @@ class PlantProvider with ChangeNotifier {
     await loadPlants();
   }
 
+  /// 指定した管理場所に紐づく植物を一括で設定する。
+  ///
+  /// [plantIds] に含まれる植物は [locationId] を設定し、現在この場所に
+  /// 属しているが [plantIds] に含まれない植物は場所の紐づけを解除する。
+  Future<void> assignPlantsToLocation(
+      String locationId, Set<String> plantIds) async {
+    for (final plant in _plants) {
+      final shouldBelong = plantIds.contains(plant.id);
+      final currentlyBelongs = plant.locationId == locationId;
+      if (shouldBelong && !currentlyBelongs) {
+        await _db.updatePlant(plant.copyWith(
+          locationId: locationId,
+          updatedAt: DateTime.now(),
+        ));
+      } else if (!shouldBelong && currentlyBelongs) {
+        await _db.updatePlant(plant.copyWith(
+          locationId: null,
+          updatedAt: DateTime.now(),
+        ));
+      }
+    }
+    await loadPlants();
+  }
+
   Future<void> deletePlant(String id) async {
     await _db.deletePlant(id);
 

--- a/lib/providers/sensor_log_provider.dart
+++ b/lib/providers/sensor_log_provider.dart
@@ -4,6 +4,7 @@ import '../models/app_settings.dart';
 import '../models/sensor_device_mapping.dart';
 import '../models/sensor_log.dart';
 import '../services/database_service.dart';
+import '../services/iot_fetch_service.dart';
 import '../services/iot_service.dart';
 
 /// センサーログの状態管理を担う Provider。
@@ -12,6 +13,7 @@ import '../services/iot_service.dart';
 class SensorLogProvider with ChangeNotifier {
   final DatabaseService _db = DatabaseService();
   final IotService _iot = IotService();
+  final IotFetchService _iotFetch = IotFetchService();
 
   List<SensorLog> _logs = [];
   bool _isLoading = false;
@@ -107,60 +109,10 @@ class SensorLogProvider with ChangeNotifier {
   /// 紐づく植物すべてにセンサーログを保存する。
   ///
   /// [settings] に API トークンと [SensorDeviceMapping] リストを含める。
+  /// 実処理は [IotFetchService]（Provider非依存）に委譲する。
   /// 戻り値: 保存に成功したログ件数。
   Future<int> fetchAndSaveWithMappings(AppSettings settings) async {
-    final mappings = settings.sensorDeviceMappings;
-    if (mappings.isEmpty) return 0;
-
-    int savedCount = 0;
-
-    // ソース別にデバイス一覧を取得（API呼び出しを最小化）
-    List<SensorData>? natureRemoDevices;
-    List<SensorData>? switchBotDevices;
-
-    for (final mapping in mappings) {
-      try {
-        final List<SensorData> devices;
-        if (mapping.source == SensorSource.natureRemo) {
-          natureRemoDevices ??=
-              await _iot.fetchNatureRemoData(settings.natureRemoToken);
-          devices = natureRemoDevices;
-        } else {
-          switchBotDevices ??= await _iot.fetchSwitchBotData(
-              settings.switchBotToken, settings.switchBotSecret);
-          devices = switchBotDevices;
-        }
-
-        // マッピングのデバイスIDに一致するデバイスを探す
-        final device = devices.firstWhere(
-          (d) => d.deviceId == mapping.deviceId,
-          orElse: () => throw StateError(
-              'デバイスが見つかりません: ${mapping.deviceName}'),
-        );
-
-        // 紐づく植物ごとにセンサーログを保存（loadLogs は後でまとめて実行）
-        for (final plantId in mapping.plantIds) {
-          final now = DateTime.now();
-          final log = SensorLog(
-            id: const Uuid().v4(),
-            plantId: plantId,
-            source: mapping.source,
-            deviceId: device.deviceId,
-            deviceName: device.deviceName,
-            temperature: device.temperature,
-            humidity: device.humidity,
-            recordedAt: now,
-            createdAt: now,
-          );
-          await _db.insertSensorLog(log);
-          savedCount++;
-        }
-      } catch (e) {
-        // 1デバイスのエラーで全体を止めない
-        debugPrint('マッピング取得エラー (${mapping.deviceName}): $e');
-      }
-    }
-
+    final savedCount = await _iotFetch.fetchAndSaveWithMappings(settings);
     if (savedCount > 0) {
       await loadLogs();
     }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -168,6 +168,46 @@ class SettingsProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  /// 指定した管理場所に紐づくセンサーデバイスを一括で設定する。
+  ///
+  /// [deviceIds] に含まれるデバイスは [locationId] を設定し、現在この場所に
+  /// 紐づいているが [deviceIds] に含まれないデバイスは紐づけを解除する。
+  Future<void> assignSensorsToLocation(
+      String locationId, Set<String> deviceIds) async {
+    final updated = _settings.sensorDeviceMappings.map((mapping) {
+      final shouldBelong = deviceIds.contains(mapping.deviceId);
+      final currentlyBelongs = mapping.locationId == locationId;
+      if (shouldBelong && !currentlyBelongs) {
+        return mapping.copyWith(locationId: locationId);
+      } else if (!shouldBelong && currentlyBelongs) {
+        return mapping.copyWith(locationId: null);
+      }
+      return mapping;
+    }).toList();
+
+    _settings = _settings.copyWith(sensorDeviceMappings: updated);
+    await _settingsService.saveSettings(_settings);
+    notifyListeners();
+  }
+
+  /// 管理場所削除時に、その場所を参照しているセンサーマッピングの
+  /// locationId をクリアする。
+  Future<void> clearLocationFromSensorMappings(String locationId) async {
+    final hasReference =
+        _settings.sensorDeviceMappings.any((m) => m.locationId == locationId);
+    if (!hasReference) return;
+
+    final updated = _settings.sensorDeviceMappings.map((mapping) {
+      return mapping.locationId == locationId
+          ? mapping.copyWith(locationId: null)
+          : mapping;
+    }).toList();
+
+    _settings = _settings.copyWith(sensorDeviceMappings: updated);
+    await _settingsService.saveSettings(_settings);
+    notifyListeners();
+  }
+
   /// 天気連動ケアアラートの設定を更新し、再スケジュールする（Issue #176）。
   Future<void> updateWeatherAlertSettings({
     required bool enabled,

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -4,6 +4,7 @@ import '../providers/plant_provider.dart';
 import '../providers/note_provider.dart';
 import '../providers/sensor_log_provider.dart';
 import '../providers/settings_provider.dart';
+import '../services/sensor_auto_fetch_service.dart';
 import 'today_watering_screen.dart';
 import 'plant_list_screen.dart';
 import 'notes_list_screen.dart';
@@ -35,38 +36,27 @@ class _HomeScreenState extends State<HomeScreen> {
     });
   }
 
-  /// 自動取得間隔が経過していた場合にセンサーデータを一括取得して保存する
+  /// 自動取得間隔が経過していた場合にセンサーデータを一括取得して保存する。
+  ///
+  /// 実際の取得・間隔判定は [SensorAutoFetchService] に委譲する
+  /// （バックグラウンドタスクと共通のロジックを使用するため）。
   Future<void> _checkAndAutoFetch() async {
     final settingsProvider = context.read<SettingsProvider>();
-    final settings = settingsProvider.settings;
 
-    final intervalHours = settings.sensorFetchIntervalHours;
-    // 間隔が0（無効）またはマッピングが空の場合はスキップ
-    if (intervalHours <= 0 || settings.sensorDeviceMappings.isEmpty) return;
-
-    // 前回取得時刻を確認して間隔が経過しているか判定
-    final lastFetchStr = settings.lastSensorFetchAt;
-    if (lastFetchStr != null) {
-      final lastFetch = DateTime.tryParse(lastFetchStr);
-      if (lastFetch != null) {
-        final elapsed = DateTime.now().difference(lastFetch);
-        if (elapsed.inHours < intervalHours) return;
-      }
-    }
-
-    // 間隔が経過しているので取得を実行する
     try {
-      final sensorProvider = context.read<SensorLogProvider>();
-      final count = await sensorProvider.fetchAndSaveWithMappings(settings);
-      // 最終取得日時を更新
-      await settingsProvider.updateLastSensorFetchAt(DateTime.now());
+      final count = await SensorAutoFetchService.run(settingsProvider.settings);
+      if (!mounted) return;
+      // SensorAutoFetchService は SharedPreferences に直接保存するため、
+      // フォアグラウンドの Provider 状態にも最終取得日時等を反映させる
+      await settingsProvider.loadSettings();
 
       if (!mounted || count == 0) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('センサーデータを自動取得しました（$count件）')),
       );
-    } catch (_) {
-      // 起動時の自動取得エラーはサイレントに無視する
+    } catch (e) {
+      // エラーはサイレントに無視せずログに残す
+      debugPrint('起動時センサー自動取得エラー: $e');
     }
   }
 

--- a/lib/screens/iot_settings_screen.dart
+++ b/lib/screens/iot_settings_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../models/sensor_device_mapping.dart';
+import '../providers/location_provider.dart';
 import '../providers/plant_provider.dart';
 import '../providers/settings_provider.dart';
 import '../services/iot_service.dart';
+import '../services/sensor_auto_fetch_service.dart';
 
 /// IoT連携APIキー・デバイスマッピング・自動取得間隔の設定画面
 class IotSettingsScreen extends StatefulWidget {
@@ -66,6 +68,8 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
       );
       await provider.updateDeviceMappings(_mappings);
       await provider.updateSensorFetchInterval(_fetchIntervalHours);
+      // 間隔・マッピング変更をバックグラウンド定期タスクへ即座に反映する
+      await SensorAutoFetchService.reschedule(provider.settings);
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('設定を保存しました')),
@@ -205,6 +209,44 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     }
   }
 
+  /// 管理場所に連動しているデバイスの連動解除を確認するダイアログを表示する
+  Future<void> _showLocationUnlinkDialog(SensorDeviceMapping mapping) async {
+    final locationName =
+        context.read<LocationProvider>().getLocationName(mapping.locationId) ??
+            '不明な場所';
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('場所との連動を解除しますか？'),
+        content: Text(
+          '「${mapping.deviceName}」は現在「$locationName」に連動しており、'
+          'この場所に属する植物全員へ自動的にデータが紐づいています。\n'
+          '解除すると植物を個別に選択できるようになります。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('連動を解除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    setState(() {
+      final idx = _mappings.indexWhere((m) => m.deviceId == mapping.deviceId);
+      if (idx >= 0) {
+        _mappings[idx] = _mappings[idx].copyWith(locationId: null);
+      }
+    });
+  }
+
   /// デバイスに紐づける植物を複数選択するダイアログを表示する
   Future<void> _showPlantPickerDialog(SensorDeviceMapping mapping) async {
     final plantProvider = context.read<PlantProvider>();
@@ -271,12 +313,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     setState(() {
       final idx = _mappings.indexWhere((m) => m.deviceId == mapping.deviceId);
       if (idx >= 0) {
-        _mappings[idx] = SensorDeviceMapping(
-          deviceId: mapping.deviceId,
-          deviceName: mapping.deviceName,
-          source: mapping.source,
-          plantIds: selectedIds.toList(),
-        );
+        _mappings[idx] = _mappings[idx].copyWith(plantIds: selectedIds.toList());
       }
     });
   }
@@ -473,6 +510,21 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
 
   /// デバイス1件のマッピング行
   Widget _buildMappingTile(SensorDeviceMapping mapping) {
+    // 管理場所に連動している場合は場所名バッジを表示し、タップで連動解除ダイアログを開く
+    if (mapping.locationId != null) {
+      final locationName =
+          context.read<LocationProvider>().getLocationName(mapping.locationId) ??
+              '不明な場所';
+      return ListTile(
+        contentPadding: EdgeInsets.zero,
+        leading: const Icon(Icons.device_hub),
+        title: Text(mapping.deviceName),
+        subtitle: Text('「$locationName」に連動中（植物は自動追従）'),
+        trailing: const Icon(Icons.link),
+        onTap: () => _showLocationUnlinkDialog(mapping),
+      );
+    }
+
     final plantProvider = context.read<PlantProvider>();
     final plants = plantProvider.plants;
 
@@ -518,14 +570,15 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
-              '自動取得（アプリ起動時）',
+              '自動取得',
               style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
                   ),
             ),
             const SizedBox(height: 4),
             Text(
-              'アプリ起動時に指定した間隔が経過していれば自動でデータを取得します。',
+              'アプリを開いていなくても、指定した間隔でバックグラウンドで自動取得します。'
+              '（OSの省電力設定により実行タイミングが多少ずれる場合があります）',
               style: Theme.of(context).textTheme.bodySmall,
             ),
             const SizedBox(height: 12),

--- a/lib/screens/location_detail_screen.dart
+++ b/lib/screens/location_detail_screen.dart
@@ -1,0 +1,320 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/location.dart';
+import '../models/sensor_device_mapping.dart';
+import '../providers/location_provider.dart';
+import '../providers/plant_provider.dart';
+import '../providers/sensor_log_provider.dart';
+import '../providers/settings_provider.dart';
+import 'iot_settings_screen.dart';
+
+/// 管理場所（Location）の詳細画面。
+///
+/// この場所に属する植物・センサーを表示し、一括での紐づけ設定を行う。
+class LocationDetailScreen extends StatelessWidget {
+  const LocationDetailScreen({super.key, required this.location});
+
+  final Location location;
+
+  /// この場所に属する植物を一括選択するダイアログを表示する
+  Future<void> _showPlantPickerDialog(BuildContext context) async {
+    final plantProvider = context.read<PlantProvider>();
+    final plants = plantProvider.plants;
+
+    if (plants.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('植物が登録されていません')),
+      );
+      return;
+    }
+
+    final selectedIds = Set<String>.from(
+      plants.where((p) => p.locationId == location.id).map((p) => p.id),
+    );
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('この場所の植物を設定'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: plants.length,
+              itemBuilder: (_, i) {
+                final plant = plants[i];
+                final isSelected = selectedIds.contains(plant.id);
+                final otherLocationName = plant.locationId != null &&
+                        plant.locationId != location.id
+                    ? ctx.read<LocationProvider>().getLocationName(plant.locationId)
+                    : null;
+                return CheckboxListTile(
+                  title: Text(plant.name),
+                  subtitle: otherLocationName != null
+                      ? Text('現在「$otherLocationName」に設定中')
+                      : (plant.variety != null ? Text(plant.variety!) : null),
+                  value: isSelected,
+                  onChanged: (checked) {
+                    setDialogState(() {
+                      if (checked == true) {
+                        selectedIds.add(plant.id);
+                      } else {
+                        selectedIds.remove(plant.id);
+                      }
+                    });
+                  },
+                );
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('確定'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+    await plantProvider.assignPlantsToLocation(location.id, selectedIds);
+  }
+
+  /// この場所に紐づけるセンサーデバイスを一括選択するダイアログを表示する
+  Future<void> _showSensorPickerDialog(BuildContext context) async {
+    final settingsProvider = context.read<SettingsProvider>();
+    final mappings = settingsProvider.settings.sensorDeviceMappings;
+
+    if (mappings.isEmpty) {
+      final goToSettings = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('センサーが未登録です'),
+          content: const Text('IoTセンサー設定でデバイスを先に登録してください。'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('閉じる'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('設定画面へ'),
+            ),
+          ],
+        ),
+      );
+      if (goToSettings == true && context.mounted) {
+        await Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => const IotSettingsScreen()),
+        );
+      }
+      return;
+    }
+
+    final selectedIds = Set<String>.from(
+      mappings.where((m) => m.locationId == location.id).map((m) => m.deviceId),
+    );
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('この場所のセンサーを設定'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: mappings.length,
+              itemBuilder: (_, i) {
+                final mapping = mappings[i];
+                final isSelected = selectedIds.contains(mapping.deviceId);
+                final otherLocationName = mapping.locationId != null &&
+                        mapping.locationId != location.id
+                    ? ctx
+                        .read<LocationProvider>()
+                        .getLocationName(mapping.locationId)
+                    : null;
+                return CheckboxListTile(
+                  title: Text(mapping.deviceName),
+                  subtitle: otherLocationName != null
+                      ? Text('現在「$otherLocationName」に連動中（付け替わります）')
+                      : null,
+                  value: isSelected,
+                  onChanged: (checked) {
+                    setDialogState(() {
+                      if (checked == true) {
+                        selectedIds.add(mapping.deviceId);
+                      } else {
+                        selectedIds.remove(mapping.deviceId);
+                      }
+                    });
+                  },
+                );
+              },
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(false),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(true),
+              child: const Text('確定'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+    await settingsProvider.assignSensorsToLocation(location.id, selectedIds);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(location.name)),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildHeaderCard(context),
+          const SizedBox(height: 16),
+          _buildPlantsCard(context),
+          const SizedBox(height: 16),
+          _buildSensorsCard(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeaderCard(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: Icon(location.isOutdoor ? Icons.deck : Icons.home),
+        title: Text(location.name),
+        subtitle: Text(location.isOutdoor ? '屋外' : '屋内'),
+      ),
+    );
+  }
+
+  Widget _buildPlantsCard(BuildContext context) {
+    return Consumer<PlantProvider>(
+      builder: (context, plantProvider, _) {
+        final plants =
+            plantProvider.plants.where((p) => p.locationId == location.id).toList();
+
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'この場所の植物',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => _showPlantPickerDialog(context),
+                      icon: const Icon(Icons.edit),
+                      label: const Text('植物を設定'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (plants.isEmpty)
+                  Text(
+                    'この場所に設定された植物はありません',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  )
+                else
+                  ...plants.map((plant) => ListTile(
+                        contentPadding: EdgeInsets.zero,
+                        leading: const Icon(Icons.eco_outlined),
+                        title: Text(plant.name),
+                        subtitle: plant.variety != null ? Text(plant.variety!) : null,
+                      )),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSensorsCard(BuildContext context) {
+    return Consumer2<SettingsProvider, SensorLogProvider>(
+      builder: (context, settingsProvider, sensorLogProvider, _) {
+        final List<SensorDeviceMapping> mappings = settingsProvider
+            .settings.sensorDeviceMappings
+            .where((m) => m.locationId == location.id)
+            .toList();
+        final latestByDevice = sensorLogProvider.latestLogPerDevice;
+
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        'この場所のセンサー',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                      ),
+                    ),
+                    OutlinedButton.icon(
+                      onPressed: () => _showSensorPickerDialog(context),
+                      icon: const Icon(Icons.sensors),
+                      label: const Text('センサーを設定'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (mappings.isEmpty)
+                  Text(
+                    'この場所に紐づくセンサーはありません',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  )
+                else
+                  ...mappings.map((mapping) {
+                    final latest = latestByDevice[mapping.deviceId];
+                    final reading = latest == null
+                        ? '未取得'
+                        : [
+                            if (latest.temperature != null)
+                              '${latest.temperature!.toStringAsFixed(1)}℃',
+                            if (latest.humidity != null)
+                              '${latest.humidity!.toStringAsFixed(0)}%',
+                          ].join(' / ');
+                    return ListTile(
+                      contentPadding: EdgeInsets.zero,
+                      leading: const Icon(Icons.device_hub),
+                      title: Text(mapping.deviceName),
+                      subtitle: Text(reading),
+                    );
+                  }),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/screens/location_list_screen.dart
+++ b/lib/screens/location_list_screen.dart
@@ -3,6 +3,8 @@ import 'package:provider/provider.dart';
 import '../models/location.dart';
 import '../providers/location_provider.dart';
 import '../providers/plant_provider.dart';
+import '../providers/settings_provider.dart';
+import 'location_detail_screen.dart';
 
 /// 置き場所（Location）の一覧・追加・編集・削除画面（Issue #180）。
 class LocationListScreen extends StatelessWidget {
@@ -71,6 +73,7 @@ class LocationListScreen extends StatelessWidget {
   Future<void> _confirmDelete(BuildContext context, Location location) async {
     final locationProvider = context.read<LocationProvider>();
     final plantProvider = context.read<PlantProvider>();
+    final settingsProvider = context.read<SettingsProvider>();
 
     final confirm = await showDialog<bool>(
       context: context,
@@ -97,6 +100,7 @@ class LocationListScreen extends StatelessWidget {
     if (confirm == true) {
       await locationProvider.deleteLocation(location.id);
       await plantProvider.loadPlants();
+      await settingsProvider.clearLocationFromSensorMappings(location.id);
     }
   }
 
@@ -146,10 +150,23 @@ class LocationListScreen extends StatelessWidget {
                       location.isOutdoor ? Icons.deck : Icons.home),
                   title: Text(location.name),
                   subtitle: Text(location.isOutdoor ? '屋外' : '屋内'),
-                  onTap: () => _showEditDialog(context, location: location),
-                  trailing: IconButton(
-                    icon: const Icon(Icons.delete_outline),
-                    onPressed: () => _confirmDelete(context, location),
+                  onTap: () => Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => LocationDetailScreen(location: location),
+                    ),
+                  ),
+                  trailing: PopupMenuButton<String>(
+                    onSelected: (value) {
+                      if (value == 'edit') {
+                        _showEditDialog(context, location: location);
+                      } else if (value == 'delete') {
+                        _confirmDelete(context, location);
+                      }
+                    },
+                    itemBuilder: (context) => const [
+                      PopupMenuItem(value: 'edit', child: Text('編集')),
+                      PopupMenuItem(value: 'delete', child: Text('削除')),
+                    ],
                   ),
                 ),
               );

--- a/lib/screens/location_list_screen.dart
+++ b/lib/screens/location_list_screen.dart
@@ -30,6 +30,8 @@ class LocationListScreen extends StatelessWidget {
                   border: OutlineInputBorder(),
                   hintText: '例: リビング、ベランダ',
                 ),
+                // 保存ボタンの活性状態を即座に反映するため、入力のたびに再描画する
+                onChanged: (_) => setState(() {}),
               ),
               const SizedBox(height: 16),
               SwitchListTile(

--- a/lib/services/iot_fetch_service.dart
+++ b/lib/services/iot_fetch_service.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:uuid/uuid.dart';
+import '../models/app_settings.dart';
+import '../models/sensor_device_mapping.dart';
+import '../models/sensor_log.dart';
+import 'database_service.dart';
+import 'iot_service.dart';
+
+/// センサーデバイス-植物マッピング設定を使って一括取得・保存する処理を担うサービス。
+///
+/// [SensorLogProvider] とバックグラウンドタスクの両方から共通利用できるよう、
+/// Provider（状態管理層）に依存せず [DatabaseService] と [IotService] のみで完結させる。
+class IotFetchService {
+  final DatabaseService _db = DatabaseService();
+  final IotService _iot = IotService();
+
+  /// マッピング設定を使って全デバイスのセンサーデータを取得し、
+  /// 紐づく植物すべてにセンサーログを保存する。
+  ///
+  /// [settings] に API トークンと [SensorDeviceMapping] リストを含める。
+  /// 戻り値: 保存に成功したログ件数。
+  Future<int> fetchAndSaveWithMappings(AppSettings settings) async {
+    final mappings = settings.sensorDeviceMappings;
+    if (mappings.isEmpty) return 0;
+
+    int savedCount = 0;
+
+    // ソース別にデバイス一覧を取得（API呼び出しを最小化）
+    List<SensorData>? natureRemoDevices;
+    List<SensorData>? switchBotDevices;
+
+    // locationId が設定されたマッピングを解決するため、全植物を1回だけ取得
+    final allPlants = await _db.getAllPlants();
+
+    for (final mapping in mappings) {
+      try {
+        final List<SensorData> devices;
+        if (mapping.source == SensorSource.natureRemo) {
+          natureRemoDevices ??=
+              await _iot.fetchNatureRemoData(settings.natureRemoToken);
+          devices = natureRemoDevices;
+        } else {
+          switchBotDevices ??= await _iot.fetchSwitchBotData(
+              settings.switchBotToken, settings.switchBotSecret);
+          devices = switchBotDevices;
+        }
+
+        // マッピングのデバイスIDに一致するデバイスを探す
+        final device = devices.firstWhere(
+          (d) => d.deviceId == mapping.deviceId,
+          orElse: () =>
+              throw StateError('デバイスが見つかりません: ${mapping.deviceName}'),
+        );
+
+        // locationId が設定されている場合はその場所に属する植物全員に自動追従、
+        // 未設定の場合は個別に選択された plantIds を使用する
+        final targetPlantIds = mapping.locationId != null
+            ? allPlants
+                .where((p) => p.locationId == mapping.locationId)
+                .map((p) => p.id)
+            : mapping.plantIds;
+
+        // 紐づく植物ごとにセンサーログを保存
+        for (final plantId in targetPlantIds) {
+          final now = DateTime.now();
+          final log = SensorLog(
+            id: const Uuid().v4(),
+            plantId: plantId,
+            source: mapping.source,
+            deviceId: device.deviceId,
+            deviceName: device.deviceName,
+            temperature: device.temperature,
+            humidity: device.humidity,
+            recordedAt: now,
+            createdAt: now,
+          );
+          await _db.insertSensorLog(log);
+          savedCount++;
+        }
+      } catch (e) {
+        // 1デバイスのエラーで全体を止めない
+        debugPrint('マッピング取得エラー (${mapping.deviceName}): $e');
+      }
+    }
+
+    return savedCount;
+  }
+}

--- a/lib/services/sensor_auto_fetch_service.dart
+++ b/lib/services/sensor_auto_fetch_service.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:workmanager/workmanager.dart';
+import '../models/app_settings.dart';
+import 'iot_fetch_service.dart';
+import 'settings_service.dart';
+
+/// センサーデータの自動取得（バックグラウンド定期実行）を管理するサービス。
+///
+/// フォアグラウンド（アプリ起動時）とバックグラウンド（Workmanagerの
+/// 別Isolate）の両方から呼び出される共通ロジックを提供する。
+class SensorAutoFetchService {
+  /// Workmanagerに登録するバックグラウンドタスク名
+  static const String taskName = 'sensor_fetch_task';
+
+  /// 現在の設定に応じてバックグラウンド定期タスクを登録・解除する。
+  ///
+  /// 取得間隔が0（無効）またはデバイスマッピングが空の場合はタスクを解除する。
+  static Future<void> reschedule(AppSettings settings) async {
+    final enabled = settings.sensorFetchIntervalHours > 0 &&
+        settings.sensorDeviceMappings.isNotEmpty;
+
+    if (!enabled) {
+      await Workmanager().cancelByUniqueName(taskName);
+      return;
+    }
+
+    await Workmanager().registerPeriodicTask(
+      taskName,
+      taskName,
+      frequency: Duration(hours: settings.sensorFetchIntervalHours),
+      constraints: Constraints(
+        networkType: NetworkType.connected,
+      ),
+      existingWorkPolicy: ExistingPeriodicWorkPolicy.replace,
+    );
+  }
+
+  /// センサーデータの取得を実行し、成功したら最終取得日時を更新する。
+  ///
+  /// [forceRun] が false の場合、前回取得からの経過時間が
+  /// [AppSettings.sensorFetchIntervalHours] 未満ならスキップする
+  /// （アプリ起動のたびに毎回取得しないようにするため）。
+  /// バックグラウンドタスクからは間隔をWorkmanager自体が管理しているため
+  /// [forceRun] を true にして呼び出す。
+  ///
+  /// 戻り値: 保存できたログ件数。スキップ時は 0。
+  /// エラー時は [debugPrint] でログを残した上で例外を再スローする。
+  static Future<int> run(AppSettings settings, {bool forceRun = false}) async {
+    if (settings.sensorDeviceMappings.isEmpty) return 0;
+
+    if (!forceRun) {
+      final lastFetchStr = settings.lastSensorFetchAt;
+      if (lastFetchStr != null) {
+        final lastFetch = DateTime.tryParse(lastFetchStr);
+        if (lastFetch != null) {
+          final elapsed = DateTime.now().difference(lastFetch);
+          if (elapsed.inHours < settings.sensorFetchIntervalHours) return 0;
+        }
+      }
+    }
+
+    try {
+      final count = await IotFetchService().fetchAndSaveWithMappings(settings);
+      final settingsService = SettingsService();
+      await settingsService.saveSettings(
+        settings.copyWith(lastSensorFetchAt: DateTime.now().toIso8601String()),
+      );
+      return count;
+    } catch (e) {
+      debugPrint('センサー自動取得エラー: $e');
+      rethrow;
+    }
+  }
+}


### PR DESCRIPTION
## 概要
- 管理場所(Location)・植物(Plant)・センサー(SensorDeviceMapping)がそれぞれ独立しており、「この管理場所にこれらの植物がある」「この管理場所のセンサーはこれ」という一括紐づけができなかった問題を解消
- センサー自動取得がアプリ起動時のみのフォアグラウンド処理で、何日もアプリを開かないとデータが更新されないバグを修正

## 変更内容

### 管理場所 ⇔ 植物・センサーの一括連携
- `SensorDeviceMapping` に `locationId` を追加。管理場所に紐づけると、その場所に属する植物全員へ自動追従してセンサーログが保存されるようになる
- 管理場所詳細画面（`LocationDetailScreen`）を新設し、以下を一括設定可能に
  - 「植物を設定」: この場所に属する植物をチェックボックスで一括選択
  - 「センサーを設定」: この場所に紐づけるセンサー機器を一括選択（他の場所に既に紐づいている場合は付け替え）
  - 紐づくセンサーの最新温湿度を表示
- `PlantProvider.assignPlantsToLocation` / `SettingsProvider.assignSensorsToLocation` / `clearLocationFromSensorMappings` を追加
- IoTセンサー設定画面で、場所連動中のデバイスは「場所名」バッジ表示＋連動解除ダイアログに変更

### センサー自動取得のバグ修正（Workmanagerバックグラウンド化）
- 新規 `SensorAutoFetchService` を追加し、Workmanagerの定期バックグラウンドタスクとして登録
  - 取得間隔が有効かつセンサーマッピングが存在する場合のみ登録、それ以外は解除
  - アプリを開いていなくても指定間隔でセンサーデータを取得・保存
- 取得ロジックを `IotFetchService`（Provider非依存のservice層）に切り出し、Provider・バックグラウンドタスクの両方から共通利用
- アプリ起動時のフォアグラウンド取得は残しつつ、サイレントに握りつぶしていたエラーをログに残すよう修正

## テスト
- `flutter analyze`: エラーなし（既存の無関係なinfoのみ）
- Android実機（エミュレータ）で動作確認
  - 管理場所を作成 → 植物を一括紐づけ → 反映を確認
  - センサー未登録時の空状態ダイアログを確認
  - 取得間隔を設定 → 保存 → センサーマッピングが空の場合はバックグラウンドタスクが登録されない（解除される）ことを確認
  - SharedPreferencesにテスト用のセンサーマッピングを注入した状態でアプリを再起動し、WorkManagerのデータベースに `sensor_fetch_task`（3時間間隔・ネットワーク接続必須）が正しく登録されることを確認

## 注意事項（既知の問題・スコープ外）
- 置き場所追加ダイアログ（`location_list_screen.dart` の既存コード）で、場所名を入力しても「保存」ボタンの活性化が即座に反映されない軽微な既存バグを発見（TextFieldにonChangedが無いため）。今回のスコープ外のため未修正。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>