### PR TITLE
fix: フォームのバリデーションエラーが入力修正後も残る不具合を修正

### DIFF
--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -131,6 +131,8 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
       ),
       body: Form(
         key: _formKey,
+        // 入力を修正した時点でエラー表示を再評価し、赤枠・エラーメッセージを残さない
+        autovalidateMode: AutovalidateMode.onUserInteraction,
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -291,6 +291,8 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
       ),
       body: Form(
         key: _formKey,
+        // 入力を修正した時点でエラー表示を再評価し、赤枠・エラーメッセージを残さない
+        autovalidateMode: AutovalidateMode.onUserInteraction,
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -351,6 +351,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
         title: const Text('観測地点を設定'),
         content: Form(
           key: formKey,
+          // 入力を修正した時点でエラー表示を再評価し、赤枠・エラーメッセージを残さない
+          autovalidateMode: AutovalidateMode.onUserInteraction,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -425,6 +427,8 @@ class _SettingsScreenState extends State<SettingsScreen> {
         title: const Text('水やり間隔を一括設定'),
         content: Form(
           key: formKey,
+          // 入力を修正した時点でエラー表示を再評価し、赤枠・エラーメッセージを残さない
+          autovalidateMode: AutovalidateMode.onUserInteraction,
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
## 概要
日中シミュレーションテスト（ペルソナ:「水やりを忘れがちな新米ズボラ」）で発見した不具合の修正です。

## 不具合
植物追加フォームで、植物名を空のまま保存を押すとエラー（赤枠＋「植物名を入力してください」）が表示されるが、その後に有効な植物名を入力しても、**保存を再度押すまでエラー表示が消えない**。

同じ問題が以下の全フォームに存在した:
- 植物の追加・編集（`add_plant_screen.dart`）
- ノートの作成・編集（`add_edit_note_screen.dart`）
- 観測地点の設定ダイアログ（`settings_screen.dart`）
- 水やり間隔の一括設定ダイアログ（`settings_screen.dart`）

## 原因
`Form` の `autovalidateMode` が未設定（デフォルト `AutovalidateMode.disabled`）のため、`_formKey.currentState.validate()` を呼ぶ保存押下時にしかバリデーションが再評価されず、入力を修正してもエラー表示が残っていた。

## 修正内容
各 `Form` に `autovalidateMode: AutovalidateMode.onUserInteraction` を付与。一度エラーが出た後は、入力修正のたびに再評価され、有効な値になった時点でエラー表示が消えるようにした。

## テスト手順
1. 植物一覧 → ＋ → 植物名を空のまま「保存」→ 赤枠とエラーメッセージが表示される
2. 植物名フィールドに文字を入力 → **赤枠が緑枠に変わり、エラーメッセージが消える**（修正前は残っていた）

実機（エミュレーター Medium_Phone_API_36.1）で確認済み。

## 影響範囲
- `flutter analyze`: 新規エラーなし（既存の Radio 非推奨 info のみ）
- 変更は各 Form への1行追加のみで、バリデーションロジック自体は不変

🤖 Generated with [Claude Code](https://claude.com/claude-code)