### PR TITLE
fix: 利用シミュレーションで見つかった不具合・UX課題を修正 (#239, #240, #242〜#252)

### DIFF
--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint;
 import 'package:uuid/uuid.dart';
 import '../models/plant.dart';
@@ -5,6 +7,7 @@ import '../models/log_entry.dart';
 import '../models/app_settings.dart';
 import '../services/database_service.dart';
 import '../services/home_widget_service.dart';
+import '../services/notification_service.dart';
 import '../utils/seasonal_interval_utils.dart';
 
 /// 植物データとログを管理する Provider。
@@ -62,6 +65,36 @@ class PlantProvider with ChangeNotifier {
     return result;
   }
 
+  /// 通知の再スケジュールをまとめるためのタイマー（Issue #246）。
+  ///
+  /// 一括記録などで loadPlants() が連続して走ると通知登録も連続してしまうため、
+  /// 短時間の変更をまとめて最後の1回だけ実行する。
+  Timer? _reminderDebounce;
+
+  /// 通知再スケジュールのまとめ待ち時間。
+  static const _reminderDebounceDuration = Duration(milliseconds: 500);
+
+  /// 水やりリマインダーを張り直す（デバウンス付き）。
+  ///
+  /// 通知設定は [NotificationService] 側が SharedPreferences から読むため、
+  /// 通知が無効なら内部でスキップされる。
+  void _scheduleWateringReminder() {
+    _reminderDebounce?.cancel();
+    _reminderDebounce = Timer(_reminderDebounceDuration, () async {
+      try {
+        await NotificationService.scheduleSmartWateringReminder();
+      } catch (e) {
+        debugPrint('水やりリマインダーの再スケジュールに失敗: $e');
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _reminderDebounce?.cancel();
+    super.dispose();
+  }
+
   /// 植物一覧をストレージから再読み込み、キャッシュを更新する。
   Future<void> loadPlants() async {
     _isLoading = true;
@@ -83,6 +116,11 @@ class PlantProvider with ChangeNotifier {
       // ホーム画面ウィジェットに今日の水やり予定を反映する（Issue #174）
       await HomeWidgetService.updateTodayWateringWidget(
           getPlantsNeedingWateringToday());
+
+      // 植物やログの変更で次回予定日が変わるため、通知を張り直す（Issue #246）。
+      // 植物の追加・編集・削除もログの記録・取り消しも loadPlants() を通るため、
+      // ここに集約することで呼び忘れを防ぐ。
+      _scheduleWateringReminder();
     } catch (e) {
       debugPrint('Error loading plants: $e');
     } finally {

--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -25,7 +25,8 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   List<String> _selectedPlantIds = [];
   List<String> _selectedImagePaths = [];
 
-  /// 新規作成時のみ使用する作成日（デフォルト=今日）
+  /// 新規作成時のみ使用する作成日時（デフォルト=現在時刻）。
+  /// 一覧では時刻も表示するため、日付だけに丸めず時刻を保持する（Issue #242）。
   late DateTime _selectedDate;
 
   @override
@@ -36,10 +37,8 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
     _selectedPlantIds = widget.note?.plantIds ??
         (widget.initialPlantId != null ? [widget.initialPlantId!] : []);
     _selectedImagePaths = widget.note?.imagePaths ?? [];
-    // 新規作成時：今日を初期値、編集時：既存のcreatedAt
-    final now = DateTime.now();
-    _selectedDate = widget.note?.createdAt ??
-        DateTime(now.year, now.month, now.day);
+    // 新規作成時：現在日時を初期値、編集時：既存のcreatedAt
+    _selectedDate = widget.note?.createdAt ?? DateTime.now();
   }
 
   @override
@@ -67,7 +66,20 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
             locale: locale,
             helpText: '作成日を選択',
           );
-          if (picked != null) setState(() => _selectedDate = picked);
+          // 日付ピッカーは 00:00 の DateTime を返すため、元の時刻を引き継ぐ
+          if (picked != null) {
+            setState(() {
+              _selectedDate = DateTime(
+                picked.year,
+                picked.month,
+                picked.day,
+                _selectedDate.hour,
+                _selectedDate.minute,
+                _selectedDate.second,
+                _selectedDate.millisecond,
+              );
+            });
+          }
         },
         child: Container(
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -245,7 +245,8 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
       }
 
       if (mounted) {
-        Navigator.of(context).pop();
+        // 保存されたことを呼び出し元に伝える（キャンセル時は null が返る）
+        Navigator.of(context).pop(true);
       }
     } catch (e) {
       if (mounted) {

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -225,7 +225,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
                   Text('まだノートがありません',
                       style: Theme.of(context).textTheme.titleMedium),
                   const SizedBox(height: 8),
-                  Text('右下の ＋ ボタンから記録しましょう',
+                  Text('右下のボタンから記録しましょう',
                       style: Theme.of(context).textTheme.bodySmall),
                 ],
               ),
@@ -295,6 +295,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
         },
       ),
       floatingActionButton: FloatingActionButton(
+        tooltip: 'ノートを作成',
         onPressed: () {
           final noteProvider = context.read<NoteProvider>();
           Navigator.of(context)

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -16,6 +16,7 @@ import '../utils/date_utils.dart';
 import 'add_plant_screen.dart';
 import 'add_edit_note_screen.dart';
 import 'iot_settings_screen.dart';
+import 'light_meter_screen.dart';
 import 'note_detail_screen.dart';
 import 'plant_growth_timeline_screen.dart';
 import '../utils/error_utils.dart';
@@ -63,7 +64,10 @@ class PlantDetailScreen extends StatefulWidget {
 
 class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTickerProviderStateMixin {
   late TabController _tabController;
-  
+
+  /// 表示中の植物。編集画面から戻った際に最新の内容へ差し替える（Issue #243）。
+  late Plant _plant;
+
   List<LogEntry> _wateringLogs = [];
   List<LogEntry> _fertilizerLogs = [];
   List<LogEntry> _vitalizerLogs = [];
@@ -83,6 +87,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
   @override
   void initState() {
     super.initState();
+    _plant = widget.plant;
     _tabController = TabController(
       length: 4,
       vsync: this,
@@ -105,7 +110,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
 
   Future<void> _loadSensorLogs() async {
     final logs = await context.read<SensorLogProvider>()
-        .getLogsForPlant(widget.plant.id);
+        .getLogsForPlant(_plant.id);
     if (mounted) {
       setState(() {
         _sensorLogs = logs;
@@ -116,11 +121,11 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
   Future<void> _loadLogs() async {
     final provider = context.read<PlantProvider>();
     final logs = await Future.wait([
-      provider.getAllLogsForPlantAndType(widget.plant.id, LogType.watering),
-      provider.getAllLogsForPlantAndType(widget.plant.id, LogType.fertilizer),
-      provider.getAllLogsForPlantAndType(widget.plant.id, LogType.vitalizer),
+      provider.getAllLogsForPlantAndType(_plant.id, LogType.watering),
+      provider.getAllLogsForPlantAndType(_plant.id, LogType.fertilizer),
+      provider.getAllLogsForPlantAndType(_plant.id, LogType.vitalizer),
       for (final type in _otherCareTypes)
-        provider.getAllLogsForPlantAndType(widget.plant.id, type),
+        provider.getAllLogsForPlantAndType(_plant.id, type),
     ]);
 
     if (mounted) {
@@ -135,7 +140,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
 
   Future<void> _loadNextWateringDate() async {
     final nextDate = await context.read<PlantProvider>()
-        .calculateNextWateringDate(widget.plant.id);
+        .calculateNextWateringDate(_plant.id);
     if (mounted) {
       setState(() {
         _nextWateringDate = nextDate;
@@ -192,7 +197,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
       builder: (context) => AlertDialog(
         title: const Text('削除の確認'),
         // ノートは削除せず紐付けを解除するだけなので、実挙動どおりに説明する（Issue #224）
-        content: Text('「${widget.plant.name}」を削除してもよろしいですか？\n'
+        content: Text('「${_plant.name}」を削除してもよろしいですか？\n'
             'すべてのケアログも削除されます。\n'
             'ノートは残りますが、この植物との紐付けは解除されます。'),
         actions: [
@@ -212,7 +217,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     );
 
     if (confirm == true) {
-      await plantProvider.deletePlant(widget.plant.id);
+      await plantProvider.deletePlant(_plant.id);
       if (!context.mounted) return;
       navigator.pop();
     }
@@ -236,12 +241,12 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
         headerSliverBuilder: (context, innerBoxIsScrolled) => [
           // 植物画像を背景に持つ SliverAppBar
           SliverAppBar(
-            expandedHeight: widget.plant.imagePath != null ? 260.0 : 160.0,
+            expandedHeight: _plant.imagePath != null ? 260.0 : 160.0,
             pinned: true,
             floating: false,
             forceElevated: innerBoxIsScrolled,
             actions: [
-              if (widget.plant.imagePath != null)
+              if (_plant.imagePath != null)
                 _buildImageOverlayAction(
                     Icons.auto_awesome_motion, _navigateToGrowthTimeline)
               else
@@ -250,14 +255,14 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                   tooltip: '成長タイムライン',
                   onPressed: _navigateToGrowthTimeline,
                 ),
-              if (widget.plant.imagePath != null)
+              if (_plant.imagePath != null)
                 _buildImageOverlayAction(Icons.edit, _navigateToEdit)
               else
                 IconButton(
                   icon: const Icon(Icons.edit),
                   onPressed: _navigateToEdit,
                 ),
-              if (widget.plant.imagePath != null)
+              if (_plant.imagePath != null)
                 _buildImageOverlayAction(Icons.delete, _deletePlant)
               else
                 IconButton(
@@ -281,7 +286,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                   padding:
                       const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                   child: Text(
-                    widget.plant.name,
+                    _plant.name,
                     style: const TextStyle(color: Colors.white),
                     overflow: TextOverflow.ellipsis,
                   ),
@@ -314,7 +319,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
 
   /// SliverAppBar の背景ウィジェットを構築する
   Widget _buildHeaderBackground(BuildContext context) {
-    if (widget.plant.imagePath != null) {
+    if (_plant.imagePath != null) {
       // 画像あり: 植物画像を全画面背景として表示
       return Stack(
         fit: StackFit.expand,
@@ -360,7 +365,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
 
   /// 植物画像を表示する
   Widget _buildFullImage() {
-    final path = widget.plant.imagePath!;
+    final path = _plant.imagePath!;
 
     // Base64 data URL の場合はメモリから表示する（レガシーデータ互換）
     if (path.startsWith('data:')) {
@@ -402,22 +407,32 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
   }
 
   Future<void> _navigateToEdit() async {
-    await Navigator.of(context).push(
+    final saved = await Navigator.of(context).push<bool>(
       MaterialPageRoute(
-        builder: (context) => AddPlantScreen(plant: widget.plant),
+        builder: (context) => AddPlantScreen(plant: _plant),
       ),
     );
-    // 編集後は前の画面にデータ変更があったことを通知する
-    if (mounted) {
-      Navigator.of(context).pop(true);
-    }
+    if (!mounted) return;
+    // キャンセル時は何もしない（この画面に留まる）
+    if (saved != true) return;
+
+    // 保存された場合は最新の内容へ差し替えて再読み込みする。
+    // 一覧側は PlantProvider を watch しているため自動的に更新される。
+    final plantProvider = context.read<PlantProvider>();
+    final updated = plantProvider.plants
+        .where((p) => p.id == _plant.id)
+        .firstOrNull;
+    setState(() {
+      if (updated != null) _plant = updated;
+    });
+    await _loadData();
   }
 
   /// 成長タイムライン画面へ遷移する（Issue #179）。
   void _navigateToGrowthTimeline() {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => PlantGrowthTimelineScreen(plant: widget.plant),
+        builder: (context) => PlantGrowthTimelineScreen(plant: _plant),
       ),
     );
   }
@@ -427,12 +442,16 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
       padding: const EdgeInsets.all(16),
       children: [
         _buildBasicInfoCard(),
-        const SizedBox(height: 16),
-        _buildWateringInfoCard(),
-        if (widget.plant.fertilizerIntervalDays != null ||
-            widget.plant.fertilizerEveryNWaterings != null ||
-            widget.plant.vitalizerIntervalDays != null ||
-            widget.plant.vitalizerEveryNWaterings != null) ...[
+        // 水やり間隔も次回予定も無い場合は見出しだけの空カードになるため表示しない
+        if (_plant.wateringIntervalDays != null ||
+            _nextWateringDate != null) ...[
+          const SizedBox(height: 16),
+          _buildWateringInfoCard(),
+        ],
+        if (_plant.fertilizerIntervalDays != null ||
+            _plant.fertilizerEveryNWaterings != null ||
+            _plant.vitalizerIntervalDays != null ||
+            _plant.vitalizerEveryNWaterings != null) ...[
           const SizedBox(height: 16),
           _buildFertilizerInfoCard(),
         ],
@@ -444,27 +463,27 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     return _InfoCard(
       title: '基本情報',
       children: [
-        _InfoRow(label: '植物名', value: widget.plant.name),
-        if (widget.plant.variety != null)
-          _InfoRow(label: '品種名', value: widget.plant.variety!),
-        if (widget.plant.purchaseDate != null)
+        _InfoRow(label: '植物名', value: _plant.name),
+        if (_plant.variety != null)
+          _InfoRow(label: '品種名', value: _plant.variety!),
+        if (_plant.purchaseDate != null)
           _InfoRow(
             label: '購入日',
-            value: DateFormat('yyyy年MM月dd日').format(widget.plant.purchaseDate!),
+            value: DateFormat('yyyy年MM月dd日').format(_plant.purchaseDate!),
           ),
-        if (widget.plant.purchaseLocation != null)
-          _InfoRow(label: '購入先', value: widget.plant.purchaseLocation!),
+        if (_plant.purchaseLocation != null)
+          _InfoRow(label: '購入先', value: _plant.purchaseLocation!),
         // 登録・編集画面で設定した置き場所を確認できるようにする（Issue #215）
         if (_locationName != null)
           _InfoRow(label: '置き場所', value: _locationName!),
-        if (widget.plant.isOutdoor) const _InfoRow(label: '設置', value: '屋外'),
+        if (_plant.isOutdoor) const _InfoRow(label: '設置', value: '屋外'),
       ],
     );
   }
 
   /// 植物に紐づく置き場所の名前を返す。未設定・削除済みの場合は null。
   String? get _locationName {
-    final locationId = widget.plant.locationId;
+    final locationId = _plant.locationId;
     if (locationId == null) return null;
     final locations = context.watch<LocationProvider>().locations;
     for (final location in locations) {
@@ -477,10 +496,10 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     return _InfoCard(
       title: '水やり情報',
       children: [
-        if (widget.plant.wateringIntervalDays != null)
+        if (_plant.wateringIntervalDays != null)
           _InfoRow(
             label: '間隔',
-            value: '${widget.plant.wateringIntervalDays}日ごと',
+            value: '${_plant.wateringIntervalDays}日ごと',
           ),
         if (_nextWateringDate != null)
           _InfoRow(
@@ -504,21 +523,21 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     return _InfoCard(
       title: '施肥情報',
       children: [
-        if (widget.plant.fertilizerIntervalDays != null ||
-            widget.plant.fertilizerEveryNWaterings != null)
+        if (_plant.fertilizerIntervalDays != null ||
+            _plant.fertilizerEveryNWaterings != null)
           _InfoRow(
             label: '肥料間隔',
             value: intervalText(
-                widget.plant.fertilizerIntervalDays,
-                widget.plant.fertilizerEveryNWaterings),
+                _plant.fertilizerIntervalDays,
+                _plant.fertilizerEveryNWaterings),
           ),
-        if (widget.plant.vitalizerIntervalDays != null ||
-            widget.plant.vitalizerEveryNWaterings != null)
+        if (_plant.vitalizerIntervalDays != null ||
+            _plant.vitalizerEveryNWaterings != null)
           _InfoRow(
             label: '活力剤間隔',
             value: intervalText(
-                widget.plant.vitalizerIntervalDays,
-                widget.plant.vitalizerEveryNWaterings),
+                _plant.vitalizerIntervalDays,
+                _plant.vitalizerEveryNWaterings),
           ),
       ],
     );
@@ -611,7 +630,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
 
     try {
       await plantProvider.recordCareLog(
-        widget.plant.id,
+        _plant.id,
         result.type,
         result.date,
         result.note,
@@ -630,7 +649,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     return Consumer<NoteProvider>(
       builder: (context, noteProvider, _) {
         final plantNotes = noteProvider.notes
-            .where((n) => n.plantIds.contains(widget.plant.id))
+            .where((n) => n.plantIds.contains(_plant.id))
             .toList()
           ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
 
@@ -654,7 +673,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                   onPressed: () => Navigator.of(context).push(
                     MaterialPageRoute(
                       builder: (_) => AddEditNoteScreen(
-                        initialPlantId: widget.plant.id,
+                        initialPlantId: _plant.id,
                       ),
                     ),
                   ).then((_) {
@@ -714,6 +733,20 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
           children: [
             _buildLatestSensorCard(),
             const SizedBox(height: 16),
+            // 光量メーターは設定画面の奥にあり見つけにくいため、
+            // 「この植物の置き場所の明るさを測る」文脈からも開けるようにする（Issue #248）
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: OutlinedButton.icon(
+                onPressed: () => Navigator.of(context).push(
+                  MaterialPageRoute(
+                    builder: (_) => const LightMeterScreen(),
+                  ),
+                ),
+                icon: const Icon(Icons.wb_sunny_outlined),
+                label: const Text('置き場所の明るさを測る'),
+              ),
+            ),
             if (!hasAnyIot)
               _buildIotSetupPrompt()
             else ...[
@@ -976,7 +1009,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     try {
       // マッピング設定でこの植物に紐づくデバイスを検索
       final mappedDevice = settings.sensorDeviceMappings.where(
-        (m) => m.source == source && m.plantIds.contains(widget.plant.id),
+        (m) => m.source == source && m.plantIds.contains(_plant.id),
       ).firstOrNull;
 
       final List<SensorData> devices;
@@ -1027,7 +1060,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
       await sensorProvider.saveSensorLog( // ignore: use_build_context_synchronously
         data: selected,
         source: source,
-        plantId: widget.plant.id,
+        plantId: _plant.id,
       );
 
       if (!mounted) return;

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -4,10 +4,12 @@ import '../providers/plant_provider.dart';
 import '../providers/settings_provider.dart';
 import '../providers/location_provider.dart';
 import '../models/app_settings.dart';
+import '../models/location.dart';
 import '../models/plant.dart';
 import '../utils/date_utils.dart';
 import '../widgets/plant_image_widget.dart';
 import 'add_plant_screen.dart';
+import 'location_list_screen.dart';
 import 'plant_detail_screen.dart';
 import 'settings_screen.dart';
 
@@ -38,45 +40,87 @@ class _PlantListScreenState extends State<PlantListScreen> {
     });
   }
 
-  /// 置き場所フィルタチップ行を構築する。置き場所が1件も登録されていない場合は何も表示しない。
-  Widget _buildLocationFilterChips() {
-    return Consumer<LocationProvider>(
-      builder: (context, locationProvider, _) {
-        if (locationProvider.locations.isEmpty) return const SizedBox.shrink();
+  /// 置き場所での絞り込みをボトムシートで選ばせる（Issue #251）。
+  Future<void> _showLocationFilterSheet(
+      BuildContext context, List<Location> locations) async {
+    await showModalBottomSheet<void>(
+      context: context,
+      builder: (sheetContext) {
+        Widget option(String label, String? value) {
+          return ListTile(
+            title: Text(label),
+            trailing: _selectedLocationId == value
+                ? Icon(Icons.check,
+                    color: Theme.of(sheetContext).colorScheme.primary)
+                : null,
+            onTap: () {
+              setState(() => _selectedLocationId = value);
+              Navigator.of(sheetContext).pop();
+            },
+          );
+        }
 
-        return SizedBox(
-          height: 44,
+        return SafeArea(
           child: ListView(
-            scrollDirection: Axis.horizontal,
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            shrinkWrap: true,
             children: [
               Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: FilterChip(
-                  label: const Text('すべて'),
-                  selected: _selectedLocationId == null,
-                  onSelected: (_) => setState(() => _selectedLocationId = null),
-                ),
+                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                child: Text('置き場所で絞り込む',
+                    style: Theme.of(sheetContext).textTheme.titleMedium),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 4),
-                child: FilterChip(
-                  label: const Text('未設定'),
-                  selected: _selectedLocationId == _unassignedLocationFilter,
-                  onSelected: (_) =>
-                      setState(() => _selectedLocationId = _unassignedLocationFilter),
-                ),
+              option('すべて', null),
+              option('未設定', _unassignedLocationFilter),
+              for (final location in locations)
+                option(location.name, location.id),
+              const Divider(),
+              // 置き場所の管理画面は設定の奥にあるため、ここからも開けるようにする
+              // （Issue #248）
+              ListTile(
+                leading: const Icon(Icons.home_outlined),
+                title: const Text('置き場所を編集'),
+                onTap: () {
+                  Navigator.of(sheetContext).pop();
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => const LocationListScreen(),
+                    ),
+                  );
+                },
               ),
-              for (final location in locationProvider.locations)
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 4),
-                  child: FilterChip(
-                    label: Text(location.name),
-                    selected: _selectedLocationId == location.id,
-                    onSelected: (_) =>
-                        setState(() => _selectedLocationId = location.id),
-                  ),
-                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// 絞り込み中であることを示すバー。解除操作もここから行える。
+  Widget _buildActiveLocationFilterBar() {
+    if (_selectedLocationId == null) return const SizedBox.shrink();
+
+    return Consumer<LocationProvider>(
+      builder: (context, locationProvider, _) {
+        final name = _selectedLocationId == _unassignedLocationFilter
+            ? '未設定'
+            : locationProvider.locations
+                    .where((l) => l.id == _selectedLocationId)
+                    .firstOrNull
+                    ?.name ??
+                '不明な置き場所';
+        return Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          color: Theme.of(context).colorScheme.secondaryContainer,
+          child: Row(
+            children: [
+              const Icon(Icons.filter_alt, size: 18),
+              const SizedBox(width: 8),
+              Expanded(child: Text('置き場所: $name')),
+              TextButton(
+                onPressed: () => setState(() => _selectedLocationId = null),
+                child: const Text('解除'),
+              ),
             ],
           ),
         );
@@ -97,8 +141,30 @@ class _PlantListScreenState extends State<PlantListScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Botanote'),
+        title: const Text('植物一覧'),
         actions: [
+          // 置き場所での絞り込み（Issue #251）。
+          // 一覧本体にチップ行を出すと、置き場所の登録有無でリストの位置が
+          // ずれてしまうため、ノートタブと同じく AppBar に寄せる。
+          Consumer2<LocationProvider, SettingsProvider>(
+            builder: (context, locationProvider, settings, _) {
+              // カスタム並び替え（ドラッグ）と併用すると並び順が破損するため無効化する
+              final isCustomSort =
+                  settings.plantSortOrder == PlantSortOrder.custom;
+              final hasLocations = locationProvider.locations.isNotEmpty;
+              return IconButton(
+                icon: Badge(
+                  isLabelVisible: _selectedLocationId != null,
+                  child: const Icon(Icons.filter_list),
+                ),
+                tooltip: '置き場所で絞り込む',
+                onPressed: (!hasLocations || isCustomSort)
+                    ? null
+                    : () => _showLocationFilterSheet(
+                        context, locationProvider.locations),
+              );
+            },
+          ),
           // グリッド/リスト表示切り替えボタン
           IconButton(
             icon: Icon(_isGridView ? Icons.view_list : Icons.grid_view),
@@ -180,7 +246,7 @@ class _PlantListScreenState extends State<PlantListScreen> {
             children: [
               // 置き場所フィルタはカスタム並び替え（ドラッグ）と併用すると並び順が
               // 破損するため、カスタムソート中は表示・適用しない
-              if (!isCustomSort) _buildLocationFilterChips(),
+              if (!isCustomSort) _buildActiveLocationFilterBar(),
               Expanded(
                 child: Consumer<PlantProvider>(
                   builder: (context, plantProvider, _) {

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -621,6 +621,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
       if (!context.mounted) return;
       await context.read<LocationProvider>().loadLocations();
       if (!context.mounted) return;
+      // 復元したアプリ設定（通知時刻・テーマ等）を画面と通知に反映する（Issue #239）
+      if (result.settingsRestored) {
+        await context.read<SettingsProvider>().loadSettings();
+        if (!context.mounted) return;
+      }
       // ダイアログ表示中もスピナーが回り続けないよう、先に読み込み状態を解除する
       setState(() => _isImporting = false);
       // 復元結果は見逃すと影響が大きいため、SnackBar ではなくダイアログで示す（Issue #225）

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -11,6 +11,7 @@ import '../models/daily_log_status.dart';
 import '../models/app_settings.dart';
 import '../utils/date_utils.dart';
 import '../widgets/plant_image_widget.dart';
+import 'care_stats_screen.dart';
 import 'plant_detail_screen.dart';
 import 'settings_screen.dart';
 import 'add_plant_screen.dart';
@@ -50,6 +51,12 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
   // 日付ページデータのキャッシュ。キーは '${date.ms}_$_refreshKey'。
   // _refreshKey が変わるとキーが変わり、古いエントリは自然に参照されなくなる。
   final Map<String, _DatePageData> _pageDataCache = {};
+
+  // FutureBuilder に渡す Future のキャッシュ。キーは _pageDataCache と同一。
+  // build のたびに `_loadDatePageData()` を直接呼ぶと毎回別の Future になり、
+  // FutureBuilder が再描画のたびに待ち直してスピナーがちらつくため、
+  // キーが同じ間は同じ Future を使い回す（Issue #252）。
+  final Map<String, Future<_DatePageData>> _pageFutureCache = {};
 
   // キャッシュエントリ数の上限（±2日×5日分＋余裕分）
   static const int _cacheMaxSize = 20;
@@ -179,20 +186,28 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
 
   /// キャッシュサイズが上限を超えた場合に古いエントリを削除する。
   void _evictOldCacheEntries() {
-    if (_pageDataCache.length <= _cacheMaxSize) return;
     // 現在の_refreshKeyに属さないエントリを優先的に削除する
     final currentKeySuffix = '_$_refreshKey';
+    // データが未確定でも Future だけ残ることがあるため、先に古い世代を掃除する
+    _pageFutureCache.removeWhere((k, _) => !k.endsWith(currentKeySuffix));
+    if (_pageDataCache.length <= _cacheMaxSize) return;
     final oldKeys = _pageDataCache.keys
         .where((k) => !k.endsWith(currentKeySuffix))
         .toList();
     for (final key in oldKeys) {
-      _pageDataCache.remove(key);
+      _removeCacheEntry(key);
       if (_pageDataCache.length <= _cacheMaxSize) return;
     }
     // それでも超えている場合は先頭から削除
     while (_pageDataCache.length > _cacheMaxSize) {
-      _pageDataCache.remove(_pageDataCache.keys.first);
+      _removeCacheEntry(_pageDataCache.keys.first);
     }
+  }
+
+  /// データと Future のキャッシュを同じキーで揃えて破棄する。
+  void _removeCacheEntry(String key) {
+    _pageDataCache.remove(key);
+    _pageFutureCache.remove(key);
   }
 
   /// 指定日に表示すべき植物リストを決定する
@@ -443,6 +458,19 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
             tooltip: _isCalendarView ? 'リスト表示' : 'カレンダー表示',
             onPressed: () => setState(() => _isCalendarView = !_isCalendarView),
           ),
+          // ケア統計は「設定」ではなく振り返り機能なので、ログ画面からも開けるようにする
+          // （Issue #248）。設定画面からの導線も従来どおり残している。
+          IconButton(
+            icon: const Icon(Icons.bar_chart),
+            tooltip: 'ケア統計',
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const CareStatsScreen(),
+                ),
+              );
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.settings),
             tooltip: '設定',
@@ -457,10 +485,32 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
         ],
       ),
       body: _isCalendarView ? _buildCalendarView() : _buildPagedLogList(),
-      floatingActionButton: _selectedPlantIds.isNotEmpty
-          ? Column(
+    );
+  }
+
+  /// 一括記録バー。選択中の植物がある場合に画面下部へ表示する。
+  ///
+  /// FloatingActionButton として浮かせると、下部の「その他の植物に水やり」ボタンや
+  /// カレンダー表示時の植物カードに重なってしまうため、レイアウト上の領域を
+  /// 占める通常のウィジェットとして配置する（Issue #240）。
+  Widget _buildBulkActionBar() {
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.1),
+            blurRadius: 8,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(16),
+      child: SafeArea(
+        top: false,
+        child: Column(
               mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 // Log type selection chips
                 Container(
@@ -565,14 +615,18 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
                 ),
                 const SizedBox(height: 8),
                 // Action button
-                FloatingActionButton.extended(
+                FilledButton.icon(
                   onPressed: _bulkLog,
                   icon: const Icon(Icons.check),
                   label: Text('${_selectedPlantIds.length}件登録'),
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    minimumSize: const Size(double.infinity, 48),
+                  ),
                 ),
               ],
-            )
-          : null,
+        ),
+      ),
     );
   }
 
@@ -697,9 +751,22 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
   }
 
   /// 指定日のログデータをDBから取得する。キャッシュヒット時は即座に返す。
+  /// 指定日のページデータ取得 Future を返す。
+  ///
+  /// build のたびに `_loadDatePageData()` を直接呼ぶと毎回別の Future になり、
+  /// FutureBuilder が再描画のたびに待ち直してしまうため、
+  /// キーが同じ間は同じ Future を返す（Issue #252）。
+  Future<_DatePageData> _datePageFuture(DateTime date) {
+    final cacheKey = _pageCacheKey(date);
+    return _pageFutureCache[cacheKey] ??= _loadDatePageData(date);
+  }
+
+  /// 日付ページのキャッシュキー。
+  String _pageCacheKey(DateTime date) =>
+      '${AppDateUtils.getDateOnly(date).millisecondsSinceEpoch}_$_refreshKey';
+
   Future<_DatePageData> _loadDatePageData(DateTime date) async {
-    final cacheKey =
-        '${AppDateUtils.getDateOnly(date).millisecondsSinceEpoch}_$_refreshKey';
+    final cacheKey = _pageCacheKey(date);
     // キャッシュヒット時はDBアクセスをスキップ
     if (_pageDataCache.containsKey(cacheKey)) {
       return _pageDataCache[cacheKey]!;
@@ -787,9 +854,8 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
     return Consumer<PlantProvider>(
       builder: (context, plantProvider, _) {
         return FutureBuilder<_DatePageData>(
-          // _refreshKeyが変化するたびにFutureが再実行される
-          key: ValueKey('${date.millisecondsSinceEpoch}_$_refreshKey'),
-          future: _loadDatePageData(date),
+          // _refreshKey が変化するとキャッシュキーが変わり Future が再実行される
+          future: _datePageFuture(date),
           builder: (context, snapshot) {
             // 未初期化中（初回loadPlants完了前）またはデータ待ちはスピナー表示
             // isInitialized を先に評価することで、_loadDatePageData が未初期化中に
@@ -1026,7 +1092,11 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
             },
           ),
         ),
-        _buildAddUnscheduledWateringButton(hasPlants: true),
+        // 選択中は一括記録バーへ切り替える（両方を同時に出すと重なるため）
+        if (_selectedPlantIds.isNotEmpty)
+          _buildBulkActionBar()
+        else
+          _buildAddUnscheduledWateringButton(hasPlants: true),
       ],
     );
   }
@@ -1372,15 +1442,21 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
     bool isDateDue(DateTime? d) =>
         d != null && !AppDateUtils.getDateOnly(d).isAfter(today);
 
+    // 次回予定は「今日」からの相対表示のため、過去日を見ているときに出すと
+    // その日の状態と誤解される（4/22 を見ているのに「2日後」と出る）。
+    // 過去日ではその日の記録だけを示す（Issue #249）。
+    final isPastDate = selectedDay.isBefore(today);
+
     // 水やり・肥料・活力剤の予定を横並び1行でまとめて表示する (#125)
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (plant.variety != null) Text(plant.variety!),
         // 予定がある項目を Wrap で横並びにまとめる
-        if (nextWateringDate != null ||
-            nextFertilizerDate != null ||
-            nextVitalizerDate != null)
+        if (!isPastDate &&
+            (nextWateringDate != null ||
+                nextFertilizerDate != null ||
+                nextVitalizerDate != null))
           Wrap(
             spacing: 8,
             runSpacing: 2,

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -441,6 +441,29 @@ class DatabaseService {
     await db.delete('notes', where: 'id = ?', whereArgs: [id]);
   }
 
+  /// 種別 [type] のログについて、植物IDごとの最終記録日を1クエリで取得する。
+  ///
+  /// 「最終水やり日」だけが必要な処理でログを全件読み込むとログ件数に比例して
+  /// 遅くなるため、SQL の集約関数で1行に畳んでから返す（Issue #252）。
+  Future<Map<String, DateTime>> _getLastLogDateByPlant(LogType type) async {
+    final db = await database;
+    final rows = await db.rawQuery(
+      'SELECT plantId, MAX(date) AS lastDate FROM logs '
+      'WHERE type = ? GROUP BY plantId',
+      [type.name],
+    );
+
+    final result = <String, DateTime>{};
+    for (final row in rows) {
+      final plantId = row['plantId'] as String?;
+      final lastDate = row['lastDate'] as String?;
+      if (plantId == null || lastDate == null) continue;
+      final parsed = DateTime.tryParse(lastDate);
+      if (parsed != null) result[plantId] = parsed;
+    }
+    return result;
+  }
+
   /// 指定日に水やり予定がある植物リストを取得する。
   ///
   /// バックグラウンドIsolateから直接呼び出すためのメソッド。
@@ -450,7 +473,6 @@ class DatabaseService {
   /// 間隔には季節調整（休眠期の延長）を適用する。適用しないと通知だけが
   /// 素の間隔で発火し、画面表示の「次回予定」より早く通知が届く（Issue #223）。
   Future<List<Plant>> getPlantsDueOn(DateTime targetDate) async {
-    // 全植物と全水やりログを取得
     final plants = await getAllPlants();
     if (plants.isEmpty) return [];
 
@@ -460,23 +482,20 @@ class DatabaseService {
       targetDate.day,
     );
 
+    // 必要なのは植物ごとの「最終水やり日」1件だけなので、
+    // ログを全件取得せず SQL 側で集約する（Issue #252）。
+    final lastWateredByPlantId = await _getLastLogDateByPlant(LogType.watering);
+
     final duePlants = <Plant>[];
 
     for (final plant in plants) {
       // 水やり間隔が未設定の植物はスキップ
       if (plant.wateringIntervalDays == null) continue;
 
-      final logs = await getLogsByPlantAndType(plant.id, LogType.watering);
-
-      final DateTime baseDate;
-      if (logs.isEmpty) {
-        // ログなし: 購入日または登録日を起算日とする
-        baseDate = plant.purchaseDate ?? plant.createdAt;
-      } else {
-        // 最終水やりログ日を起算日とする
-        logs.sort((a, b) => b.date.compareTo(a.date));
-        baseDate = logs.first.date;
-      }
+      // 最終水やりログ日を起算日とする。ログが無ければ購入日または登録日。
+      final baseDate = lastWateredByPlantId[plant.id] ??
+          plant.purchaseDate ??
+          plant.createdAt;
 
       // 起算日が休眠期なら間隔を延長する（画面表示側と同じ計算に揃える）
       final intervalDays = applySeasonalAdjustment(

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -11,8 +11,10 @@ import '../models/plant.dart';
 import '../models/log_entry.dart';
 import '../models/note.dart';
 import '../models/sensor_log.dart';
+import '../models/app_settings.dart';
 import '../models/location.dart';
 import 'database_service.dart';
+import 'settings_service.dart';
 
 /// データのエクスポート / インポートを担うサービス
 ///
@@ -29,6 +31,29 @@ class ExportService {
   ExportService._internal();
 
   final _db = DatabaseService();
+  final _settingsService = SettingsService();
+
+  /// 書き出すバックアップのバージョン。
+  /// 5 でアプリ設定（`settings`）を含めるようになった（Issue #239）。
+  static const int _backupVersion = 5;
+
+  /// バックアップに含めないアプリ設定のキー。
+  ///
+  /// バックアップ ZIP は OS の共有シートで外部サービスへ送られるため、
+  /// IoT サービスの認証情報は書き出さない（復元時も端末側の値を保持する）。
+  static const Set<String> _secretSettingKeys = {
+    'natureRemoToken',
+    'switchBotToken',
+    'switchBotSecret',
+  };
+
+  /// エクスポート対象のアプリ設定を返す（認証情報は除外する）。
+  Future<Map<String, dynamic>> _exportableSettingsMap() async {
+    final settings = await _settingsService.loadSettings();
+    final map = settings.toMap();
+    map.removeWhere((key, _) => _secretSettingKeys.contains(key));
+    return map;
+  }
 
   // ── エクスポート ──────────────────────────────────────────
 
@@ -145,15 +170,20 @@ class ExportService {
     // 全消失し、植物側の locationId が孤児参照になる（Issue #206）。
     final locations = await _db.getAllLocations();
 
+    // ── アプリ設定を収集（Issue #239） ──
+    // 通知時刻やテーマを含めないと機種変更で設定だけが初期値に戻る。
+    final settingsMap = await _exportableSettingsMap();
+
     // ── data.json を生成 ──
     final data = {
-      'version': 4,
+      'version': _backupVersion,
       'exportedAt': DateTime.now().toIso8601String(),
       'plants': plantMaps,
       'logs': allLogs.map((l) => l.toMap()).toList(),
       'notes': noteMaps,
       'sensorLogs': sensorLogs.map((s) => s.toMap()).toList(),
       'locations': locations.map((l) => l.toMap()).toList(),
+      'settings': settingsMap,
     };
     final jsonBytes = utf8.encode(const JsonEncoder.withIndent('  ').convert(data));
     archive.addFile(ArchiveFile('data.json', jsonBytes.length, jsonBytes));
@@ -226,7 +256,7 @@ class ExportService {
         jsonDecode(jsonStr) as Map<String, dynamic>;
 
     final version = data['version'] as int? ?? 1;
-    if (version > 4) {
+    if (version > _backupVersion) {
       throw FormatException('未対応のバックアップバージョン: $version');
     }
 
@@ -253,7 +283,7 @@ class ExportService {
     final Map<String, dynamic> data =
         jsonDecode(jsonStr) as Map<String, dynamic>;
     final version = data['version'] as int? ?? 1;
-    if (version > 4) {
+    if (version > _backupVersion) {
       throw FormatException('未対応のバックアップバージョン: $version');
     }
     return _importData(data, const {});
@@ -268,6 +298,7 @@ class ExportService {
     int logCount = 0;
     int noteCount = 0;
     int locationCount = 0;
+    bool settingsRestored = false;
 
     // 復元対象の行をテーブルごとに組み立て、最後に1トランザクションで投入する
     // （1件ずつ insert すると数千件で数十秒〜数分かかるため。Issue #214）。
@@ -343,6 +374,23 @@ class ExportService {
       sensorLogCount++;
     }
 
+    // アプリ設定を復元する（version 5 以降のバックアップにのみ含まれる。Issue #239）。
+    // 認証情報はバックアップに含めないため、端末側の現在値をそのまま引き継ぐ。
+    final settingsJson = data['settings'];
+    if (settingsJson is Map) {
+      try {
+        final current = await _settingsService.loadSettings();
+        final merged = Map<String, dynamic>.from(current.toMap())
+          ..addAll(Map<String, dynamic>.from(settingsJson)
+            ..removeWhere((key, _) => _secretSettingKeys.contains(key)));
+        await _settingsService.saveSettings(AppSettings.fromMap(merged));
+        settingsRestored = true;
+      } catch (e) {
+        // 設定の復元に失敗してもデータ本体の復元は続行する
+        settingsRestored = false;
+      }
+    }
+
     // 参照先（locations → plants）を先に投入する順序で一括コミットする
     await _db.insertRowsInBatch({
       'locations': locationRows,
@@ -358,6 +406,7 @@ class ExportService {
       noteCount: noteCount,
       sensorLogCount: sensorLogCount,
       locationCount: locationCount,
+      settingsRestored: settingsRestored,
     );
   }
 }
@@ -370,12 +419,17 @@ class ImportResult {
   final int sensorLogCount;
   final int locationCount;
 
+  /// アプリ設定（通知時刻・テーマ等）を復元したかどうか。
+  /// version 4 以前のバックアップには設定が含まれないため false になる。
+  final bool settingsRestored;
+
   const ImportResult({
     required this.plantCount,
     required this.logCount,
     required this.noteCount,
     this.sensorLogCount = 0,
     this.locationCount = 0,
+    this.settingsRestored = false,
   });
 
   @override
@@ -387,6 +441,7 @@ class ImportResult {
     ];
     if (sensorLogCount > 0) parts.add('センサーログ: $sensorLogCount件');
     if (locationCount > 0) parts.add('置き場所: $locationCount件');
+    if (settingsRestored) parts.add('アプリ設定');
     return parts.join('、');
   }
 }

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -97,6 +97,22 @@ class NotificationService {
     return true;
   }
 
+  /// 水やりリマインダーの本文を組み立てる。
+  ///
+  /// 対象植物が分かっている場合は名前を載せる。多い場合は先頭の名前＋残り件数に
+  /// 丸めて、通知本文が長くなりすぎないようにする（Issue #245）。
+  /// [duePlantNames] が空の場合は従来どおりの汎用文言を返す。
+  static String buildWateringReminderBody(List<String> duePlantNames) {
+    if (duePlantNames.isEmpty) return '水やりが必要な植物を確認しましょう';
+    if (duePlantNames.length == 1) {
+      return '${duePlantNames.first}に水やりをしましょう';
+    }
+    if (duePlantNames.length == 2) {
+      return '${duePlantNames[0]}と${duePlantNames[1]}に水やりをしましょう';
+    }
+    return '${duePlantNames.first} ほか${duePlantNames.length - 1}件に水やりをしましょう';
+  }
+
   /// 翌日の水やり予定をDBから直接確認し、予定がある場合のみ通知を1件登録する。
   ///
   /// バックグラウンドIsolateとアプリ起動時の両方から呼び出す共通ロジック。
@@ -132,10 +148,13 @@ class NotificationService {
     // 翌日の水やり予定をDBから確認
     final tomorrow = DateTime.now().add(const Duration(days: 1));
     bool hasDuePlants = false;
+    // 通知本文に載せる対象植物名（DBエラー時は空のまま汎用文言にフォールバック）
+    var duePlantNames = <String>[];
     try {
       final db = DatabaseService();
       final duePlants = await db.getPlantsDueOn(tomorrow);
       hasDuePlants = duePlants.isNotEmpty;
+      duePlantNames = duePlants.map((p) => p.name).toList();
       debugPrint(
           'NotificationService: plants due tomorrow = ${duePlants.length}');
     } catch (e) {
@@ -222,7 +241,7 @@ class NotificationService {
     await plugin.zonedSchedule(
       id: _dailyWateringNotificationId,
       title: '💧 水やりの時間です',
-      body: '水やりが必要な植物を確認しましょう',
+      body: buildWateringReminderBody(duePlantNames),
       scheduledDate: scheduledDate,
       notificationDetails: details,
       androidScheduleMode: scheduleMode,


### PR DESCRIPTION
## 概要

`/user-simulation`（ペルソナ: 一人暮らしの新米社会人・拡張モード）で発見した13件を修正しました。
**#241 のみ原因を特定できず未修正**です（詳細は下記）。

## 対応内容

### 不具合修正

| Issue | 内容 |
|---|---|
| #239 | バックアップにアプリ設定を含めるようにした（version 5）。認証情報は共有時の漏洩を避けるため除外 |
| #240 | 一括記録UIを FAB から下部バーに変更し、下部ボタン・植物カードとの重なりを解消 |
| #242 | ノートの作成時刻が常に「00:00」になる問題を修正 |
| #243 | 編集をキャンセルしても植物詳細ごと閉じて一覧に戻る問題を修正 |
| #244 | 見出しだけの空の「水やり情報」カードを非表示に |

### UX改善

| Issue | 内容 |
|---|---|
| #245 | 通知本文に対象の植物名・件数を入れた |
| #246 | 植物の追加・間隔変更・ログ記録時に通知を再スケジュール（500msデバウンス） |
| #247 | ノート空状態の文言をFABアイコンに合わせ、tooltip を追加 |
| #248 | ケア統計→水やりログのAppBar、置き場所管理→絞り込みシート、光量メーター→植物詳細「環境」タブに導線追加 |
| #249 | 過去日を見ているときは「今日」基準の次回予定チップを出さないようにした |
| #250 | 植物一覧のAppBarタイトルを「Botanote」→「植物一覧」に |
| #251 | 置き場所フィルタをAppBarのアイコン＋ボトムシートに移し、一覧のレイアウトずれを解消 |
| #252 | `getPlantsDueOn` のログ全件取得を `MAX(date)` の1クエリに置換 |

## 未対応

**#241（カレンダー日付タップでセマンティクスが消える）は未修正です。**
実際にセマンティクスツリーが失われていること（描画ループやuiautomatorのidle待ちではない）、
トリガーが「カレンダー表示中の `_selectedDate` 変更」であることまでは切り分けましたが、
仮説だった FutureBuilder のサブツリー再生成を修正しても再現したため、原因未特定です。
調査経過は #241 のコメントに残しました。

## 実装上の判断

- **#239 で認証情報を除外**: `AppSettings` には `natureRemoToken` / `switchBotToken` /
  `switchBotSecret` が含まれます。バックアップZIPはOSの共有シートでDrive・Gmail等へ
  送られるため、これらは書き出さず、復元時も端末側の現在値を保持します。
- **#243 で `pop(true)` を廃止**: 呼び出し元3箇所すべてが戻り値を使っておらず、
  一覧は `Consumer<PlantProvider>` で自動更新されるため、詳細に留まる実装にしました。
- **#249 は「非表示」を選択**: 次回予定を選択日基準に変えると、赤字判定を今日基準に
  統一した #124 の方針と矛盾するため、過去日では予定チップ自体を出さない形にしました。

## テスト

- `flutter analyze`: エラー・警告 0（既存の info 10件のみ）
- `flutter test`: 6件すべてパス
- 実機（エミュレータ `Medium_Phone_API_36.1` / 植物14件・ログ1991件）で確認:
  - #239: 通知時刻を21:00に設定 → エクスポート → アンインストール → 再インストール
    （09:00に戻る）→ インポート → **21:00に復元**、ダイアログに「アプリ設定」表示。
    ZIP内 `data.json` は `"version": 5` / `notificationHour: 21` / 認証情報3キーなし
  - #240: リスト表示・カレンダー表示の両方で重なりなし
  - #242: 00:17に作成したノートが「00:17」と表示
  - #243: 編集画面で戻る → 植物詳細に留まる
  - #245/#246: 間隔1日の植物を追加した直後に
    `plants due tomorrow = 1` → `smart scheduled for tomorrow at 21:00` をログで確認。
    翌21:00に「**DueTomorrowに水やりをしましょう**」の通知を受信
  - #248: 3つの導線すべて遷移確認
  - #250/#251: タイトル変更・チップ行の消失・絞り込みシート・解除バーを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)