### PR TITLE
fix: 植物削除時にケアログが孤児として残る不具合を修正

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -35,7 +35,7 @@ class DatabaseService {
 
     return await openDatabase(
       newPath,
-      version: 7,
+      version: 8,
       onCreate: _onCreate,
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -131,6 +131,14 @@ class DatabaseService {
           } catch (_) {
             // 既にカラムが存在する場合は無視
           }
+        }
+        if (oldVersion < 8) {
+          // sqflite は既定で PRAGMA foreign_keys=ON を設定しないため、logs テーブルの
+          // `ON DELETE CASCADE` が効かず、植物を削除してもそのログが孤児として
+          // 残り続けていた（DB肥大・カレンダーの幽霊ログ日付・バックアップ汚染）。
+          // 参照先の植物が存在しない孤児ログをここで一括削除する。
+          await db.execute(
+              'DELETE FROM logs WHERE plantId NOT IN (SELECT id FROM plants)');
         }
       },
     );
@@ -300,11 +308,13 @@ class DatabaseService {
   /// 指定IDの植物を削除する（関連ログは CASCADE で自動削除）。
   Future<void> deletePlant(String id) async {
     final db = await database;
-    await db.delete(
-      'plants',
-      where: 'id = ?',
-      whereArgs: [id],
-    );
+    // logs テーブルには `ON DELETE CASCADE` が宣言されているが、sqflite は既定で
+    // PRAGMA foreign_keys=ON を設定しないためカスケードが発火しない。植物削除時に
+    // ログが孤児として残らないよう、同一トランザクションで明示的に削除する。
+    await db.transaction((txn) async {
+      await txn.delete('logs', where: 'plantId = ?', whereArgs: [id]);
+      await txn.delete('plants', where: 'id = ?', whereArgs: [id]);
+    });
   }
 
   // ── Log CRUD ─────────────────────────────────────────────────


### PR DESCRIPTION
## 概要
日中シミュレーションテスト（植物の入れ替えが多い長期利用シナリオ）で発見した**データ整合性の不具合**の修正です。

## 不具合
`logs` テーブルには次のFKが宣言されている:
```sql
FOREIGN KEY (plantId) REFERENCES plants(id) ON DELETE CASCADE
```
しかし **sqflite は接続時に `PRAGMA foreign_keys=ON` を設定しない**ため、この `ON DELETE CASCADE` が発火しない。結果、植物を削除してもそのケアログが `logs` テーブルに**孤児として残り続ける**。

削除確認ダイアログは「すべてのケアログも削除されます」と案内しているが、実際には削除されていなかった。

### 影響
- 長期利用・植物の入れ替えで **DBが肥大化**
- カレンダーの `getAllLogs()` が孤児ログを含むため**幽霊ログ日付が表示され得る**
- バックアップ（エクスポート）に孤児ログが混入

### 実証
取り出したDBを host sqlite3 で検証:
- `PRAGMA foreign_keys=OFF`（アプリの既定）→ 植物削除後もログが**残存**
- `PRAGMA foreign_keys=ON` → ログが**0件**（本来の CASCADE 挙動）
- アプリの接続既定も `PRAGMA foreign_keys=0` であることを確認

## 修正
- **`deletePlant`**: FK に依存せず、同一トランザクションで対象植物のログを明示的に削除してから植物を削除。
- **マイグレーション（v7→v8）**: 既存の孤児ログ（参照先の植物が存在しないログ）を一括削除。

> グローバルに `foreign_keys=ON` にする案は、孤児ログを含む既存バックアップのインポートがFK違反で失敗し得るため採らず、影響範囲の小さい明示削除方式にしています。

## テスト
- 実機（エミュレーター）: ログ1件を持つ Pothos を削除 → `plants=0 / logs=0 / 孤児=0` を確認
- `flutter analyze`: 対象ファイル No issues
- `flutter test`: 全6件成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)