### PR TITLE
fix: バックアップのファイル名を日時ベースにする (#216)

### DIFF
--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:archive/archive_io.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
@@ -17,7 +18,7 @@ import 'database_service.dart';
 ///
 /// 画像を含む ZIP アーカイブとして保存・復元する。
 /// ZIP 構成:
-///   botanote_backup_XXXXXX.zip
+///   botanote_backup_yyyyMMdd_HHmm.zip
 ///   ├── data.json          # Plants / Logs / Notes (imagePath は ZIP 内相対パス)
 ///   └── images/
 ///       ├── plants/`plant_id`.jpg
@@ -35,7 +36,10 @@ class ExportService {
   ///
   /// キャンセル時は null を返す。
   Future<String?> exportToFile() async {
-    final ts = DateTime.now().millisecondsSinceEpoch;
+    // ファイル名から取得日時が読み取れるようにする（Issue #216）。
+    // エポックミリ秒だと、ファイルピッカーで名前が省略表示された際に
+    // 複数世代のバックアップを判別できない。
+    final ts = DateFormat('yyyyMMdd_HHmm').format(DateTime.now());
     final fileName = 'botanote_backup_$ts.zip';
 
     // ZIP バイト列を生成して一時ファイルに書き出す


### PR DESCRIPTION
## 概要
Closes #216

エクスポートで生成されるバックアップのファイル名が `botanote_backup_1784379041592.zip` のように **UNIXエポックミリ秒** になっており、いつ取ったバックアップか判別できませんでした。

実際にファイルピッカーでは名前が `botanote_backu…` と省略表示され、2つのバックアップをサイズと更新日時でしか区別できない状態でした。定期的にバックアップを取る利用者ほど、復元時に「どれが最新か」が分からず困ります。

## 変更内容
`lib/services/export_service.dart`

```diff
-    final ts = DateTime.now().millisecondsSinceEpoch;
+    final ts = DateFormat('yyyyMMdd_HHmm').format(DateTime.now());
     final fileName = 'botanote_backup_$ts.zip';
```

- `intl` は既に依存に入っているためパッケージ追加なし
- クラスのドキュメントコメントの ZIP 構成例もあわせて更新

## テスト手順
実機（Android エミュレーター Medium_Phone_API_36.1）で確認済み。

設定 → データをエクスポート を実行 → 共有シートのファイル名が **`botanote_backup_20260718_0614.zip`** になっていることを確認（スクリーンショットのとおり）。

`flutter analyze` エラーなし（既存の info 10件のみ）。

## 補足
長期利用シミュレーション（ベテラン主婦ペルソナ・定期バックアップ習慣あり）で発見しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)