### PR TITLE
fix: 5年利用シミュレーションで見つかった不具合を修正 (#223, #224, #225, #226)

### DIFF
--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -190,7 +190,10 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('削除の確認'),
-        content: Text('「${widget.plant.name}」を削除してもよろしいですか？\nすべてのログとノートも削除されます。'),
+        // ノートは削除せず紐付けを解除するだけなので、実挙動どおりに説明する（Issue #224）
+        content: Text('「${widget.plant.name}」を削除してもよろしいですか？\n'
+            'すべてのケアログも削除されます。\n'
+            'ノートは残りますが、この植物との紐付けは解除されます。'),
         actions: [
           TextButton(
             onPressed: () => Navigator.of(context).pop(false),

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -160,6 +160,7 @@ class _PlantListScreenState extends State<PlantListScreen> {
           ),
           IconButton(
             icon: const Icon(Icons.settings),
+            tooltip: '設定',
             onPressed: () {
               Navigator.of(context).push(
                 MaterialPageRoute(
@@ -245,6 +246,7 @@ class _PlantListScreenState extends State<PlantListScreen> {
         },
       ),
       floatingActionButton: FloatingActionButton(
+        tooltip: '植物を追加',
         onPressed: () {
           Navigator.of(context).push(
             MaterialPageRoute(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -584,6 +584,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (!context.mounted) return;
       await context.read<LocationProvider>().loadLocations();
       if (!context.mounted) return;
+      // ダイアログ表示中もスピナーが回り続けないよう、先に読み込み状態を解除する
+      setState(() => _isImporting = false);
       // 復元結果は見逃すと影響が大きいため、SnackBar ではなくダイアログで示す（Issue #225）
       await _showImportResultDialog(
         context,
@@ -593,6 +595,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     } catch (e) {
       debugPrint('インポートに失敗: $e');
       if (!context.mounted) return;
+      setState(() => _isImporting = false);
       await _showImportResultDialog(
         context,
         title: 'インポートできませんでした',

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -584,17 +584,50 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (!context.mounted) return;
       await context.read<LocationProvider>().loadLocations();
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('インポートしました（$result）')),
+      // 復元結果は見逃すと影響が大きいため、SnackBar ではなくダイアログで示す（Issue #225）
+      await _showImportResultDialog(
+        context,
+        title: 'インポートが完了しました',
+        message: '以下のデータを復元しました。\n\n$result',
       );
     } catch (e) {
+      debugPrint('インポートに失敗: $e');
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('インポートに失敗しました: $e')),
+      await _showImportResultDialog(
+        context,
+        title: 'インポートできませんでした',
+        message: 'バックアップファイルが壊れているか、このバージョンでは'
+            '対応していない形式の可能性があります。\n\n'
+            '既存のデータは変更されていません。'
+            '別のバックアップファイルでお試しください。',
       );
     } finally {
       if (context.mounted) setState(() => _isImporting = false);
     }
+  }
+
+  /// インポートの成否をダイアログで通知する（Issue #225）。
+  ///
+  /// バックアップ復元の結果は見逃すと影響が大きいため、
+  /// 自動で消える SnackBar ではなくユーザーが閉じるまで残す。
+  Future<void> _showImportResultDialog(
+    BuildContext context, {
+    required String title,
+    required String message,
+  }) {
+    return showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   Widget _buildSectionHeader(BuildContext context, String title) {

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -445,6 +445,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
           ),
           IconButton(
             icon: const Icon(Icons.settings),
+            tooltip: '設定',
             onPressed: () {
               Navigator.of(context).push(
                 MaterialPageRoute(

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -6,6 +6,7 @@ import '../models/log_entry.dart';
 import '../models/note.dart';
 import '../models/sensor_log.dart';
 import '../models/location.dart';
+import '../utils/seasonal_interval_utils.dart';
 
 /// SQLite データベースへのアクセスを担うサービス。
 ///
@@ -435,6 +436,9 @@ class DatabaseService {
   /// バックグラウンドIsolateから直接呼び出すためのメソッド。
   /// 各植物の最終水やりログと [wateringIntervalDays] から次回予定日を計算し、
   /// [targetDate] 以前になっている植物のみを返す。
+  ///
+  /// 間隔には季節調整（休眠期の延長）を適用する。適用しないと通知だけが
+  /// 素の間隔で発火し、画面表示の「次回予定」より早く通知が届く（Issue #223）。
   Future<List<Plant>> getPlantsDueOn(DateTime targetDate) async {
     // 全植物と全水やりログを取得
     final plants = await getAllPlants();
@@ -464,11 +468,19 @@ class DatabaseService {
         baseDate = logs.first.date;
       }
 
+      // 起算日が休眠期なら間隔を延長する（画面表示側と同じ計算に揃える）
+      final intervalDays = applySeasonalAdjustment(
+        baseIntervalDays: plant.wateringIntervalDays!,
+        seasonalAdjustmentEnabled: plant.seasonalAdjustmentEnabled,
+        dormantMultiplier: plant.dormantSeasonIntervalMultiplier,
+        referenceDate: baseDate,
+      );
+
       final nextDate = DateTime(
         baseDate.year,
         baseDate.month,
         baseDate.day,
-      ).add(Duration(days: plant.wateringIntervalDays!));
+      ).add(Duration(days: intervalDays));
 
       // 次回予定日がtargetDay以前であれば対象
       if (!nextDate.isAfter(targetDay)) {


### PR DESCRIPTION
## 概要

ベテラン主婦ペルソナで **5年分（ケアログ8,171件）** の利用シミュレーションを実施し、
発見した4件の不具合を修正しました。

Closes #223
Closes #224
Closes #225
Closes #226

## 変更内容

### #223 季節調整が水やり通知の予定判定に反映されない 🔴
`DatabaseService.getPlantsDueOn()` が素の `wateringIntervalDays` で次回日を計算していたため、
画面表示（`PlantProvider.calculateNextWateringDate()`、季節調整を適用）と食い違い、
**冬季に表示より早く水やり通知が届いていました**。

`applySeasonalAdjustment()` を通して両者の計算を揃えました。

### #224 植物削除ダイアログの文言が実挙動と異なる 🔴
「すべてのログとノートも削除されます。」→ 実際はノートは削除されず紐付けが解除されるだけ。

```
すべてのケアログも削除されます。
ノートは残りますが、この植物との紐付けは解除されます。
```

### #225 インポート失敗時のメッセージが技術的すぎる
`type 'Null' is not a subtype of type 'String' in type cast` がそのまま表示されていました。
平易な文言に変更し、約4秒で消える SnackBar から**ユーザーが閉じるまで残るダイアログ**に変更。
「既存のデータは変更されていません」も明示しました。例外の詳細は `debugPrint` に回しています。

### #226 アクセシビリティラベルの欠落
植物追加FAB・設定アイコン（植物一覧／水やりログ）に `tooltip` を追加しました。

## テスト手順（実機確認済み）

エミュレータ `Medium_Phone_API_36.1` で、間隔14日・季節調整ON（倍率1.5）・
最終水やり 2031-12-20 の植物を用意して確認しました。

### #223
| 端末日付 | 翌日 | 修正前の想定 | 修正後の実測 |
|---|---|---|---|
| 2032-01-02 | 1/3（旧計算の予定日） | 通知登録される | `plants due tomorrow = 0` ✅ |
| 2032-01-09 | 1/10（画面表示の予定日） | 通知されない | `plants due tomorrow = 1` / `smart scheduled` ✅ |

画面の「次回予定」は 1月10日 で、通知タイミングと一致するようになりました。

### #224
植物詳細 → 削除アイコン → ダイアログ文言が実挙動どおりであることを確認。

### #225
インポート実行 → 「インポートが完了しました／以下のデータを復元しました。」の
ダイアログが OK を押すまで残ることを確認。

### #226
`adb shell uiautomator dump` で `desc:設定` / `desc:植物を追加` が出力されることを確認。

### 静的解析
`flutter analyze` → エラー0件（既存の info レベル lint 10件のみ）

## 補足：シミュレーションで確認できた良好な点

- ログ8,171件でも起動時間はデータ0件時と有意差なし（3.3〜4.0秒 / デバッグビルド）
- 一覧・ケア統計・カレンダー・ノートいずれも表示崩れなし
- 日本語（和名・品種名・長文メモ）の表示崩れなし
- バックアップのファイル名が日時ベース（#216）で世代管理しやすい

🤖 Generated with [Claude Code](https://claude.com/claude-code)