### PR TITLE
fix: インポート後にホーム画面が更新されない不具合とインポート性能を改善 (#213, #214)

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -21,6 +21,12 @@ class PlantProvider with ChangeNotifier {
   /// 初回起動時の「空リスト一瞬表示」を防ぐために使用する。
   bool _isInitialized = false;
 
+  /// loadPlants() が完了するたびに増加するデータ世代カウンタ。
+  ///
+  /// 画面側がこの値を監視することで、他画面での植物追加・削除・編集や
+  /// バックアップからのインポート後にも自前のキャッシュを破棄できる（Issue #213）。
+  int _dataVersion = 0;
+
   final Map<String, DateTime?> _nextWateringCache = {};
 
   /// カレンダー表示用：ログが存在する日付のセット（時刻なし）
@@ -32,6 +38,9 @@ class PlantProvider with ChangeNotifier {
   /// loadPlants() が一度以上正常完了した場合 true。
   /// 初回起動ローディング中は false のままになる。
   bool get isInitialized => _isInitialized;
+
+  /// loadPlants() の完了回数。値が変わったらデータが入れ替わったことを示す。
+  int get dataVersion => _dataVersion;
 
   Set<DateTime> get logDates => _logDatesCache;
 
@@ -61,6 +70,7 @@ class PlantProvider with ChangeNotifier {
     } finally {
       _isLoading = false;
       _isInitialized = true;
+      _dataVersion++;
       notifyListeners();
     }
   }

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -40,8 +40,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
   // FutureBuilderの再実行トリガー用カウンタ（インクリメントで全キャッシュを無効化）
   int _refreshKey = 0;
 
-  // PlantProviderのisLoading前回値。loadPlants()完了検知に使用する。
-  bool _wasLoading = false;
+  // PlantProviderのdataVersion前回値。loadPlants()完了検知に使用する（Issue #213）。
+  int? _prevDataVersion;
 
   // SettingsProviderのソート設定前回値。ソート変更検知に使用する。
   PlantSortOrder? _prevSortOrder;
@@ -119,17 +119,25 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // PlantProvider の loadPlants() 完了（isLoading: true → false）を検知して
-    // キャッシュをリセットし、最新の植物データで再プリロードする。
-    // 植物追加・削除・編集が他タブで行われた場合も自動的に反映される。
-    final isLoading = context.read<PlantProvider>().isLoading;
-    if (_wasLoading && !isLoading) {
+    // PlantProvider を listen: true で購読することで、他画面での植物追加・削除・
+    // 編集やインポート完了時にも didChangeDependencies が再実行される。
+    final plantProvider = Provider.of<PlantProvider>(context);
+
+    // loadPlants() の完了を dataVersion の変化で検知してキャッシュをリセットし、
+    // 最新の植物データで再プリロードする。
+    //
+    // 以前は isLoading の true→false 遷移で検知していたが、設定画面など別画面が
+    // push された状態で loadPlants() が始まって終わるとこの画面が遷移を観測できず、
+    // 古いキャッシュが残り続けていた（Issue #213: インポート後に
+    // 「今日は水やりの予定と記録がありません」のままになる不具合）。
+    final dataVersion = plantProvider.dataVersion;
+    if (_prevDataVersion != null && _prevDataVersion != dataVersion) {
       setState(() {
         _refreshKey++;
       });
       _loadSelectedDateFirst(_selectedDate).ignore();
     }
-    _wasLoading = isLoading;
+    _prevDataVersion = dataVersion;
 
     // SettingsProvider のソート設定変更（ソート順 or カスタム順の変化）を検知して
     // キャッシュをリセットし、新しいソート順で再プリロードする。

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -210,6 +210,31 @@ class DatabaseService {
     ''');
   }
 
+  // ── 一括投入（インポート用） ─────────────────────────────────
+
+  /// 複数テーブルのレコードを1つのトランザクションでまとめて投入する。
+  ///
+  /// [rowsByTable] はテーブル名をキーに、そのテーブルへ挿入する行のリストを持つ。
+  /// キーの順序どおりに挿入するため、外部キー参照のある表は参照先を先に並べること。
+  ///
+  /// 1件ずつ [insertPlant] 等を await すると件数分の暗黙トランザクションが発生し、
+  /// 数千件の復元に数十秒〜数分かかる。バッチ化して大幅に短縮する（Issue #214）。
+  Future<void> insertRowsInBatch(
+    Map<String, List<Map<String, dynamic>>> rowsByTable,
+  ) async {
+    final db = await database;
+    await db.transaction((txn) async {
+      final batch = txn.batch();
+      for (final entry in rowsByTable.entries) {
+        for (final row in entry.value) {
+          batch.insert(entry.key, row,
+              conflictAlgorithm: ConflictAlgorithm.replace);
+        }
+      }
+      await batch.commit(noResult: true);
+    });
+  }
+
   // ── Plant CRUD ───────────────────────────────────────────────
 
   /// 植物を挙録（同一IDが存在する場合は上書き）する。

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -265,14 +265,23 @@ class ExportService {
     int noteCount = 0;
     int locationCount = 0;
 
+    // 復元対象の行をテーブルごとに組み立て、最後に1トランザクションで投入する
+    // （1件ずつ insert すると数千件で数十秒〜数分かかるため。Issue #214）。
+    // 外部キー参照のある表より参照先が先に来るよう、挿入順に並べる。
+    final locationRows = <Map<String, dynamic>>[];
+    final plantRows = <Map<String, dynamic>>[];
+    final logRows = <Map<String, dynamic>>[];
+    final noteRows = <Map<String, dynamic>>[];
+    final sensorLogRows = <Map<String, dynamic>>[];
+
     // 置き場所をインポート（植物が locationId で参照するため植物より先に復元する）
     // version 4 以降のバックアップにのみ含まれる。
     final locationsJson = data['locations'] as List<dynamic>?;
     final hasLocations = locationsJson != null;
     if (hasLocations) {
       for (final l0 in locationsJson) {
-        await _db.insertLocation(
-          Location.fromMap(Map<String, dynamic>.from(l0 as Map)),
+        locationRows.add(
+          Location.fromMap(Map<String, dynamic>.from(l0 as Map)).toMap(),
         );
         locationCount++;
       }
@@ -292,7 +301,7 @@ class ExportService {
       if (!hasLocations) {
         map['locationId'] = null;
       }
-      await _db.insertPlant(Plant.fromMap(map));
+      plantRows.add(Plant.fromMap(map).toMap());
       plantCount++;
     }
 
@@ -300,7 +309,7 @@ class ExportService {
     final logsJson = data['logs'] as List<dynamic>? ?? [];
     for (final l in logsJson) {
       final log = LogEntry.fromMap(Map<String, dynamic>.from(l as Map));
-      await _db.insertLog(log);
+      logRows.add(log.toMap());
       logCount++;
     }
 
@@ -317,7 +326,7 @@ class ExportService {
             .toList();
         map['imagePaths'] = absPaths.join('|');
       }
-      await _db.insertNote(Note.fromMap(map));
+      noteRows.add(Note.fromMap(map).toMap());
       noteCount++;
     }
 
@@ -326,9 +335,18 @@ class ExportService {
     final sensorLogsJson = data['sensorLogs'] as List<dynamic>? ?? [];
     for (final s in sensorLogsJson) {
       final log = SensorLog.fromMap(Map<String, dynamic>.from(s as Map));
-      await _db.insertSensorLog(log);
+      sensorLogRows.add(log.toMap());
       sensorLogCount++;
     }
+
+    // 参照先（locations → plants）を先に投入する順序で一括コミットする
+    await _db.insertRowsInBatch({
+      'locations': locationRows,
+      'plants': plantRows,
+      'logs': logRows,
+      'notes': noteRows,
+      'sensor_logs': sensorLogRows,
+    });
 
     return ImportResult(
       plantCount: plantCount,


### PR DESCRIPTION
## 概要
長期利用シミュレーション（ベテラン主婦ペルソナ・2年相当 / 植物15鉢・ログ2,685件）で検出した、バックアップ復元まわりの2件を修正します。

- Closes #213 — インポート後にホーム（水やりログ）画面が更新されない
- Closes #214 — インポートが遅い（ログ2,685件で約1分半）

## 変更内容

### #213 インポート後にホーム画面が更新されない
`today_watering_screen.dart` は `PlantProvider.isLoading` の **true→false 遷移** を `didChangeDependencies` で検知してキャッシュを破棄していました。しかしインポートは Navigator で push された設定画面で実行されるため、`loadPlants()` の開始〜完了が水やりログ画面のリビルドを挟まずに終わり、遷移を観測できずに古いキャッシュが残っていました。

- `PlantProvider` に `dataVersion`（`loadPlants()` 完了ごとに増加）を追加
- 画面側は `Provider.of<PlantProvider>(context)`（listen: true）で購読し、`dataVersion` の変化でキャッシュを破棄
- 従来の `isLoading` 遷移判定は `dataVersion` が完全に包含するため削除（二重リフレッシュも回避）

### #214 インポートの高速化
`ExportService._importData()` がレコードを1件ずつ `await` して個別 INSERT しており、件数分の暗黙トランザクションが発生していました。

- `DatabaseService.insertRowsInBatch()` を追加（1トランザクション + `Batch`、テーブル順に挿入して外部キー参照を保つ）
- `_importData()` は行を組み立てて最後に一括コミットする方式に変更

## テスト手順
実機（Android エミュレーター Medium_Phone_API_36.1）で、植物15鉢・ログ2,685件・ノート48件・置き場所5件のバックアップZIPを使って検証済み。

1. エクスポート → アンインストール → 再インストール → インポート
2. **復元完了までの時間**: 修正前 約90秒 → 修正後 **約3秒**
3. **復元直後にホームへ戻る**: 修正前は「今日は水やりの予定と記録がありません」のまま（要再起動）→ 修正後は再起動なしで水やり予定（Rosemary / Basil / Cherry Tomato）が表示される
4. 復元件数は修正前後とも plants=15 / logs=2685 / notes=48 / locations=5 で一致

`flutter analyze` エラーなし（既存の info 10件のみ）、`flutter test` 全6件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)