### PR TITLE
fix: 「N回に1回」肥料・活力剤で施肥忘れの超過状態が隠れる不具合を修正

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -467,8 +467,13 @@ class PlantProvider with ChangeNotifier {
       // 現在のグループ内の残り回数を計算（N回ごとの次の区切りを求める）
       // 例: N=3, 水やり7回の場合 → 7%3=1 → 残り2回（次の区切りは9回目）
       final completedInCurrentGroup = wateringsAfter.length % n;
+      // completedInCurrentGroup == 0 は 2 パターンある:
+      //   ・水やり実績なし（起算後まだ0回）→ 次のN回目が期限（remaining = n）
+      //   ・水やりが N の倍数に到達済み（例: N=3 で3回）→ 施肥期限に到達済みで
+      //     期限は最後の水やり日（remaining = 0）。ここを n にすると施肥忘れが
+      //     Nサイクル先に飛び、超過状態が隠れてしまう。
       final remaining = completedInCurrentGroup == 0
-          ? n // ちょうど区切り済み → 次のN回目
+          ? (wateringsAfter.isEmpty ? n : 0)
           : n - completedInCurrentGroup;
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
@@ -545,8 +550,13 @@ class PlantProvider with ChangeNotifier {
       // 現在のグループ内の残り回数を計算（N回ごとの次の区切りを求める）
       // 例: N=3, 水やり7回の場合 → 7%3=1 → 残り2回（次の区切りは9回目）
       final completedInCurrentGroup = wateringsAfter.length % n;
+      // completedInCurrentGroup == 0 は 2 パターンある:
+      //   ・水やり実績なし（起算後まだ0回）→ 次のN回目が期限（remaining = n）
+      //   ・水やりが N の倍数に到達済み（例: N=3 で3回）→ 期限に到達済みで
+      //     期限は最後の水やり日（remaining = 0）。ここを n にすると付与忘れが
+      //     Nサイクル先に飛び、超過状態が隠れてしまう。
       final remaining = completedInCurrentGroup == 0
-          ? n // ちょうど区切り済み → 次のN回目
+          ? (wateringsAfter.isEmpty ? n : 0)
           : n - completedInCurrentGroup;
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date


### PR DESCRIPTION
## 概要
日中シミュレーションテスト（ペルソナ:「ガーデニング歴20年のベテラン主婦」＝間隔設定を細かく使う層）で発見した不具合の修正です。

## 不具合
肥料/活力剤を「水やりN回に1回」で設定した植物で、最終付与日以降の水やり回数が **N の倍数**（例: N=3 で3回水やり・未付与）に達すると、次回付与予定日が**丸々Nサイクル先に飛ぶ**。結果、施肥/活力剤の期限に到達・超過しても「当分不要」と表示され、**付与忘れ（超過状態）が隠れる**。

### 原因
`calculateNextFertilizerDate` / `calculateNextVitalizerDate`（`lib/providers/plant_provider.dart`）で、
```dart
final completedInCurrentGroup = wateringsAfter.length % n;
final remaining = completedInCurrentGroup == 0
    ? n              // ← 水やりN回済み(期限到達)も 0 になるため n 扱いになっていた
    : n - completedInCurrentGroup;
```
`completedInCurrentGroup == 0` には「起算後まだ0回」と「Nの倍数に到達済み」の2ケースがあるが、両方を `remaining = n`（Nサイクル先）にしていた。

## 修正
2ケースを分離:
- 水やり実績なし（`wateringsAfter.isEmpty`）→ `remaining = n`（次のN回目が期限）
- Nの倍数に到達済み → `remaining = 0`（期限＝最後の水やり日 → 期限到達/超過として表示）

肥料・活力剤の両メソッドに同一の修正を適用。

## 再現手順
1. 植物に「水やり間隔（日数）」＋「肥料: 水やり3回に1回」を設定
2. 肥料を付与せず水やりを3回記録
3. 修正前: 肥料予定日が「3サイクル先」になり超過が見えない／修正後: 「期限到達（最後の水やり日）」として表示される

## テスト
- `flutter analyze`: 対象ファイル No issues
- `flutter test`: 全6件成功
- ⚠️ 本メソッドは DB 依存（`sqflite`）で、現状のテスト基盤（`sqflite_common_ffi` 未導入）では自動テストを追加していません。ロジック分岐の追加のみで、`wateringsAfter.isEmpty` の既存経路（起算後0回）は挙動不変です。

## レビュー観点
コア（付与スケジュール）の挙動変更のため、意図した仕様（期限超過を隠さない）で問題ないかご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)