### PR TITLE
fix: 植物詳細の基本情報に置き場所と屋外設定を表示する (#215)

### DIFF
--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -7,6 +7,7 @@ import '../models/plant.dart';
 import '../models/log_entry.dart';
 import '../models/sensor_log.dart';
 import '../providers/plant_provider.dart';
+import '../providers/location_provider.dart';
 import '../providers/note_provider.dart';
 import '../providers/sensor_log_provider.dart';
 import '../providers/settings_provider.dart';
@@ -449,8 +450,23 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
           ),
         if (widget.plant.purchaseLocation != null)
           _InfoRow(label: '購入先', value: widget.plant.purchaseLocation!),
+        // 登録・編集画面で設定した置き場所を確認できるようにする（Issue #215）
+        if (_locationName != null)
+          _InfoRow(label: '置き場所', value: _locationName!),
+        if (widget.plant.isOutdoor) const _InfoRow(label: '設置', value: '屋外'),
       ],
     );
+  }
+
+  /// 植物に紐づく置き場所の名前を返す。未設定・削除済みの場合は null。
+  String? get _locationName {
+    final locationId = widget.plant.locationId;
+    if (locationId == null) return null;
+    final locations = context.watch<LocationProvider>().locations;
+    for (final location in locations) {
+      if (location.id == locationId) return location.name;
+    }
+    return null;
   }
 
   Widget _buildWateringInfoCard() {


### PR DESCRIPTION
## 概要
Closes #215

植物の登録・編集画面では「置き場所」を設定できるのに、**植物詳細画面のどのタブにも表示されていなかった**ため、設定した内容を確認するには編集画面を開き直すしかありませんでした。

植物一覧には置き場所フィルタのチップが出ているため、機能としては利用者に見えている状態で、詳細だけ抜けているのがちぐはぐでした。

## 変更内容
`lib/screens/plant_detail_screen.dart` の基本情報カードに以下を追加：

- **置き場所** — `LocationProvider` から `locationId` に対応する名前を解決して表示
- **設置** — 屋外の植物の場合に「屋外」と表示

置き場所が未設定、または参照先の置き場所が削除済みの場合は行自体を表示しません（`null` 安全）。

## テスト手順
実機（Android エミュレーター Medium_Phone_API_36.1）で確認済み。

1. 設定 → 置き場所管理 で置き場所を作成
2. 植物にその置き場所を割り当てて保存
3. 植物一覧 → 該当の植物をタップ

→ 基本情報に「置き場所 / Living」が表示されることを確認（スクリーンショットのとおり）。置き場所未設定の植物では行が出ないことも確認。

`flutter analyze` エラーなし（既存の info 10件のみ）。

## 補足
長期利用シミュレーション（ベテラン主婦ペルソナ・15鉢）で発見しました。鉢数が増えるほど「これはどこに置いていたか」を確認したくなる場面が増えます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)