### PR TITLE
chore: アプリバージョンの二重管理をやめ pubspec から実行時取得する (#221)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -133,14 +133,36 @@ rclone lsd gdrive:
 
 いずれか失敗した場合は初回セットアップを案内して停止する。
 
-### ステップ2: バージョン番号の確認
+### ステップ2: バージョン番号の更新（必須）
 
-`pubspec.yaml` の `version:` を確認し、ユーザーに現在のバージョンを伝える。
-必要であればビルド前にバージョンを更新する（例: `1.0.0+1` → `1.0.1+2`）。
+> ⚠️ **バージョンの更新は任意ではなく必須**。過去に同じ versionName `1.3.0` で3回リリースされ、
+> ファイル名の日付でしか世代を区別できない状態になった（Issue #221）。
+> 不具合報告を受けた際にどのビルドか特定できなくなるため、必ず実施する。
+
+**1. 既存リリースと重複していないか確認する**
+
+```bash
+grep '^version:' pubspec.yaml
+rclone ls "gdrive:Botanote/releases/"
+git tag --sort=-creatordate | head -5
+```
+
+**2. `pubspec.yaml` の `version:` を必ずインクリメントする**
 
 バージョン形式: `<versionName>+<versionCode>`
-- versionName: ユーザー向け表示（例: `1.2.0`）
-- versionCode: Google Play 用の整数、毎回インクリメント（例: `3`）
+- versionName: ユーザー向け表示。バグ修正のみなら patch（`1.3.0` → `1.3.1`）、機能追加なら minor（`1.3.0` → `1.4.0`）
+- versionCode: 整数。**毎回必ず +1**（例: `6` → `7`）
+
+**3. 更新をコミットする**
+
+```bash
+git add pubspec.yaml
+git commit -m "chore: バージョンを <新バージョン> に更新"
+git push
+```
+
+> バージョン表示は `package_info_plus` で pubspec から実行時に取得しているため、
+> 画面側のコード修正は不要（Issue #221 対応済み）。
 
 ### ステップ3: リリース APK をビルドする
 
@@ -178,7 +200,21 @@ rclone ls "gdrive:Botanote/releases/"
 
 アップロード成功を確認したら、Google Drive の Web UI でファイルの共有リンクを取得してユーザーに報告する。
 
-### ステップ6: 完了報告
+### ステップ6: git tag を打つ（必須）
+
+配布した APK とソースコードを対応付けられるようにする（Issue #221）。
+不具合報告を受けた際、「どのコミットのビルドか」を tag から特定できる。
+
+```bash
+VERSION=$(grep '^version:' pubspec.yaml | sed 's/version: //' | sed 's/+.*//')
+git tag -a "v${VERSION}" -m "Release v${VERSION}"
+git push origin "v${VERSION}"
+```
+
+> 同名の tag が既に存在する場合はバージョンの更新漏れ（ステップ2）なので、
+> リリースを中止してバージョンを上げ直す。
+
+### ステップ7: 完了報告
 
 以下の形式でユーザーに報告する:
 
@@ -189,6 +225,7 @@ rclone ls "gdrive:Botanote/releases/"
 - ファイル名: botanote_<version>_<date>.apk
 - ファイルサイズ: XX MB
 - アップロード先: Google Drive / Botanote / releases /
+- git tag: v<versionName>
 - ビルド日時: <日時>
 
 Google Drive の Web UI からファイルを選択して共有リンクを取得してください。

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import '../providers/settings_provider.dart';
 import '../providers/plant_provider.dart';
 import '../providers/note_provider.dart';
@@ -22,6 +23,37 @@ class SettingsScreen extends StatefulWidget {
 class _SettingsScreenState extends State<SettingsScreen> {
   bool _isExporting = false;
   bool _isImporting = false;
+
+  /// pubspec.yaml のバージョンを実行時に取得した表示用文字列（例: '1.3.0 (6)'）。
+  /// 取得完了までは null で、その間はバージョン行を控えめに「取得中」と表示する。
+  String? _appVersion;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadAppVersion();
+  }
+
+  /// アプリのバージョンを取得して表示用に整形する（Issue #221）。
+  ///
+  /// 以前は画面側にバージョンをハードコードしていたため pubspec.yaml と
+  /// 食い違い、配布APKで実際と異なるバージョンが表示されていた。
+  Future<void> _loadAppVersion() async {
+    try {
+      final info = await PackageInfo.fromPlatform();
+      if (!mounted) return;
+      setState(() {
+        _appVersion = '${info.version} (${info.buildNumber})';
+      });
+    } catch (e) {
+      // 取得に失敗しても設定画面自体は使えるため、表示のみフォールバックする
+      debugPrint('Error loading package info: $e');
+      if (!mounted) return;
+      setState(() {
+        _appVersion = '不明';
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -269,10 +301,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
 
           // About
           _buildSectionHeader(context, 'アプリについて'),
-          const ListTile(
-            leading: Icon(Icons.info),
-            title: Text('バージョン'),
-            subtitle: Text('1.3.0'),
+          ListTile(
+            leading: const Icon(Icons.info),
+            title: const Text('バージョン'),
+            subtitle: Text(_appVersion ?? '取得中…'),
           ),
           ListTile(
             leading: const Icon(Icons.code),
@@ -282,7 +314,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
               showAboutDialog(
                 context: context,
                 applicationName: 'Botanote',
-                applicationVersion: '1.3.0',
+                applicationVersion: _appVersion ?? '',
                 applicationIcon: const Icon(Icons.eco, size: 48),
                 children: const [
                   Text('植物の水やりを管理するためのアプリです。'),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -509,6 +509,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "16eee997588c60225bda0488b6dcfac69280a6b7a3cf02c741895dd370a02968"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,9 @@ dependencies:
   # ホーム画面ウィジェット（Issue #174）
   home_widget: ^0.9.3
 
+  # アプリバージョンの実行時取得（Issue #221: バージョンの二重管理を防ぐ）
+  package_info_plus: ^8.1.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## 概要
Closes #221

アプリのバージョンが `pubspec.yaml` と `lib/screens/settings_screen.dart` の2箇所で管理されており、実際に `1.3.0+6` と `1.2.0` で食い違っていました（PR #220 で暫定的に手動で揃えた分の根本対応）。

あわせて、同じ versionName `1.3.0` で3回リリースされていた運用上の問題にも対処します。

## 変更内容

### 1. バージョンを実行時に取得する（ハードコード削除）
- `package_info_plus: ^8.1.0` を追加
- `_SettingsScreenState` に `_appVersion` を持たせ、`initState` で `PackageInfo.fromPlatform()` から取得
- 設定画面の「バージョン」と About ダイアログの両方が pubspec の値を参照するようになり、二重管理が解消
- 表示形式は `1.3.0 (6)`（versionName + versionCode）で、どのビルドか特定できるようにした
- 取得失敗時は「不明」を表示。例外はサイレントに握り潰さず `debugPrint` に残す（CLAUDE.md 規約）

### 2. リリース手順の強化（`.claude/commands/release.md`）
- ステップ2を「バージョン番号の**確認**」→「バージョン番号の**更新（必須）**」に変更。既存リリース・tag との重複確認コマンドを追加
- ステップ6として `git tag -a v<version>` の付与を追加。同名 tag が既にある場合はリリースを中止する運用を明記
- 完了報告のテンプレートに git tag を追加

## テスト手順
実機（Android エミュレーター Medium_Phone_API_36.1）で確認済み。

1. 設定 → 「アプリについて」 → バージョンが **`1.3.0 (6)`** と表示される（pubspec の `1.3.0+6` と一致）
2. 「開発情報」をタップ → About ダイアログにも **`1.3.0 (6)`** が表示される

`flutter analyze` エラー/警告なし（既存の info 10件のみ）、`flutter test` 全6件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)