### PR TITLE
fix: 設定画面のバージョン表示を pubspec に合わせて 1.3.0 にする

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -272,7 +272,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           const ListTile(
             leading: Icon(Icons.info),
             title: Text('バージョン'),
-            subtitle: Text('1.2.0'),
+            subtitle: Text('1.3.0'),
           ),
           ListTile(
             leading: const Icon(Icons.code),
@@ -282,7 +282,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               showAboutDialog(
                 context: context,
                 applicationName: 'Botanote',
-                applicationVersion: '1.2.0',
+                applicationVersion: '1.3.0',
                 applicationIcon: const Icon(Icons.eco, size: 48),
                 children: const [
                   Text('植物の水やりを管理するためのアプリです。'),


### PR DESCRIPTION
## 概要
リリース準備中に発見。設定画面の「バージョン」表示と About ダイアログが `1.2.0` のハードコードのままで、`pubspec.yaml` の `1.3.0+6` と食い違っていました。

このまま配布すると、APK の実バージョンと利用者に見えるバージョンが一致せず、不具合報告時にどのビルドか特定できません。

## 変更内容
`lib/screens/settings_screen.dart` の2箇所を `1.3.0` に更新。

- `subtitle: Text('1.2.0')` → `Text('1.3.0')`
- `applicationVersion: '1.2.0'` → `'1.3.0'`

## 補足
本来は `package_info_plus` で pubspec のバージョンを実行時に取得し、二重管理をなくすべきです。今回はリリース直前のため最小修正に留めました（別途 Issue 化を推奨）。

## テスト
`flutter analyze` エラー/警告なし、`flutter test` 全6件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)