### PR TITLE
fix: ユーザー向けエラー文言に生の例外を直出ししないよう共通化

### DIFF
--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -7,6 +7,7 @@ import '../providers/settings_provider.dart';
 import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/claude_share_service.dart';
+import '../utils/error_utils.dart';
 
 class AddEditNoteScreen extends StatefulWidget {
   final Note? note;
@@ -264,7 +265,7 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
         ),
       );
     } catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('共有に失敗しました: $e')));
+      messenger.showSnackBar(SnackBar(content: Text('共有に失敗しました: ${describeError(e)}')));
     }
   }
 

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -7,6 +7,7 @@ import '../providers/location_provider.dart';
 import '../models/plant.dart';
 import '../services/claude_share_service.dart';
 import '../widgets/plant_image_widget.dart';
+import '../utils/error_utils.dart';
 
 class AddPlantScreen extends StatefulWidget {
   final Plant? plant;
@@ -131,7 +132,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
       setState(() => _imagePath = cropResult.filePath);
     } catch (e) {
       scaffoldMessenger.showSnackBar(
-        SnackBar(content: Text('画像の取得に失敗しました: $e')),
+        SnackBar(content: Text('画像の取得に失敗しました: ${describeError(e)}')),
       );
     }
   }
@@ -151,7 +152,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('再トリミングに失敗しました: $e')),
+          SnackBar(content: Text('再トリミングに失敗しました: ${describeError(e)}')),
         );
       }
     }
@@ -177,7 +178,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
         ),
       );
     } catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('共有に失敗しました: $e')));
+      messenger.showSnackBar(SnackBar(content: Text('共有に失敗しました: ${describeError(e)}')));
     }
   }
 
@@ -249,7 +250,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('エラーが発生しました: $e')),
+          SnackBar(content: Text('エラーが発生しました: ${describeError(e)}')),
         );
       }
     } finally {

--- a/lib/screens/image_crop_screen.dart
+++ b/lib/screens/image_crop_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:crop_your_image/crop_your_image.dart';
 import 'package:path/path.dart' as path;
 import 'package:path_provider/path_provider.dart';
+import '../utils/error_utils.dart';
 
 /// トリミング結果のファイルパスを保持するクラス。
 class CropResult {
@@ -47,7 +48,7 @@ class _ImageCropScreenState extends State<ImageCropScreen> {
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('保存に失敗しました: $e')));
+            .showSnackBar(SnackBar(content: Text('保存に失敗しました: ${describeError(e)}')));
       }
     } finally {
       if (mounted) setState(() => _isCropping = false);

--- a/lib/screens/iot_settings_screen.dart
+++ b/lib/screens/iot_settings_screen.dart
@@ -6,6 +6,7 @@ import '../providers/plant_provider.dart';
 import '../providers/settings_provider.dart';
 import '../services/iot_service.dart';
 import '../services/sensor_auto_fetch_service.dart';
+import '../utils/error_utils.dart';
 
 /// IoT連携APIキー・デバイスマッピング・自動取得間隔の設定画面
 class IotSettingsScreen extends StatefulWidget {
@@ -77,20 +78,11 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('保存に失敗しました: $e')),
+        SnackBar(content: Text('保存に失敗しました: ${describeError(e)}')),
       );
     } finally {
       if (mounted) setState(() => _isSaving = false);
     }
-  }
-
-  /// 例外オブジェクトをユーザー向けの文言に変換する。
-  ///
-  /// `Exception: ...` の接頭辞を取り除き、メッセージ本体のみを返す。
-  String _describeError(Object e) {
-    final text = e.toString();
-    const prefix = 'Exception: ';
-    return text.startsWith(prefix) ? text.substring(prefix.length) : text;
   }
 
   Future<void> _testNatureRemo() async {
@@ -116,7 +108,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('接続失敗: ${_describeError(e)}')),
+        SnackBar(content: Text('接続失敗: ${describeError(e)}')),
       );
     } finally {
       if (mounted) setState(() => _isTestingNatureRemo = false);
@@ -147,7 +139,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('接続失敗: ${_describeError(e)}')),
+        SnackBar(content: Text('接続失敗: ${describeError(e)}')),
       );
     } finally {
       if (mounted) setState(() => _isTestingSwitchBot = false);
@@ -180,7 +172,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
           final devices = await iot.fetchNatureRemoData(natureRemoToken);
           allDevices.addAll(devices);
         } catch (e) {
-          errors.add(_describeError(e));
+          errors.add(describeError(e));
         }
       }
       if (switchBotToken.isNotEmpty && switchBotSecret.isNotEmpty) {
@@ -189,7 +181,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
               await iot.fetchSwitchBotData(switchBotToken, switchBotSecret);
           allDevices.addAll(devices);
         } catch (e) {
-          errors.add(_describeError(e));
+          errors.add(describeError(e));
         }
       }
 

--- a/lib/screens/light_meter_screen.dart
+++ b/lib/screens/light_meter_screen.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import '../services/light_meter_service.dart';
+import '../utils/error_utils.dart';
 
 /// カメラで撮影した写真から明るさの目安を測定する画面（Issue #181）。
 class LightMeterScreen extends StatefulWidget {
@@ -38,7 +39,7 @@ class _LightMeterScreenState extends State<LightMeterScreen> {
       }
       setState(() => _result = result);
     } catch (e) {
-      messenger.showSnackBar(SnackBar(content: Text('撮影に失敗しました: $e')));
+      messenger.showSnackBar(SnackBar(content: Text('撮影に失敗しました: ${describeError(e)}')));
     } finally {
       if (mounted) setState(() => _isProcessing = false);
     }

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -18,6 +18,7 @@ import 'add_edit_note_screen.dart';
 import 'iot_settings_screen.dart';
 import 'note_detail_screen.dart';
 import 'plant_growth_timeline_screen.dart';
+import '../utils/error_utils.dart';
 
 /// SliverPersistentHeaderDelegate: TabBarを固定表示するためのデリゲート
 class _StickyTabBarDelegate extends SliverPersistentHeaderDelegate {
@@ -619,7 +620,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('記録に失敗しました: $e')),
+          SnackBar(content: Text('記録に失敗しました: ${describeError(e)}')),
         );
       }
     }
@@ -1038,7 +1039,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('取得エラー: $e')),
+        SnackBar(content: Text('取得エラー: ${describeError(e)}')),
       );
     } finally {
       if (mounted) {

--- a/lib/screens/sensor_log_screen.dart
+++ b/lib/screens/sensor_log_screen.dart
@@ -6,6 +6,7 @@ import '../models/sensor_log.dart';
 import '../providers/sensor_log_provider.dart';
 import '../providers/settings_provider.dart';
 import 'iot_settings_screen.dart';
+import '../utils/error_utils.dart';
 
 /// センサー環境ダッシュボード画面
 ///
@@ -50,7 +51,7 @@ class _SensorLogScreenState extends State<SensorLogScreen> {
     } catch (e) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('取得に失敗しました: $e')),
+        SnackBar(content: Text('取得に失敗しました: ${describeError(e)}')),
       );
     } finally {
       if (mounted) setState(() => _isFetching = false);

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -12,6 +12,7 @@ import 'iot_settings_screen.dart';
 import 'light_meter_screen.dart';
 import 'care_stats_screen.dart';
 import 'location_list_screen.dart';
+import '../utils/error_utils.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -481,7 +482,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     } catch (e) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('更新に失敗しました: $e')),
+        SnackBar(content: Text('更新に失敗しました: ${describeError(e)}')),
       );
     }
   }
@@ -550,7 +551,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     } catch (e) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('更新に失敗しました: $e')),
+        SnackBar(content: Text('更新に失敗しました: ${describeError(e)}')),
       );
     }
   }
@@ -571,7 +572,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     } catch (e) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('エクスポートに失敗しました: $e')),
+        SnackBar(content: Text('エクスポートに失敗しました: ${describeError(e)}')),
       );
     } finally {
       if (context.mounted) setState(() => _isExporting = false);

--- a/lib/utils/error_utils.dart
+++ b/lib/utils/error_utils.dart
@@ -1,0 +1,22 @@
+// 例外オブジェクトをユーザー向けの文言に整形するユーティリティ。
+
+/// 例外 [e] をユーザー表示用の文字列に整形して返す。
+///
+/// `Object.toString()` の結果には `Exception: ` などの実装都合のプレフィックスが
+/// 付くことがあり、そのままユーザーに見せると分かりにくい。ここで既知の
+/// プレフィックスを取り除き、読みやすい文言に整える。
+///
+/// SnackBar 等でエラー内容をユーザーに提示する際は、生の `$e` を埋め込まず
+/// 本関数を通すこと。
+String describeError(Object e) {
+  var text = e.toString();
+  // よくある実装都合のプレフィックスを除去する。
+  const prefixes = ['Exception: ', 'FormatException: ', 'Error: '];
+  for (final prefix in prefixes) {
+    if (text.startsWith(prefix)) {
+      text = text.substring(prefix.length);
+      break;
+    }
+  }
+  return text;
+}


### PR DESCRIPTION
## 概要
日中シミュレーションテスト（ペルソナ:「IoT・ガジェット好きエンジニア」＝エラー時の原因表示にこだわる層、ダークモードで検証）で発見した品質問題の修正です。

## 問題
保存・エクスポート・画像取得・接続テスト失敗などの `SnackBar` で、例外オブジェクトを `$e` のまま埋め込んでいた。
- 例: 「保存に失敗しました: **Exception: ...**」のように、実装都合の `Exception: ` プレフィックスや内部詳細がそのままユーザーに露出。
- pr-review チェックリスト項目「ユーザー向けエラー文言に例外オブジェクト（`$e`）をそのまま埋め込んでいないか」に該当。
- `iot_settings_screen.dart` には整形用ローカル関数 `_describeError` があり接続テスト等では使われていたが、保存パスや他画面は未整形で不統一だった。

対象: 9ファイル・計14箇所の user-facing SnackBar。

## 修正
- `lib/utils/error_utils.dart` に `describeError(Object e)` を新設（`Exception: ` 等の既知プレフィックスを除去）。
- ユーザー向け各 SnackBar を `describeError(e)` 経由に統一。
- `iot_settings_screen.dart` のローカル `_describeError` を共通関数へ置き換え（重複解消）。
- **開発者向けの `debugPrint` は原因調査のため生の例外（`$e`）を維持**（誤って整形しないよう明示的に除外）。

## 影響範囲・リスク
- 変更はエラーメッセージの**文言整形のみ**でロジック・制御フローの変更なし（低リスク）。
- `flutter analyze`: 新規 error/warning なし
- `flutter test`: 全6件成功
- デバッグビルド・実機起動スモークテスト成功（ダークモード）

🤖 Generated with [Claude Code](https://claude.com/claude-code)