### PR TITLE
feat: シミュレーションで見つかったUX課題を改善 (#233, #234, #235, #236)

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -44,6 +44,24 @@ class PlantProvider with ChangeNotifier {
 
   Set<DateTime> get logDates => _logDatesCache;
 
+  /// 指定した植物の次回水やり予定日をキャッシュから返す（同期・DBアクセスなし）。
+  ///
+  /// [loadPlants] 完了後に有効。間隔未設定などで算出できない場合は null。
+  /// 一覧画面などで各植物の水やり状態をまとめて表示する用途に使う（Issue #233）。
+  DateTime? cachedNextWateringDate(String plantId) => _nextWateringCache[plantId];
+
+  /// 未来を含む「いずれかの植物の次回水やり予定日」の集合を返す（時刻なし）。
+  ///
+  /// カレンダーで予定日にマーカーを出す用途に使う（Issue #234）。
+  Set<DateTime> get scheduledWateringDates {
+    final result = <DateTime>{};
+    for (final next in _nextWateringCache.values) {
+      if (next == null) continue;
+      result.add(DateTime(next.year, next.month, next.day));
+    }
+    return result;
+  }
+
   /// 植物一覧をストレージから再読み込み、キャッシュを更新する。
   Future<void> loadPlants() async {
     _isLoading = true;

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -647,6 +647,17 @@ class _WateringIntervalDialogState extends State<_WateringIntervalDialog> {
     _days = widget.initialValue ?? 3;
   }
 
+  /// 水やり間隔の下限・上限（日）。上限は多肉・サボテン等の長い間隔にも対応（Issue #235）。
+  static const int _minDays = 1;
+  static const int _maxDays = 90;
+
+  /// 日数を範囲内に丸めて更新する。
+  void _setDays(int value) {
+    setState(() {
+      _days = value.clamp(_minDays, _maxDays);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -654,18 +665,38 @@ class _WateringIntervalDialogState extends State<_WateringIntervalDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Text('$_days日ごと', style: Theme.of(context).textTheme.headlineSmall),
+          // ステッパーで厳密に日数を指定できるようにする（スライダーだけでは
+          // 狙った日数に合わせにくいため。Issue #235）。
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.remove_circle_outline),
+                tooltip: '1日減らす',
+                onPressed: _days > _minDays ? () => _setDays(_days - 1) : null,
+              ),
+              SizedBox(
+                width: 120,
+                child: Text(
+                  '$_days日ごと',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add_circle_outline),
+                tooltip: '1日増やす',
+                onPressed: _days < _maxDays ? () => _setDays(_days + 1) : null,
+              ),
+            ],
+          ),
           Slider(
             value: _days.toDouble(),
-            min: 1,
-            max: 30,
-            divisions: 29,
+            min: _minDays.toDouble(),
+            max: _maxDays.toDouble(),
+            divisions: _maxDays - _minDays,
             label: '$_days日',
-            onChanged: (value) {
-              setState(() {
-                _days = value.toInt();
-              });
-            },
+            onChanged: (value) => _setDays(value.toInt()),
           ),
         ],
       ),

--- a/lib/screens/care_stats_screen.dart
+++ b/lib/screens/care_stats_screen.dart
@@ -167,6 +167,19 @@ class _CareStatsScreenState extends State<CareStatsScreen> {
     );
   }
 
+  /// 月別グラフの横軸ラベルを組み立てる（Issue #236）。
+  ///
+  /// 直近6ヶ月が年を跨ぐと「1月」だけでは何年か分からないため、
+  /// 先頭の月と、年の変わり目（1月）には西暦下2桁を添える。
+  String _monthLabel(DateTime month, DateTime? previous) {
+    final isYearBoundary = previous == null || month.year != previous.year;
+    if (isYearBoundary) {
+      final yy = (month.year % 100).toString().padLeft(2, '0');
+      return "'$yy/${month.month}月";
+    }
+    return '${month.month}月';
+  }
+
   Widget _buildMonthlyChart(BuildContext context) {
     final monthly = _monthlyCounts();
     final maxCount = monthly.map((e) => e.value).fold(0, (a, b) => a > b ? a : b);
@@ -176,7 +189,10 @@ class _CareStatsScreenState extends State<CareStatsScreen> {
       height: chartHeight + 40,
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.end,
-        children: monthly.map((entry) {
+        children: monthly.asMap().entries.map((indexed) {
+          final i = indexed.key;
+          final entry = indexed.value;
+          final prevMonth = i > 0 ? monthly[i - 1].key : null;
           final barHeight =
               maxCount == 0 ? 0.0 : chartHeight * entry.value / maxCount;
           return Expanded(
@@ -198,7 +214,7 @@ class _CareStatsScreenState extends State<CareStatsScreen> {
                 ),
                 const SizedBox(height: 4),
                 Text(
-                  '${entry.key.month}月',
+                  _monthLabel(entry.key, prevMonth),
                   style: Theme.of(context).textTheme.bodySmall,
                 ),
               ],

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -5,6 +5,7 @@ import '../providers/settings_provider.dart';
 import '../providers/location_provider.dart';
 import '../models/app_settings.dart';
 import '../models/plant.dart';
+import '../utils/date_utils.dart';
 import '../widgets/plant_image_widget.dart';
 import 'add_plant_screen.dart';
 import 'plant_detail_screen.dart';
@@ -326,10 +327,25 @@ class _PlantListScreenState extends State<PlantListScreen> {
       child: ListTile(
         leading: PlantImageWidget(plant: plant),
         title: Text(plant.name),
-        subtitle: plant.variety != null ? Text(plant.variety!) : null,
+        subtitle: _buildListSubtitle(plant),
         trailing: const Icon(Icons.drag_handle),
         onTap: () => _navigateToDetail(plant),
       ),
+    );
+  }
+
+  /// 一覧行の subtitle（品種名＋水やり状態）を組み立てる（Issue #233）。
+  ///
+  /// 品種名・水やり状態のどちらも無い場合は null を返す。
+  Widget? _buildListSubtitle(Plant plant) {
+    final rows = <Widget>[
+      if (plant.variety != null) Text(plant.variety!),
+      _WateringStatusText(plant: plant),
+    ];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: rows,
     );
   }
 
@@ -414,9 +430,14 @@ class _PlantListTile extends StatelessWidget {
       child: ListTile(
         leading: PlantImageWidget(plant: plant),
         title: Text(plant.name),
-        subtitle: plant.variety != null
-            ? Text(plant.variety!)
-            : null,
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (plant.variety != null) Text(plant.variety!),
+            _WateringStatusText(plant: plant),
+          ],
+        ),
         onTap: () => _navigateToDetail(context, plant),
       ),
     );
@@ -493,6 +514,8 @@ class _PlantGridCard extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                       ),
                     ],
+                    const SizedBox(height: 2),
+                    _WateringStatusText(plant: plant),
                   ],
                 ),
               ),
@@ -500,6 +523,46 @@ class _PlantGridCard extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// 植物の次回水やり状態を表す小さなテキスト（Issue #233）。
+///
+/// 水やり間隔が未設定などで予定日を算出できない植物では何も表示しない。
+/// 予定超過（今日以前）の場合は error 色で強調する。
+class _WateringStatusText extends StatelessWidget {
+  final Plant plant;
+
+  const _WateringStatusText({required this.plant});
+
+  @override
+  Widget build(BuildContext context) {
+    // 次回水やり日は loadPlants() 完了後にキャッシュ済みのため read で十分。
+    final next = context.read<PlantProvider>().cachedNextWateringDate(plant.id);
+    if (next == null) return const SizedBox.shrink();
+
+    final today = AppDateUtils.getDateOnly(DateTime.now());
+    final nextDay = AppDateUtils.getDateOnly(next);
+    final isOverdue = !nextDay.isAfter(today);
+    final color = isOverdue
+        ? Theme.of(context).colorScheme.error
+        : Theme.of(context).colorScheme.primary;
+
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(Icons.water_drop, size: 13, color: color),
+        const SizedBox(width: 2),
+        Flexible(
+          child: Text(
+            AppDateUtils.formatDateDifference(next),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(color: color),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -580,6 +580,9 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
     return Consumer<PlantProvider>(
       builder: (context, plantProvider, _) {
         final logDates = plantProvider.logDates;
+        // 未来を含む水やり予定日（Issue #234）。過去ログのドットとは色を分けて表示する。
+        final scheduledDates = plantProvider.scheduledWateringDates;
+        final today = AppDateUtils.getDateOnly(DateTime.now());
 
         return Column(
           children: [
@@ -602,15 +605,32 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
                   _focusedDay = focusedDay;
                 });
               },
-              eventLoader: (day) {
-                final d = DateTime(day.year, day.month, day.day);
-                return logDates.contains(d) ? [true] : [];
-              },
+              calendarBuilders: CalendarBuilders(
+                // 過去ログのある日（primary）と、未来の水やり予定日（secondary）で
+                // マーカーを塗り分ける。両方に該当する場合は実績（過去ログ）を優先。
+                markerBuilder: (context, day, events) {
+                  final d = AppDateUtils.getDateOnly(day);
+                  final hasLog = logDates.contains(d);
+                  // 予定日マーカーは「今日より後」だけに出す。今日以前は実績側で扱う。
+                  final isScheduled =
+                      d.isAfter(today) && scheduledDates.contains(d);
+                  if (!hasLog && !isScheduled) return null;
+                  final color = hasLog
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).colorScheme.tertiary;
+                  return Align(
+                    alignment: Alignment.bottomCenter,
+                    child: Container(
+                      width: 6,
+                      height: 6,
+                      margin: const EdgeInsets.only(bottom: 6),
+                      decoration:
+                          BoxDecoration(color: color, shape: BoxShape.circle),
+                    ),
+                  );
+                },
+              ),
               calendarStyle: CalendarStyle(
-                markerDecoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary,
-                  shape: BoxShape.circle,
-                ),
                 selectedDecoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.primary,
                   shape: BoxShape.circle,
@@ -625,6 +645,20 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
                 titleCentered: true,
               ),
               locale: 'ja_JP',
+            ),
+            // 凡例：実績（過去ログ）と予定（未来の水やり）の色を説明する
+            Padding(
+              padding: const EdgeInsets.only(top: 4, bottom: 2),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  _CalendarLegendDot(
+                      color: Theme.of(context).colorScheme.primary, label: '記録'),
+                  const SizedBox(width: 16),
+                  _CalendarLegendDot(
+                      color: Theme.of(context).colorScheme.tertiary, label: '予定'),
+                ],
+              ),
             ),
             const Divider(height: 1),
             Expanded(
@@ -1727,6 +1761,30 @@ class _UnscheduledWateringDialogState extends State<_UnscheduledWateringDialog> 
                 },
           child: const Text('記録する'),
         ),
+      ],
+    );
+  }
+}
+
+/// カレンダー凡例の1項目（色付きドット＋ラベル）。Issue #234。
+class _CalendarLegendDot extends StatelessWidget {
+  final Color color;
+  final String label;
+
+  const _CalendarLegendDot({required this.color, required this.label});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        ),
+        const SizedBox(width: 4),
+        Text(label, style: Theme.of(context).textTheme.bodySmall),
       ],
     );
   }


### PR DESCRIPTION
## 概要
長期利用シミュレーション（ベテラン主婦ペルソナ・2年相当）で見つかった、機能の欠落ではないが使い勝手を損なうUX課題4点を改善します。

- Closes #233 — 植物一覧の各行に水やり状態を表示
- Closes #234 — カレンダーに未来の水やり予定ドットを表示
- Closes #235 — 水やり間隔設定に直接指定（ステッパー）と上限拡張
- Closes #236 — ケア統計の月ラベルに年を表示

## 変更内容

### #233 植物一覧に水やり状態
リスト・グリッド・並び替えの各行に、次回水やり状態（例:「3日後」「昨日（予定超過）」）を表示。予定超過は error 色で強調します。
- `PlantProvider.cachedNextWateringDate(plantId)` を追加（キャッシュ済みの次回水やり日を同期取得）
- 共通ウィジェット `_WateringStatusText` で3種のタイル全てに適用

### #234 カレンダーに予定ドット
- `PlantProvider.scheduledWateringDates`（未来を含む予定日集合）を追加
- `CalendarBuilders.markerBuilder` で過去ログ（primary）と未来予定（tertiary）を塗り分け、凡例「●記録 ●予定」を追加

### #235 間隔設定の直接指定・上限拡張
- 水やり間隔ダイアログに `+ / -` ステッパーを追加し、狙った日数に厳密に合わせられるように
- スライダー上限を 30日 → 90日 に拡張（多肉・サボテン・アロエ等の長い間隔に対応）

### #236 月ラベルに年
- `care_stats_screen.dart` の月別グラフラベルを、先頭月と年の変わり目に西暦下2桁を添える形式（例: `'26/2月`）に変更

## テスト手順
実機（Android エミュレーター Medium_Phone_API_36.1）で、植物14鉢・ログ約2,700件のシードデータを用いて全4件を確認済み。

1. 植物一覧（リスト/グリッド両方）に水やり状態が表示され、予定超過が赤くなる
2. カレンダーで過去（緑）と未来予定（別色）のドットが塗り分けられ、凡例が出る
3. 間隔ダイアログでステッパーにより 44日 など30日超を設定できる
4. ケア統計の先頭ラベルが `'26/2月` と表示される

`flutter analyze` エラー/警告なし（既存 info のみ、変更ファイルに新規指摘なし）、`flutter test` 全6件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)