### PR TITLE
chore: バージョンを 1.4.0+8 に更新

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.1+7
+version: 1.4.0+8
 
 environment:
   sdk: ^3.11.0


### PR DESCRIPTION
## 概要
v1.4.0 リリースに向けたバージョン更新。

v1.3.1（2026-07-20 リリース済み）以降、以下をマージしたためリリースします。新機能（UX改善）を含むため minor を上げます。

### バグ修正
- #228 フォームのバリデーションエラーが入力修正後も残る
- #229 「N回に1回」肥料・活力剤で施肥忘れの超過状態が隠れる
- #230 ユーザー向けエラー文言に生の例外を直出ししない
- #231 植物削除時にケアログが孤児として残る
- #232 植物詳細のログ空状態の誤字（肝料→肥料）

### UX改善
- #233 植物一覧の各行に水やり状態を表示
- #234 カレンダーに未来の水やり予定ドットを表示
- #235 水やり間隔設定にステッパー追加＋上限拡張
- #236 ケア統計の月ラベルに年を表示

## 変更
`pubspec.yaml`: `1.3.1+7` → `1.4.0+8`

バージョン表示は package_info_plus で pubspec から実行時取得しているため画面側の修正は不要（#221 対応済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)