### PR TITLE
fix: 利用シミュレーションで見つかった不具合・UX課題を修正 (#255〜#263)

### DIFF
--- a/lib/models/plant.dart
+++ b/lib/models/plant.dart
@@ -6,6 +6,12 @@ class Plant {
   /// 植物名（必須）
   final String name;
 
+  /// 植物名の読み仮名（任意）。五十音順の並び替えに使う（Issue #257）。
+  ///
+  /// 漢字の和名は読みを機械的に導けないため、正しく五十音順に並べたい
+  /// ユーザーが任意で入力する。未入力の場合は [name] を代わりに使う。
+  final String? nameReading;
+
   /// 品種名
   final String? variety;
 
@@ -55,6 +61,7 @@ class Plant {
   const Plant({
     required this.id,
     required this.name,
+    this.nameReading,
     this.variety,
     this.purchaseDate,
     this.purchaseLocation,
@@ -76,6 +83,7 @@ class Plant {
     return {
       'id': id,
       'name': name,
+      'nameReading': nameReading,
       'variety': variety,
       'purchaseDate': purchaseDate?.toIso8601String(),
       'purchaseLocation': purchaseLocation,
@@ -99,6 +107,7 @@ class Plant {
     return Plant(
       id: map['id'] as String,
       name: map['name'] as String,
+      nameReading: map['nameReading'] as String?,
       variety: map['variety'] as String?,
       purchaseDate: map['purchaseDate'] != null
           ? DateTime.parse(map['purchaseDate'] as String)
@@ -124,6 +133,7 @@ class Plant {
   /// nullable フィールドを明示的に null にしたい場合は sentinel パターンを使用する。
   Plant copyWith({
     String? name,
+    Object? nameReading = _sentinel,
     Object? variety = _sentinel,
     Object? purchaseDate = _sentinel,
     Object? purchaseLocation = _sentinel,
@@ -142,6 +152,8 @@ class Plant {
     return Plant(
       id: id,
       name: name ?? this.name,
+      nameReading:
+          nameReading == _sentinel ? this.nameReading : nameReading as String?,
       variety: variety == _sentinel ? this.variety : variety as String?,
       purchaseDate: purchaseDate == _sentinel ? this.purchaseDate : purchaseDate as DateTime?,
       purchaseLocation: purchaseLocation == _sentinel ? this.purchaseLocation : purchaseLocation as String?,

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -8,6 +8,7 @@ import '../models/app_settings.dart';
 import '../services/database_service.dart';
 import '../services/home_widget_service.dart';
 import '../services/notification_service.dart';
+import '../utils/japanese_sort_utils.dart';
 import '../utils/seasonal_interval_utils.dart';
 
 /// 植物データとログを管理する Provider。
@@ -149,11 +150,15 @@ class PlantProvider with ChangeNotifier {
     final plantsCopy = List<Plant>.from(_plants);
     
     switch (sortOrder) {
+      // 単純な compareTo だとコードポイント順になり和名が読み順に並ばないため、
+      // 読み仮名とかな正規化を考慮して比較する（Issue #257）
       case PlantSortOrder.nameAsc:
-        plantsCopy.sort((a, b) => a.name.compareTo(b.name));
+        plantsCopy.sort((a, b) =>
+            compareJapanese(a.name, a.nameReading, b.name, b.nameReading));
         break;
       case PlantSortOrder.nameDesc:
-        plantsCopy.sort((a, b) => b.name.compareTo(a.name));
+        plantsCopy.sort((a, b) =>
+            compareJapanese(b.name, b.nameReading, a.name, a.nameReading));
         break;
       case PlantSortOrder.purchaseDateDesc:
         plantsCopy.sort((a, b) {
@@ -214,6 +219,7 @@ class PlantProvider with ChangeNotifier {
 
   Future<void> addPlant({
     required String name,
+    String? nameReading,
     String? variety,
     DateTime? purchaseDate,
     String? purchaseLocation,
@@ -232,6 +238,7 @@ class PlantProvider with ChangeNotifier {
     final plant = Plant(
       id: const Uuid().v4(),
       name: name,
+      nameReading: nameReading,
       variety: variety,
       purchaseDate: purchaseDate,
       purchaseLocation: purchaseLocation,

--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -7,6 +7,7 @@ import '../providers/settings_provider.dart';
 import '../models/note.dart';
 import '../providers/note_provider.dart';
 import '../services/claude_share_service.dart';
+import '../widgets/claude_share_hint_dialog.dart';
 import '../utils/error_utils.dart';
 
 class AddEditNoteScreen extends StatefulWidget {
@@ -236,7 +237,7 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
                   TextButton.icon(
                     onPressed: _shareFirstImageForDiagnosis,
                     icon: const Icon(Icons.health_and_safety_outlined, size: 18),
-                    label: const Text('Claudeで診断'),
+                    label: const Text('Claudeに送って診断'),
                   ),
                 TextButton.icon(
                   onPressed: _showImageSourceOptions,
@@ -265,6 +266,10 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   /// 応答はClaudeアプリ上で確認し、内容欄に手動で貼り付ける。
   Future<void> _shareFirstImageForDiagnosis() async {
     if (_selectedImagePaths.isEmpty) return;
+
+    // 共有シートが開くことを初回だけ説明する（Issue #261）
+    if (!await confirmClaudeShare(context)) return;
+    if (!mounted) return;
 
     final messenger = ScaffoldMessenger.of(context);
     try {

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -6,6 +6,7 @@ import '../providers/plant_provider.dart';
 import '../providers/location_provider.dart';
 import '../models/plant.dart';
 import '../services/claude_share_service.dart';
+import '../widgets/claude_share_hint_dialog.dart';
 import '../widgets/plant_image_widget.dart';
 import '../utils/error_utils.dart';
 
@@ -21,6 +22,7 @@ class AddPlantScreen extends StatefulWidget {
 class _AddPlantScreenState extends State<AddPlantScreen> {
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
+  final _nameReadingController = TextEditingController();
   final _varietyController = TextEditingController();
   final _purchaseLocationController = TextEditingController();
   
@@ -45,6 +47,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
     super.initState();
     if (widget.plant != null) {
       _nameController.text = widget.plant!.name;
+      _nameReadingController.text = widget.plant!.nameReading ?? '';
       _varietyController.text = widget.plant!.variety ?? '';
       _purchaseLocationController.text = widget.plant!.purchaseLocation ?? '';
       _purchaseDate = widget.plant!.purchaseDate;
@@ -65,6 +68,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
   @override
   void dispose() {
     _nameController.dispose();
+    _nameReadingController.dispose();
     _varietyController.dispose();
     _purchaseLocationController.dispose();
     super.dispose();
@@ -167,6 +171,10 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
   Future<void> _shareImageForIdentification() async {
     if (_imagePath == null) return;
 
+    // 共有シートが開くことを初回だけ説明する（Issue #261）
+    if (!await confirmClaudeShare(context)) return;
+    if (!mounted) return;
+
     final messenger = ScaffoldMessenger.of(context);
     try {
       await ClaudeShareService.shareForIdentification(_imagePath!);
@@ -198,8 +206,11 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
         // Add new plant
         await plantProvider.addPlant(
           name: _nameController.text.trim(),
-          variety: _varietyController.text.trim().isEmpty 
-              ? null 
+          nameReading: _nameReadingController.text.trim().isEmpty
+              ? null
+              : _nameReadingController.text.trim(),
+          variety: _varietyController.text.trim().isEmpty
+              ? null
               : _varietyController.text.trim(),
           purchaseDate: _purchaseDate,
           purchaseLocation: _purchaseLocationController.text.trim().isEmpty
@@ -222,6 +233,9 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
         // sentinel パターンを用いて copyWith を呼び出す。
         final updatedPlant = widget.plant!.copyWith(
           name: _nameController.text.trim(),
+          nameReading: _nameReadingController.text.trim().isEmpty
+              ? null
+              : _nameReadingController.text.trim(),
           variety: _varietyController.text.trim().isEmpty
               ? null  // sentinel により null として保存される
               : _varietyController.text.trim(),
@@ -346,7 +360,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
                 child: TextButton.icon(
                   onPressed: _shareImageForIdentification,
                   icon: const Icon(Icons.auto_awesome_outlined, size: 18),
-                  label: const Text('Claudeで植物名を推定'),
+                  label: const Text('Claudeに送って推定'),
                 ),
               ),
             const SizedBox(height: 24),
@@ -367,7 +381,19 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
               },
             ),
             const SizedBox(height: 16),
-            
+
+            // 読み仮名（五十音順の並び替え用、Issue #257）
+            TextFormField(
+              controller: _nameReadingController,
+              decoration: const InputDecoration(
+                labelText: '読み仮名（任意）',
+                helperText: '入力すると「名前（あ→ん）」で五十音順に並びます',
+                border: OutlineInputBorder(),
+                prefixIcon: Icon(Icons.sort_by_alpha),
+              ),
+            ),
+            const SizedBox(height: 16),
+
             // Variety
             TextFormField(
               controller: _varietyController,
@@ -742,10 +768,53 @@ class _LogIntervalDialog extends StatefulWidget {
 }
 
 class _LogIntervalDialogState extends State<_LogIntervalDialog> {
+  static const int _minDays = 1;
+  static const int _maxDays = 60;
+  static const int _minEveryN = 1;
+  static const int _maxEveryN = 10;
+
   // 0 = 日数指定, 1 = 水やりN回に1回
   late int _modeIndex;
   late int _days;
   late int _everyN;
+
+  /// −/+ ボタン付きのステッパーを構築する（Issue #260）。
+  ///
+  /// スライダーだけでは狙った値に合わせにくいため、水やり間隔ダイアログ
+  /// （Issue #235 で対応済み）と同じ操作方法に揃える。
+  Widget _buildStepper({
+    required String label,
+    required int value,
+    required int min,
+    required int max,
+    required String decrementTooltip,
+    required String incrementTooltip,
+    required ValueChanged<int> onChanged,
+  }) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.remove_circle_outline),
+          tooltip: decrementTooltip,
+          onPressed: value > min ? () => onChanged(value - 1) : null,
+        ),
+        SizedBox(
+          width: 150,
+          child: Text(
+            label,
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.headlineSmall,
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.add_circle_outline),
+          tooltip: incrementTooltip,
+          onPressed: value < max ? () => onChanged(value + 1) : null,
+        ),
+      ],
+    );
+  }
 
   @override
   void initState() {
@@ -789,24 +858,39 @@ class _LogIntervalDialogState extends State<_LogIntervalDialog> {
             ),
           const SizedBox(height: 16),
           if (_modeIndex == 0) ...[
-            Text('$_days日ごと',
-                style: Theme.of(context).textTheme.headlineSmall),
+            // 水やり間隔ダイアログと操作を揃える（Issue #260）
+            _buildStepper(
+              label: '$_days日ごと',
+              value: _days,
+              min: _minDays,
+              max: _maxDays,
+              decrementTooltip: '1日減らす',
+              incrementTooltip: '1日増やす',
+              onChanged: (v) => setState(() => _days = v),
+            ),
             Slider(
               value: _days.toDouble(),
-              min: 1,
-              max: 60,
-              divisions: 59,
+              min: _minDays.toDouble(),
+              max: _maxDays.toDouble(),
+              divisions: _maxDays - _minDays,
               label: '$_days日',
               onChanged: (v) => setState(() => _days = v.toInt()),
             ),
           ] else ...[
-            Text('水やり$_everyN回に1回',
-                style: Theme.of(context).textTheme.headlineSmall),
+            _buildStepper(
+              label: '水やり$_everyN回に1回',
+              value: _everyN,
+              min: _minEveryN,
+              max: _maxEveryN,
+              decrementTooltip: '1回減らす',
+              incrementTooltip: '1回増やす',
+              onChanged: (v) => setState(() => _everyN = v),
+            ),
             Slider(
               value: _everyN.toDouble(),
-              min: 1,
-              max: 10,
-              divisions: 9,
+              min: _minEveryN.toDouble(),
+              max: _maxEveryN.toDouble(),
+              divisions: _maxEveryN - _minEveryN,
               label: '$_everyN回に1回',
               onChanged: (v) => setState(() => _everyN = v.toInt()),
             ),

--- a/lib/screens/location_list_screen.dart
+++ b/lib/screens/location_list_screen.dart
@@ -177,6 +177,7 @@ class LocationListScreen extends StatelessWidget {
         },
       ),
       floatingActionButton: FloatingActionButton(
+        tooltip: '置き場所を追加',
         onPressed: () => _showEditDialog(context),
         child: const Icon(Icons.add),
       ),

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -13,6 +13,7 @@ import '../providers/sensor_log_provider.dart';
 import '../providers/settings_provider.dart';
 import '../services/iot_service.dart';
 import '../utils/date_utils.dart';
+import '../utils/seasonal_interval_utils.dart';
 import 'add_plant_screen.dart';
 import 'add_edit_note_screen.dart';
 import 'iot_settings_screen.dart';
@@ -492,14 +493,49 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
     return null;
   }
 
+  /// 次回予定日の起算日（最終水やり日。ログが無ければ購入日または登録日）。
+  ///
+  /// 季節調整が効いているかの判定に使うため、`PlantProvider` の
+  /// `calcNextWateringDateFromLogs` と同じ基準で求める。
+  DateTime get _wateringBaseDate {
+    if (_wateringLogs.isEmpty) {
+      return _plant.purchaseDate ?? _plant.createdAt;
+    }
+    final sorted = [..._wateringLogs]..sort((a, b) => b.date.compareTo(a.date));
+    return sorted.first.date;
+  }
+
+  /// 季節調整を反映した実効の水やり間隔（日数）。
+  int? get _effectiveWateringIntervalDays {
+    final base = _plant.wateringIntervalDays;
+    if (base == null) return null;
+    return applySeasonalAdjustment(
+      baseIntervalDays: base,
+      seasonalAdjustmentEnabled: _plant.seasonalAdjustmentEnabled,
+      dormantMultiplier: _plant.dormantSeasonIntervalMultiplier,
+      referenceDate: _wateringBaseDate,
+    );
+  }
+
   Widget _buildWateringInfoCard() {
+    final base = _plant.wateringIntervalDays;
+    final effective = _effectiveWateringIntervalDays;
+    // 休眠期は間隔が延長されるため、素の間隔だけを出すと
+    // 「14日ごと」なのに次回が28日後、という矛盾に見える（Issue #255）
+    final isExtended = base != null && effective != null && effective != base;
+
     return _InfoCard(
       title: '水やり情報',
       children: [
-        if (_plant.wateringIntervalDays != null)
+        if (base != null)
           _InfoRow(
             label: '間隔',
-            value: '${_plant.wateringIntervalDays}日ごと',
+            value: isExtended ? '$effective日ごと' : '$base日ごと',
+          ),
+        if (isExtended)
+          _InfoRow(
+            label: '季節調整',
+            value: '休眠期のため $base日 → $effective日',
           ),
         if (_nextWateringDate != null)
           _InfoRow(

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -153,9 +153,11 @@ class _PlantListScreenState extends State<PlantListScreen> {
                   settings.plantSortOrder == PlantSortOrder.custom;
               final hasLocations = locationProvider.locations.isNotEmpty;
               return IconButton(
+                // 並び順の Icons.sort と形が似て見分けづらいため、
+                // 「置き場所」だと分かる家アイコンにする（Issue #259）
                 icon: Badge(
                   isLabelVisible: _selectedLocationId != null,
-                  child: const Icon(Icons.filter_list),
+                  child: const Icon(Icons.home_outlined),
                 ),
                 tooltip: '置き場所で絞り込む',
                 onPressed: (!hasLocations || isCustomSort)
@@ -326,9 +328,12 @@ class _PlantListScreenState extends State<PlantListScreen> {
     );
   }
 
+  /// 「植物を追加」FAB に最後の項目が隠れないよう確保する下部余白（Issue #262）。
+  static const double _fabBottomInset = 80;
+
   Widget _buildListView(List<Plant> plants) {
     return ListView.builder(
-      padding: const EdgeInsets.all(8),
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, _fabBottomInset),
       itemCount: plants.length,
       itemBuilder: (context, index) {
         return _PlantListTile(plant: plants[index]);
@@ -339,7 +344,7 @@ class _PlantListScreenState extends State<PlantListScreen> {
   /// グリッド（カード）表示ビューを構築する
   Widget _buildGridView(List<Plant> plants) {
     return GridView.builder(
-      padding: const EdgeInsets.all(12),
+      padding: const EdgeInsets.fromLTRB(12, 12, 12, _fabBottomInset),
       gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
         crossAxisCount: 2,
         crossAxisSpacing: 12,
@@ -359,7 +364,7 @@ class _PlantListScreenState extends State<PlantListScreen> {
     SettingsProvider settings,
   ) {
     return ReorderableListView.builder(
-      padding: const EdgeInsets.all(8),
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, _fabBottomInset),
       itemCount: plants.length,
       onReorder: (oldIndex, newIndex) {
         _onReorder(context, plants, oldIndex, newIndex, settings);
@@ -502,6 +507,9 @@ class _PlantListTile extends StatelessWidget {
           children: [
             if (plant.variety != null) Text(plant.variety!),
             _WateringStatusText(plant: plant),
+            // 鉢数と置き場所が増えると一覧では所在が分からなくなるため、
+            // 置き場所を設定している植物にはバッジを出す（Issue #258）
+            _LocationBadge(locationId: plant.locationId),
           ],
         ),
         onTap: () => _navigateToDetail(context, plant),
@@ -597,6 +605,47 @@ class _PlantGridCard extends StatelessWidget {
 ///
 /// 水やり間隔が未設定などで予定日を算出できない植物では何も表示しない。
 /// 予定超過（今日以前）の場合は error 色で強調する。
+/// 植物カードに置き場所を表示するバッジ（Issue #258）。
+///
+/// 置き場所が未設定、または参照先が削除済みの場合は何も表示しない。
+class _LocationBadge extends StatelessWidget {
+  final String? locationId;
+
+  const _LocationBadge({required this.locationId});
+
+  @override
+  Widget build(BuildContext context) {
+    final id = locationId;
+    if (id == null) return const SizedBox.shrink();
+
+    final locations = context.watch<LocationProvider>().locations;
+    final name = locations.where((l) => l.id == id).firstOrNull?.name;
+    if (name == null) return const SizedBox.shrink();
+
+    final color = Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6);
+    return Padding(
+      padding: const EdgeInsets.only(top: 2),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.home_outlined, size: 13, color: color),
+          const SizedBox(width: 2),
+          Flexible(
+            child: Text(
+              name,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodySmall
+                  ?.copyWith(color: color),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _WateringStatusText extends StatelessWidget {
   final Plant plant;
 

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -35,7 +35,7 @@ class DatabaseService {
 
     return await openDatabase(
       newPath,
-      version: 8,
+      version: 9,
       onCreate: _onCreate,
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -140,6 +140,15 @@ class DatabaseService {
           await db.execute(
               'DELETE FROM logs WHERE plantId NOT IN (SELECT id FROM plants)');
         }
+        if (oldVersion < 9) {
+          // 名前順の並び替えを五十音順にするための読み仮名（Issue #257）。
+          // 任意入力のため NOT NULL にはしない。
+          try {
+            await db.execute('ALTER TABLE plants ADD COLUMN nameReading TEXT');
+          } catch (_) {
+            // 既にカラムが存在する場合は無視
+          }
+        }
       },
     );
   }
@@ -149,6 +158,7 @@ class DatabaseService {
       CREATE TABLE plants(
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
+        nameReading TEXT,
         variety TEXT,
         purchaseDate TEXT,
         purchaseLocation TEXT,

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -35,7 +35,11 @@ class ExportService {
 
   /// 書き出すバックアップのバージョン。
   /// 5 でアプリ設定（`settings`）を含めるようになった（Issue #239）。
-  static const int _backupVersion = 5;
+  /// 6 で植物に読み仮名（`nameReading`）が加わった（Issue #257）。
+  ///
+  /// 旧バージョンのアプリが新しい形式を取り込むと、DB に存在しない列を
+  /// insert しようとして失敗するため、版数を上げて明示的に弾く。
+  static const int _backupVersion = 6;
 
   /// バックアップに含めないアプリ設定のキー。
   ///

--- a/lib/utils/date_utils.dart
+++ b/lib/utils/date_utils.dart
@@ -17,7 +17,21 @@ class AppDateUtils {
     return DateTime(date.year, date.month, date.day);
   }
 
+  /// 年をまたぐ場合だけ年を付けて日付をフォーマットする（Issue #256）。
+  ///
+  /// 現在の年と同じなら `M月d日`、異なる年なら `yyyy年M月d日` を返す。
+  /// 「1月2日」とだけ表示されると来年なのか去年なのか判別できないため、
+  /// 日付を表示する箇所はこのメソッドを経由させる。
+  static String formatDateWithYearIfNeeded(DateTime date) {
+    final now = DateTime.now();
+    if (date.year == now.year) return DateFormat('M月d日').format(date);
+    return DateFormat('yyyy年M月d日').format(date);
+  }
+
   /// 相対日付文字列（今日・昨日・明日 等）にフォーマットする。
+  ///
+  /// 相対表現に当てはまらない場合は [formatDateWithYearIfNeeded] に委ねるため、
+  /// 年をまたぐ予定日は年つきで表示される。
   static String formatRelativeDate(DateTime date) {
     final now = DateTime.now();
     final today = getDateOnly(now);
@@ -27,7 +41,7 @@ class AppDateUtils {
     if (difference == 0) return '今日';
     if (difference == -1) return '昨日';
     if (difference == 1) return '明日';
-    return DateFormat('M月d日').format(date);
+    return formatDateWithYearIfNeeded(date);
   }
 
   /// 日付差を文字列化する。期限切れの場合は文言を付加する。

--- a/lib/utils/japanese_sort_utils.dart
+++ b/lib/utils/japanese_sort_utils.dart
@@ -1,0 +1,150 @@
+/// 日本語の名前を五十音順で比較するためのユーティリティ（Issue #257）。
+///
+/// `String.compareTo` は UTF-16 のコードポイント順で比較するため、
+/// 「冬型→多肉→月兎耳→朧月→火祭り」のように読みと無関係な順序になる。
+/// ここでは以下の方針で並べる。
+///
+/// 1. 読み仮名（`nameReading`）が入力されていればそれを優先して使う
+/// 2. 全角カタカナはひらがなへ、半角カナは全角へ正規化して比較する
+/// 3. 濁点・半濁点・長音・小書き文字の違いは無視して比較し、
+///    同値になった場合のみ元の文字列で比較して順序を安定させる
+///
+/// 漢字は読みを機械的に導けないため、読み仮名が未入力の漢字名は
+/// かな名のあとにコードポイント順で並ぶ。
+library;
+
+/// ソート用のキー文字列を生成する。
+///
+/// [reading] があればそれを、無ければ [name] を正規化して返す。
+String buildJapaneseSortKey(String name, String? reading) {
+  final source = (reading != null && reading.trim().isNotEmpty)
+      ? reading.trim()
+      : name;
+  return _normalizeForSort(source);
+}
+
+/// 五十音順に比較する。
+///
+/// 正規化後のキーが同値の場合は元の文字列で比較し、順序を安定させる。
+int compareJapanese(
+  String aName,
+  String? aReading,
+  String bName,
+  String? bReading,
+) {
+  final aKey = buildJapaneseSortKey(aName, aReading);
+  final bKey = buildJapaneseSortKey(bName, bReading);
+
+  // かな始まりを漢字・英数字より先に並べる（読み順で探せるようにするため）
+  final aKana = _startsWithKana(aKey);
+  final bKana = _startsWithKana(bKey);
+  if (aKana != bKana) return aKana ? -1 : 1;
+
+  final byKey = aKey.compareTo(bKey);
+  if (byKey != 0) return byKey;
+  return aName.compareTo(bName);
+}
+
+/// 比較用に文字列を正規化する。
+///
+/// - 半角カナ → 全角カナ
+/// - カタカナ → ひらがな
+/// - 濁点/半濁点を除去（か = が）
+/// - 小書き文字を大書きへ（っ = つ）
+/// - 長音記号「ー」と中黒「・」、空白を除去
+String _normalizeForSort(String input) {
+  final buffer = StringBuffer();
+  for (final rune in _toFullWidthKana(input).runes) {
+    var c = rune;
+
+    // カタカナ（ァ-ヶ）をひらがなへ寄せる
+    if (c >= 0x30A1 && c <= 0x30F6) {
+      c -= 0x60;
+    }
+
+    // 長音・中黒・各種空白は無視する
+    if (c == 0x30FC || c == 0x30FB || c == 0x0020 || c == 0x3000) {
+      continue;
+    }
+
+    // 濁点・半濁点・小書きを基本形へ寄せる
+    c = _kanaBaseForm[c] ?? c;
+
+    buffer.writeCharCode(c);
+  }
+  return buffer.toString();
+}
+
+/// 先頭がひらがな（正規化後）かどうか。
+bool _startsWithKana(String normalized) {
+  if (normalized.isEmpty) return false;
+  final c = normalized.runes.first;
+  return c >= 0x3041 && c <= 0x3096;
+}
+
+/// 半角カナを全角カナに変換する。
+///
+/// 濁点・半濁点は後段で落とすため、ここでは基本形のみ対応させる。
+String _toFullWidthKana(String input) {
+  final buffer = StringBuffer();
+  for (final rune in input.runes) {
+    final mapped = _halfToFullKana[rune];
+    buffer.write(mapped ?? String.fromCharCode(rune));
+  }
+  return buffer.toString();
+}
+
+/// 濁点・半濁点・小書きのひらがなを基本形に対応付ける表。
+const Map<int, int> _kanaBaseForm = {
+  0x304C: 0x304B, // が→か
+  0x304E: 0x304D, // ぎ→き
+  0x3050: 0x304F, // ぐ→く
+  0x3052: 0x3051, // げ→け
+  0x3054: 0x3053, // ご→こ
+  0x3056: 0x3055, // ざ→さ
+  0x3058: 0x3057, // じ→し
+  0x305A: 0x3059, // ず→す
+  0x305C: 0x305B, // ぜ→せ
+  0x305E: 0x305D, // ぞ→そ
+  0x3060: 0x305F, // だ→た
+  0x3062: 0x3061, // ぢ→ち
+  0x3065: 0x3064, // づ→つ
+  0x3067: 0x3066, // で→て
+  0x3069: 0x3068, // ど→と
+  0x3070: 0x306F, // ば→は
+  0x3071: 0x306F, // ぱ→は
+  0x3073: 0x3072, // び→ひ
+  0x3074: 0x3072, // ぴ→ひ
+  0x3076: 0x3075, // ぶ→ふ
+  0x3077: 0x3075, // ぷ→ふ
+  0x3079: 0x3078, // べ→へ
+  0x307A: 0x3078, // ぺ→へ
+  0x307C: 0x307B, // ぼ→ほ
+  0x307D: 0x307B, // ぽ→ほ
+  0x3041: 0x3042, // ぁ→あ
+  0x3043: 0x3044, // ぃ→い
+  0x3045: 0x3046, // ぅ→う
+  0x3047: 0x3048, // ぇ→え
+  0x3049: 0x304A, // ぉ→お
+  0x3063: 0x3064, // っ→つ
+  0x3083: 0x3084, // ゃ→や
+  0x3085: 0x3086, // ゅ→ゆ
+  0x3087: 0x3088, // ょ→よ
+  0x308E: 0x308F, // ゎ→わ
+};
+
+/// 半角カナ → 全角カナ（基本形のみ）
+const Map<int, String> _halfToFullKana = {
+  0xFF66: 'ヲ', 0xFF67: 'ァ', 0xFF68: 'ィ', 0xFF69: 'ゥ', 0xFF6A: 'ェ',
+  0xFF6B: 'ォ', 0xFF6C: 'ャ', 0xFF6D: 'ュ', 0xFF6E: 'ョ', 0xFF6F: 'ッ',
+  0xFF70: 'ー', 0xFF71: 'ア', 0xFF72: 'イ', 0xFF73: 'ウ', 0xFF74: 'エ',
+  0xFF75: 'オ', 0xFF76: 'カ', 0xFF77: 'キ', 0xFF78: 'ク', 0xFF79: 'ケ',
+  0xFF7A: 'コ', 0xFF7B: 'サ', 0xFF7C: 'シ', 0xFF7D: 'ス', 0xFF7E: 'セ',
+  0xFF7F: 'ソ', 0xFF80: 'タ', 0xFF81: 'チ', 0xFF82: 'ツ', 0xFF83: 'テ',
+  0xFF84: 'ト', 0xFF85: 'ナ', 0xFF86: 'ニ', 0xFF87: 'ヌ', 0xFF88: 'ネ',
+  0xFF89: 'ノ', 0xFF8A: 'ハ', 0xFF8B: 'ヒ', 0xFF8C: 'フ', 0xFF8D: 'ヘ',
+  0xFF8E: 'ホ', 0xFF8F: 'マ', 0xFF90: 'ミ', 0xFF91: 'ム', 0xFF92: 'メ',
+  0xFF93: 'モ', 0xFF94: 'ヤ', 0xFF95: 'ユ', 0xFF96: 'ヨ', 0xFF97: 'ラ',
+  0xFF98: 'リ', 0xFF99: 'ル', 0xFF9A: 'レ', 0xFF9B: 'ロ', 0xFF9C: 'ワ',
+  0xFF9D: 'ン',
+};

--- a/lib/widgets/claude_share_hint_dialog.dart
+++ b/lib/widgets/claude_share_hint_dialog.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Claude連携（画像共有）の仕組みを初回だけ説明するダイアログ（Issue #261）。
+///
+/// 「Claudeで診断」を押すと OS の共有シートが開く実装のため、
+/// 何も説明が無いと Google検索・印刷・Maps などが並ぶ画面が出てきて面食らう。
+/// 共有シートを開く前に一度だけ手順を示し、以降は表示しない。
+const String _hintShownKey = 'claude_share_hint_shown';
+
+/// 必要なら説明ダイアログを表示し、共有処理を続行してよいかを返す。
+///
+/// 戻り値が `false` の場合はユーザーがキャンセルしたので共有しない。
+/// 2回目以降は何も表示せず `true` を返す。
+Future<bool> confirmClaudeShare(BuildContext context) async {
+  final prefs = await SharedPreferences.getInstance();
+  if (prefs.getBool(_hintShownKey) ?? false) return true;
+  if (!context.mounted) return false;
+
+  final proceed = await showDialog<bool>(
+    context: context,
+    builder: (context) => AlertDialog(
+      title: const Text('Claudeアプリに写真を送ります'),
+      content: const Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('このあと共有先を選ぶ画面が開きます。'
+              '一覧から「Claude」を選ぶと、質問文つきで写真が送られます。'),
+          SizedBox(height: 12),
+          Text('Claudeアプリが一覧に出てこない場合は、'
+              'ストアからインストールしてからお試しください。'),
+          SizedBox(height: 12),
+          Text('※ 回答はClaudeアプリ側に表示されます。'
+              'この画面には自動で反映されないため、必要な内容は手動で書き写してください。'),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: const Text('キャンセル'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          child: const Text('共有先を選ぶ'),
+        ),
+      ],
+    ),
+  );
+
+  if (proceed == true) {
+    await prefs.setBool(_hintShownKey, true);
+    return true;
+  }
+  return false;
+}

--- a/test/japanese_sort_utils_test.dart
+++ b/test/japanese_sort_utils_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bota_note/utils/japanese_sort_utils.dart';
+
+/// 名前だけのリストを五十音順に並べたものを返すテスト用ヘルパー。
+List<String> _sortedByName(List<String> names) {
+  final copy = [...names]
+    ..sort((a, b) => compareJapanese(a, null, b, null));
+  return copy;
+}
+
+/// (名前, 読み仮名) のリストを五十音順に並べて名前だけ返すヘルパー。
+List<String> _sortedWithReading(List<(String, String?)> entries) {
+  final copy = [...entries]
+    ..sort((a, b) => compareJapanese(a.$1, a.$2, b.$1, b.$2));
+  return copy.map((e) => e.$1).toList();
+}
+
+void main() {
+  group('compareJapanese', () {
+    test('ひらがなは五十音順に並ぶ', () {
+      expect(
+        _sortedByName(['さくら', 'あさがお', 'かすみそう']),
+        ['あさがお', 'かすみそう', 'さくら'],
+      );
+    });
+
+    test('カタカナはひらがなと同じ読み位置に並ぶ', () {
+      expect(
+        _sortedByName(['サクラ', 'あさがお', 'カスミソウ']),
+        ['あさがお', 'カスミソウ', 'サクラ'],
+      );
+    });
+
+    test('濁点・半濁点は清音と同じ位置で比較される', () {
+      // が・か は同値扱いなので、2文字目の「き」「く」で決まる
+      expect(
+        _sortedByName(['がく', 'かき']),
+        ['かき', 'がく'],
+      );
+    });
+
+    test('長音・中黒は無視される', () {
+      // 「アガベ・チタノタ」→「あかへちたのた」、「アガベ」→「あかへ」
+      expect(
+        _sortedByName(['アガベ・チタノタ', 'アガベ']),
+        ['アガベ', 'アガベ・チタノタ'],
+      );
+    });
+
+    test('小書き文字は大書きと同じ位置で比較される', () {
+      // 「きゃ」→「きや」なので「きは」より後ろ
+      expect(
+        _sortedByName(['きゃく', 'きはい']),
+        ['きはい', 'きゃく'],
+      );
+    });
+
+    test('読み仮名が入力されていれば漢字名でも五十音順に並ぶ', () {
+      // Issue #257: 読み仮名が無いとコードポイント順になってしまうケース
+      expect(
+        _sortedWithReading([
+          ('火祭り', 'ひまつり'),
+          ('朧月', 'おぼろづき'),
+          ('月兎耳', 'つきとじ'),
+          ('多肉', 'たにく'),
+        ]),
+        ['朧月', '多肉', '月兎耳', '火祭り'],
+      );
+    });
+
+    test('かな名は読み仮名なしの漢字名より先に並ぶ', () {
+      final sorted = _sortedWithReading([
+        ('朧月', null),
+        ('アガベ', null),
+        ('さくら', null),
+      ]);
+      expect(sorted.take(2), ['アガベ', 'さくら']);
+      expect(sorted.last, '朧月');
+    });
+
+    test('読み仮名が空文字の場合は名前で比較する', () {
+      expect(
+        _sortedWithReading([('さくら', '   '), ('あさがお', '')]),
+        ['あさがお', 'さくら'],
+      );
+    });
+
+    test('半角カナは全角カナと同じ位置で比較される', () {
+      expect(
+        _sortedByName(['ｻｸﾗ', 'あさがお']),
+        ['あさがお', 'ｻｸﾗ'],
+      );
+    });
+  });
+
+  group('buildJapaneseSortKey', () {
+    test('読み仮名があればそれを正規化して返す', () {
+      expect(buildJapaneseSortKey('朧月', 'オボロヅキ'), 'おほろつき');
+    });
+
+    test('読み仮名が無ければ名前を正規化して返す', () {
+      expect(buildJapaneseSortKey('アガベ・チタノタ', null), 'あかへちたのた');
+    });
+  });
+}


### PR DESCRIPTION
## 概要

`/user-simulation`（ペルソナ: 多肉・サボテンマニアの大学生・拡張モード）で見つかった9件を修正しました。
**#241 のみ未修正**ですが、今回の調査で**原因を `table_calendar` パッケージ側に特定**できました（詳細は下記）。

## 対応内容

| Issue | 内容 |
|---|---|
| #255 | 🔴 休眠期の実効間隔を表示し、「間隔」と「次回予定」の矛盾を解消 |
| #256 | 年をまたぐ日付に年を表示 |
| #257 | 名前順の並び替えを五十音順に（読み仮名フィールド追加・DB v9） |
| #258 | 植物一覧のカードに置き場所バッジを追加 |
| #259 | 置き場所フィルタのアイコンを `home_outlined` に変更し並び順と区別 |
| #260 | 肥料/活力剤の間隔ダイアログに −/+ ステッパーを追加 |
| #261 | Claude連携が共有シートであることを初回に案内 |
| #262 | 一覧の最下段カードとFABの重なりを解消 |
| #263 | 置き場所管理の追加FABに tooltip を追加 |

## 実装上の判断

- **#257 は読み仮名フィールドを追加**しました。漢字の読みは機械的に導けないため、
  `Collator` 等では解決できません。任意入力の `nameReading` を持たせ、
  未入力の漢字名は「かな名の後ろ」にまとめることで、読み順で探せる並びを優先しています。
  カタカナ/半角カナ/濁点/小書き/長音の正規化は
  `test/japanese_sort_utils_test.dart`（11ケース）で検証しています。
- **バックアップ版数を 6 に上げました**。旧バージョンのアプリが `nameReading` を含む
  バックアップを取り込むと、DB に存在しない列を insert して失敗するためです。
  逆方向（新アプリが v5 以前を読む）は実機で確認済みです。
- **#255 は「間隔」を実効値に変更**しました。素の値を残したまま注記を足す案もありましたが、
  次回予定日と直接対応する値を主表示にするほうが誤解が少ないと判断し、
  元の値は「季節調整」行で `16日 → 32日` と示しています。
- **#261 は毎回ではなく初回のみ案内**します。共有のたびにダイアログが出ると煩わしいため、
  `SharedPreferences` に表示済みフラグを持たせました。

## #241 について（未修正・原因は特定）

`onDaySelected` の中身を段階的に削って実機で計測したところ、**完全な no-op にしても再現**しました。

| `onDaySelected` の中身 | タップ前 | タップ後 |
|---|---|---|
| 現状のまま | 175 | 7 |
| 先読み呼び出しを削除 | 164 | 7 |
| `_selectedDate` の更新も削除 | 164 | 7 |
| **完全な no-op** | 187 | 7 |

アプリ側のコールバックは無関係で、`table_calendar` の日付セルのタップ処理が原因と確定しました。
また `pm clear` でデータを空にしても再現するため、**データ量には依存しません**
（前回の「27鉢だと起きやすい」という見立ては誤りでした）。
`table_calendar` は既に最新の 3.2.0 のため、バージョンを上げる回避策も取れません。
経緯と今後の選択肢は #241 にコメントしています。

## テスト

- `flutter analyze`: エラー・警告 0（既存の info 10件のみ）
- `flutter test`: 17件パス（うち五十音ソートの新規11件）
- 実機（エミュレータ `Medium_Phone_API_36.1`）で確認:
  - #255/#256: 12/20に水やり記録 → 「間隔 32日ごと / 季節調整 休眠期のため 16日 → 32日 / 次回予定 **2027年**1月21日」
  - #257: 「アガベ→アロエ→エケベリア→コノフィツム→サボテン→セダム→ハオルチア」と五十音順に。漢字名はかな名の後ろに整列
  - #258/#259: カードに「南向きの窓辺」等のバッジ、AppBarは家アイコンで並び順と区別可能
  - #262: 最下段の「銀月」がFABに隠れないことを確認
  - DBマイグレーション（v8→v9）と、v5形式バックアップの取り込みが正常に動作

Closes #255, #256, #257, #258, #259, #260, #261, #262, #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)