### PR TITLE
fix: 植物0件時の水やり記録CTAを植物登録へ誘導する (#208)

### DIFF
--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -13,6 +13,7 @@ import '../utils/date_utils.dart';
 import '../widgets/plant_image_widget.dart';
 import 'plant_detail_screen.dart';
 import 'settings_screen.dart';
+import 'add_plant_screen.dart';
 
 class TodayWateringScreen extends StatefulWidget {
   const TodayWateringScreen({super.key});
@@ -1139,6 +1140,34 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
     );
   }
 
+  /// 植物が未登録のときに、植物登録を促すダイアログを表示する。
+  ///
+  /// 「登録する」を選ぶと植物追加画面へ遷移する。
+  Future<void> _showNoPlantsDialog() async {
+    final goToAdd = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('植物が登録されていません'),
+        content: const Text('水やりを記録するには、まず植物を登録してください。'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('植物を登録'),
+          ),
+        ],
+      ),
+    );
+    if (goToAdd == true && mounted) {
+      await Navigator.of(context).push(
+        MaterialPageRoute(builder: (context) => const AddPlantScreen()),
+      );
+    }
+  }
+
   Future<void> _showUnscheduledWateringDialog() async {
     final plantProvider = context.read<PlantProvider>();
     final settings = context.read<SettingsProvider>();
@@ -1154,11 +1183,19 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
       data.nextWateringDateCache, data.nextFertilizerDateCache, data.nextVitalizerDateCache,
     ).toSet();
 
+    // 植物が1件も登録されていない場合は、未予定判定より先に案内する。
+    // 初回起動直後の唯一の導線を押したときに手詰まりにならないようにする（Issue #208）。
+    if (sortedPlants.isEmpty) {
+      if (!context.mounted) return;
+      await _showNoPlantsDialog();
+      return;
+    }
+
     // ソート順を保持したまま未予定植物を抽出する
     final unscheduledPlants = sortedPlants
         .where((plant) => !plantsForDate.contains(plant))
         .toList();
-    
+
     if (unscheduledPlants.isEmpty) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## 対応 Issue

Closes #208

## 問題

初インストール直後、植物0件の状態で水やりログ画面の唯一のCTA「水やり記録をつける」を押すと「すべての植物が表示されています」というスナックバーが出るだけで、植物登録への導線もなく手詰まりになっていた。`unscheduledPlants.isEmpty` の分岐に「植物が0件」のケースが含まれてしまっていた。

## 変更内容

### `lib/screens/today_watering_screen.dart`
- `_showUnscheduledWateringDialog` で `sortedPlants.isEmpty`（植物未登録）を、未予定植物の判定より**先に**分岐
- `_showNoPlantsDialog` を追加。「植物が登録されていません／水やりを記録するには、まず植物を登録してください」＋「植物を登録」ボタンのダイアログを表示し、ボタンで `AddPlantScreen` へ遷移する
- 植物が存在するが全て予定済みの場合は従来どおり「すべての植物が表示されています」

## テスト手順・結果

- `flutter analyze`: error / warning 0
- `flutter test`: 6件全成功
- 実機（Medium_Phone_API_36.1）で新規インストール後に確認:
  - 植物0件で「水やり記録をつける」→ **案内ダイアログ表示**（旧: 「すべての植物が表示されています」）
  - 「植物を登録」→ **植物追加画面へ遷移**

🤖 Generated with [Claude Code](https://claude.com/claude-code)