### PR TITLE
fix: 植物詳細のログ空状態の誤字を修正（肝料→肥料）

### DIFF
--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -566,7 +566,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                   ),
                   const SizedBox(height: 8),
                   Text(
-                    '「記録」ボタンから水やり・肝料・活力剤を記録できます',
+                    '「記録」ボタンから水やり・肥料・活力剤を記録できます',
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                 ],


### PR DESCRIPTION
## 概要
日中シミュレーションテストで発見した誤字の修正です。

## 内容
植物詳細画面「ログ」タブの空状態メッセージ（`plant_detail_screen.dart:569`）で、「肥料」が **「肝料」**（肝臓の肝）と誤変換されていました。

- 誤: `「記録」ボタンから水やり・肝料・活力剤を記録できます`
- 正: `「記録」ボタンから水やり・肥料・活力剤を記録できます`

他画面はすべて「肥料」で統一されており、ここだけの誤字でした。

## テスト
- `flutter analyze`: No issues
- 文言のみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)