### PR TITLE
fix: センサー取得の認証エラー握り潰しを解消しエラー文言を改善 (#207)

### DIFF
--- a/lib/screens/iot_settings_screen.dart
+++ b/lib/screens/iot_settings_screen.dart
@@ -84,6 +84,15 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     }
   }
 
+  /// 例外オブジェクトをユーザー向けの文言に変換する。
+  ///
+  /// `Exception: ...` の接頭辞を取り除き、メッセージ本体のみを返す。
+  String _describeError(Object e) {
+    final text = e.toString();
+    const prefix = 'Exception: ';
+    return text.startsWith(prefix) ? text.substring(prefix.length) : text;
+  }
+
   Future<void> _testNatureRemo() async {
     final token = _natureRemoController.text.trim();
     if (token.isEmpty) {
@@ -107,7 +116,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('接続失敗: $e')),
+        SnackBar(content: Text('接続失敗: ${_describeError(e)}')),
       );
     } finally {
       if (mounted) setState(() => _isTestingNatureRemo = false);
@@ -138,7 +147,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('接続失敗: $e')),
+        SnackBar(content: Text('接続失敗: ${_describeError(e)}')),
       );
     } finally {
       if (mounted) setState(() => _isTestingSwitchBot = false);
@@ -162,13 +171,16 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     try {
       final iot = IotService();
       final allDevices = <SensorData>[];
+      // 各サービスの取得失敗理由を収集する。片方が失敗しても続行するが、
+      // エラーをサイレントに握り潰さず、後でユーザーに提示する。
+      final errors = <String>[];
 
       if (natureRemoToken.isNotEmpty) {
         try {
           final devices = await iot.fetchNatureRemoData(natureRemoToken);
           allDevices.addAll(devices);
         } catch (e) {
-          // NatureRemoが失敗しても SwitchBot の取得を続行
+          errors.add(_describeError(e));
         }
       }
       if (switchBotToken.isNotEmpty && switchBotSecret.isNotEmpty) {
@@ -177,17 +189,31 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
               await iot.fetchSwitchBotData(switchBotToken, switchBotSecret);
           allDevices.addAll(devices);
         } catch (e) {
-          // SwitchBotが失敗しても続行
+          errors.add(_describeError(e));
         }
       }
 
       if (!mounted) return;
 
       if (allDevices.isEmpty) {
+        // 取得0件でも、エラーがあれば「見つからない」ではなく実際の原因を出す。
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('デバイスが見つかりませんでした')),
+          SnackBar(
+            content: Text(errors.isEmpty
+                ? 'デバイスが見つかりませんでした'
+                : '取得に失敗しました: ${errors.join(' / ')}'),
+          ),
         );
         return;
+      }
+
+      // 一部のサービスだけ成功した場合は、成功分を反映しつつ失敗も知らせる。
+      if (errors.isNotEmpty) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('一部の取得に失敗しました: ${errors.join(' / ')}'),
+          ),
+        );
       }
 
       setState(() {

--- a/lib/services/iot_service.dart
+++ b/lib/services/iot_service.dart
@@ -41,6 +41,26 @@ class IotService {
 
   static const Duration _timeout = Duration(seconds: 10);
 
+  /// HTTPステータスコードをユーザー向けのエラーメッセージに変換する。
+  ///
+  /// [service] はサービス名（例: 'Nature Remo'）。認証エラーなど原因が分かる
+  /// コードは具体的な文言にし、それ以外は汎用の HTTP エラー文言を返す。
+  static String _httpErrorMessage(String service, int statusCode) {
+    switch (statusCode) {
+      case 401:
+      case 403:
+        return '$service のAPIトークンが正しくありません（HTTP $statusCode）';
+      case 429:
+        return '$service へのリクエストが多すぎます。しばらく待ってから再試行してください（HTTP $statusCode）';
+      case 500:
+      case 502:
+      case 503:
+        return '$service のサーバーが一時的に応答していません（HTTP $statusCode）';
+      default:
+        return '$service APIエラー: HTTP $statusCode';
+    }
+  }
+
   // ── Nature Remo ──────────────────────────────────────────────
 
   /// Nature Remo からすべてのデバイスのセンサーデータを取得する。
@@ -57,8 +77,7 @@ class IotService {
     ).timeout(_timeout);
 
     if (response.statusCode != 200) {
-      throw Exception(
-          'Nature Remo APIエラー: HTTP ${response.statusCode}');
+      throw Exception(_httpErrorMessage('Nature Remo', response.statusCode));
     }
 
     final List<dynamic> devices =
@@ -112,7 +131,7 @@ class IotService {
 
     if (deviceListResponse.statusCode != 200) {
       throw Exception(
-          'SwitchBot APIエラー: HTTP ${deviceListResponse.statusCode}');
+          _httpErrorMessage('SwitchBot', deviceListResponse.statusCode));
     }
 
     final deviceListBody =


### PR DESCRIPTION
## 対応 Issue

Closes #207

## 問題

「センサーを取得」が Nature Remo / SwitchBot の例外を空の catch で握り潰していたため、APIトークンが不正(401)でも「デバイスが見つかりませんでした」と表示され、原因が完全に隠れていた。CLAUDE.md「エラーをサイレントに無視しない」にも反していた。

## 変更内容

### `lib/screens/iot_settings_screen.dart`
- `_fetchDevices`: 空 catch を廃止し、各サービスの失敗理由を `errors` に収集
  - 取得0件かつエラーあり → 「取得に失敗しました: <原因>」
  - 一部成功 → 成功分を反映しつつ「一部の取得に失敗しました: <原因>」を通知
- `_describeError`: 例外文字列から `Exception: ` 接頭辞を除去するヘルパーを追加し、接続テスト2箇所＋取得で共通利用

### `lib/services/iot_service.dart`
- `_httpErrorMessage`: HTTPステータス→ユーザー向け文言の変換を追加
  - 401/403 → 「APIトークンが正しくありません（HTTP xxx）」
  - 429 → 「リクエストが多すぎます…」、5xx → 「サーバーが一時的に応答していません…」
  - その他 → 従来の「APIエラー: HTTP xxx」

## テスト手順・結果

- `flutter analyze`: error / warning 0
- `flutter test`: 6件全成功
- 実機（Medium_Phone_API_36.1）で不正トークンを入力し確認:
  - 「センサーを取得」→ **「取得に失敗しました: Nature Remo のAPIトークンが正しくありません（HTTP 401）」**（旧: 「デバイスが見つかりませんでした」）
  - 「接続テスト」→ **「接続失敗: Nature Remo のAPIトークンが正しくありません（HTTP 401）」**（旧: 「接続失敗: Exception: Nature Remo APIエラー: HTTP 401」）

🤖 Generated with [Claude Code](https://claude.com/claude-code)