### PR TITLE
fix: オープン中のIssueをまとめて対応（バグ6件・機能12件）

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'providers/note_provider.dart';
 import 'providers/sensor_log_provider.dart';
 import 'providers/location_provider.dart';
 import 'screens/home_screen.dart';
+import 'screens/onboarding_screen.dart';
 import 'theme/app_themes.dart';
 import 'models/app_settings.dart';
 import 'services/notification_service.dart';
@@ -124,7 +125,15 @@ class MyApp extends StatelessWidget {
             theme: AppThemes.getLightTheme(settingsProvider.theme),
             darkTheme: AppThemes.getDarkTheme(settingsProvider.theme),
             themeMode: mode,
-            home: const HomeScreen(),
+            // 初回起動時はオンボーディングを挟む（Issue #277）。
+            // 設定の読み込み完了前に判定すると既存ユーザーにも一瞬表示されて
+            // しまうため、読み込みが終わるまではローディングを出す。
+            home: !settingsProvider.isLoaded
+                ? const Scaffold(
+                    body: Center(child: CircularProgressIndicator()))
+                : settingsProvider.onboardingCompleted
+                    ? const HomeScreen()
+                    : const OnboardingScreen(),
             debugShowCheckedModeBanner: false,
           );
         },

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -127,6 +127,9 @@ class AppSettings {
   /// 天気予報取得地点の経度
   final double? weatherLongitude;
 
+  /// 初回起動時のオンボーディングを完了したか（Issue #277）
+  final bool onboardingCompleted;
+
   AppSettings({
     this.viewMode = ViewMode.card,
     this.theme = AppTheme.green,
@@ -146,6 +149,7 @@ class AppSettings {
     this.weatherAlertsEnabled = false,
     this.weatherLatitude,
     this.weatherLongitude,
+    this.onboardingCompleted = false,
   }) : logTypeColors = logTypeColors ?? LogTypeColors();
 
   Map<String, dynamic> toMap() {
@@ -169,6 +173,7 @@ class AppSettings {
       'weatherAlertsEnabled': weatherAlertsEnabled,
       'weatherLatitude': weatherLatitude,
       'weatherLongitude': weatherLongitude,
+      'onboardingCompleted': onboardingCompleted,
     };
   }
 
@@ -215,6 +220,7 @@ class AppSettings {
       weatherAlertsEnabled: map['weatherAlertsEnabled'] as bool? ?? false,
       weatherLatitude: (map['weatherLatitude'] as num?)?.toDouble(),
       weatherLongitude: (map['weatherLongitude'] as num?)?.toDouble(),
+      onboardingCompleted: map['onboardingCompleted'] as bool? ?? false,
     );
   }
 
@@ -237,6 +243,7 @@ class AppSettings {
     bool? weatherAlertsEnabled,
     Object? weatherLatitude = _sentinel,
     Object? weatherLongitude = _sentinel,
+    bool? onboardingCompleted,
   }) {
     return AppSettings(
       viewMode: viewMode ?? this.viewMode,
@@ -264,6 +271,7 @@ class AppSettings {
       weatherLongitude: weatherLongitude == _sentinel
           ? this.weatherLongitude
           : weatherLongitude as double?,
+      onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
     );
   }
 }

--- a/lib/models/app_settings.dart
+++ b/lib/models/app_settings.dart
@@ -28,6 +28,7 @@ enum PlantSortOrder {
   custom,            // ユーザー指定
   varietyAsc,        // 品種名昇順
   varietyDesc,       // 品種名降順
+  nextWateringAsc,   // 次の水やり予定が近い順（予定超過を先頭に、Issue #271）
 }
 
 class LogTypeColors {

--- a/lib/models/note.dart
+++ b/lib/models/note.dart
@@ -15,6 +15,9 @@ class Note {
   /// 関連する植物IDリスト
   final List<String> plantIds;
 
+  /// タグ（`#` は含めない素の文字列。例: `発根管理`）（Issue #278）
+  final List<String> tags;
+
   final DateTime createdAt;
   final DateTime updatedAt;
 
@@ -24,6 +27,7 @@ class Note {
     this.content,
     this.imagePaths = const [],
     this.plantIds = const [],
+    this.tags = const [],
     required this.createdAt,
     required this.updatedAt,
   });
@@ -37,6 +41,7 @@ class Note {
       'content': content,
       'imagePaths': jsonEncode(imagePaths),
       'plantIds': jsonEncode(plantIds),
+      'tags': jsonEncode(tags),
       'createdAt': createdAt.toIso8601String(),
       'updatedAt': updatedAt.toIso8601String(),
     };
@@ -65,6 +70,7 @@ class Note {
       content: map['content'] as String?,
       imagePaths: parseList(map['imagePaths']),
       plantIds: parseList(map['plantIds']),
+      tags: parseList(map['tags']),
       createdAt: DateTime.parse(map['createdAt'] as String),
       updatedAt: DateTime.parse(map['updatedAt'] as String),
     );
@@ -78,6 +84,7 @@ class Note {
     Object? content = _sentinel,
     List<String>? imagePaths,
     List<String>? plantIds,
+    List<String>? tags,
     DateTime? updatedAt,
   }) {
     return Note(
@@ -86,6 +93,7 @@ class Note {
       content: content == _sentinel ? this.content : content as String?,
       imagePaths: imagePaths ?? this.imagePaths,
       plantIds: plantIds ?? this.plantIds,
+      tags: tags ?? this.tags,
       createdAt: createdAt,
       updatedAt: updatedAt ?? DateTime.now(),
     );

--- a/lib/providers/note_provider.dart
+++ b/lib/providers/note_provider.dart
@@ -38,6 +38,7 @@ class NoteProvider with ChangeNotifier {
     String? content,
     List<String>? plantIds,
     List<String>? imagePaths,
+    List<String>? tags,
     DateTime? createdAt,
   }) async {
     final now = DateTime.now();
@@ -47,11 +48,31 @@ class NoteProvider with ChangeNotifier {
       content: content,
       plantIds: plantIds ?? [],
       imagePaths: imagePaths ?? [],
+      tags: tags ?? [],
       createdAt: createdAt ?? now,
       updatedAt: now,
     );
     await _db.insertNote(note);
     await loadNotes();
+  }
+
+  /// 登録済みの全タグを、使用回数の多い順・同数なら五十音順で返す（Issue #278）。
+  ///
+  /// タグ入力欄の候補表示と、一覧の絞り込みチップに使う。
+  List<String> get allTags {
+    final counts = <String, int>{};
+    for (final note in _notes) {
+      for (final tag in note.tags) {
+        counts[tag] = (counts[tag] ?? 0) + 1;
+      }
+    }
+    final tags = counts.keys.toList();
+    tags.sort((a, b) {
+      final diff = counts[b]!.compareTo(counts[a]!);
+      if (diff != 0) return diff;
+      return a.compareTo(b);
+    });
+    return tags;
   }
 
   /// 既存のノートを更新する。

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -212,6 +212,23 @@ class PlantProvider with ChangeNotifier {
           return b.variety!.compareTo(a.variety!);
         });
         break;
+      case PlantSortOrder.nextWateringAsc:
+        // 次回水やり予定が近い順。予定日が過去（予定超過）のものほど先頭に来る。
+        // 水やり間隔が未設定で予定日を持たない植物は末尾にまとめる（Issue #271）。
+        plantsCopy.sort((a, b) {
+          final aNext = _nextWateringCache[a.id];
+          final bNext = _nextWateringCache[b.id];
+          if (aNext == null && bNext == null) {
+            return compareJapanese(a.name, a.nameReading, b.name, b.nameReading);
+          }
+          if (aNext == null) return 1;
+          if (bNext == null) return -1;
+          final diff = aNext.compareTo(bNext);
+          if (diff != 0) return diff;
+          // 同じ予定日なら名前順で安定させる
+          return compareJapanese(a.name, a.nameReading, b.name, b.nameReading);
+        });
+        break;
     }
     
     return plantsCopy;

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -689,13 +689,29 @@ class PlantProvider with ChangeNotifier {
   }
 
   /// 指定日の複数種別のログを一括削除する。
-  Future<void> deleteMultipleLogsForDate(
+  ///
+  /// 戻り値は削除したログの一覧。[restoreLogs] に渡すと取り消しを戻せる
+  /// （Issue #280 の「元に戻す」用）。
+  Future<List<LogEntry>> deleteMultipleLogsForDate(
     String plantId,
     List<LogType> logTypes,
     DateTime date,
   ) async {
+    final deleted = <LogEntry>[];
     for (final logType in logTypes) {
+      // 削除前のログを控えてから消す
+      deleted.addAll(await getLogsForDate(plantId, logType, date));
       await deleteLogsForDate(plantId, logType, date);
+    }
+    return deleted;
+  }
+
+  /// 削除したログを元の内容のまま復元する（Issue #280 の「元に戻す」）。
+  ///
+  /// ID も含めて同一のレコードを書き戻すため、二重実行しても増えない。
+  Future<void> restoreLogs(List<LogEntry> logs) async {
+    for (final log in logs) {
+      await _db.insertLog(log);
     }
   }
 
@@ -859,7 +875,25 @@ class PlantProvider with ChangeNotifier {
   }
 
   /// すべての植物の水やり間隔を指定日数に一括設定する。
-  Future<void> bulkUpdateWateringInterval(int days) async {
+  /// 一括変更の対象となる植物の件数を返す（Issue #274）。
+  ///
+  /// [onlyWithInterval] が true の場合は、水やり間隔が設定済みの植物だけを数える
+  /// （一括調整の対象件数）。
+  int countBulkIntervalTargets({required bool onlyWithInterval}) {
+    if (!onlyWithInterval) return _plants.length;
+    return _plants.where((p) => p.wateringIntervalDays != null).length;
+  }
+
+  /// 変更前の水やり間隔を植物IDごとに控える（Issue #274 の「元に戻す」用）。
+  Map<String, int?> _snapshotWateringIntervals() {
+    return {for (final plant in _plants) plant.id: plant.wateringIntervalDays};
+  }
+
+  /// すべての植物の水やり間隔を [days] に設定する。
+  ///
+  /// 戻り値は変更前の間隔（植物ID → 日数）。「元に戻す」に使う。
+  Future<Map<String, int?>> bulkUpdateWateringInterval(int days) async {
+    final previous = _snapshotWateringIntervals();
     for (final plant in _plants) {
       final updated = plant.copyWith(
         wateringIntervalDays: days,
@@ -868,16 +902,38 @@ class PlantProvider with ChangeNotifier {
       await _db.updatePlant(updated);
     }
     await loadPlants();
+    return previous;
   }
 
   /// 水やり間隔が設定されている植物のみ、間隔に delta を加算して一括調整する。
   /// 結果は最低 1 日にクランプする。
-  Future<void> bulkAdjustWateringInterval(int delta) async {
+  ///
+  /// 戻り値は変更前の間隔（植物ID → 日数）。「元に戻す」に使う。
+  Future<Map<String, int?>> bulkAdjustWateringInterval(int delta) async {
+    final previous = _snapshotWateringIntervals();
     for (final plant in _plants) {
       if (plant.wateringIntervalDays == null) continue;
       final newDays = (plant.wateringIntervalDays! + delta).clamp(1, 9999);
       final updated = plant.copyWith(
         wateringIntervalDays: newDays,
+        updatedAt: DateTime.now(),
+      );
+      await _db.updatePlant(updated);
+    }
+    await loadPlants();
+    return previous;
+  }
+
+  /// 一括変更前の水やり間隔を復元する（Issue #274 の「元に戻す」）。
+  ///
+  /// [previous] に含まれない植物（一括変更後に追加された等）は対象外。
+  Future<void> restoreWateringIntervals(Map<String, int?> previous) async {
+    for (final plant in _plants) {
+      if (!previous.containsKey(plant.id)) continue;
+      final before = previous[plant.id];
+      if (plant.wateringIntervalDays == before) continue;
+      final updated = plant.copyWith(
+        wateringIntervalDays: before,
         updatedAt: DateTime.now(),
       );
       await _db.updatePlant(updated);

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -20,10 +20,21 @@ class SettingsProvider with ChangeNotifier {
   PlantSortOrder get plantSortOrder => _settings.plantSortOrder;
   List<String> get customSortOrder => _settings.customSortOrder;
 
+  /// 初回起動時のオンボーディングを完了済みか（Issue #277）。
+  bool get onboardingCompleted => _settings.onboardingCompleted;
+
+  /// 設定の初回読み込みが完了したか。
+  ///
+  /// 読み込み前に「オンボーディング未完了」と判定してしまうと、既存ユーザーに
+  /// 一瞬オンボーディングが表示されてしまうため、完了を待ってから判定する。
+  bool get isLoaded => _isLoaded;
+  bool _isLoaded = false;
+
   /// 保存済み設定を読み込む。
   /// 通知が有効な場合はアプリ起動時に再スケジュールする。
   Future<void> loadSettings() async {
     _settings = await _settingsService.loadSettings();
+    _isLoaded = true;
     notifyListeners();
     // アプリ起動時に通知設定が有効ならスマートスケジュールを実行する
     // （OSが再起動するとスケジュール済み通知が消えるため）
@@ -43,6 +54,13 @@ class SettingsProvider with ChangeNotifier {
         minute: _settings.notificationMinute,
       );
     }
+  }
+
+  /// オンボーディングの完了状態を保存する（Issue #277）。
+  Future<void> setOnboardingCompleted(bool completed) async {
+    _settings = _settings.copyWith(onboardingCompleted: completed);
+    await _settingsService.saveSettings(_settings);
+    notifyListeners();
   }
 
   /// 表示モードを変更する。

--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -140,7 +140,10 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
       appBar: AppBar(
         title: Text(widget.note == null ? 'ノート作成' : 'ノート編集'),
         actions: [
-          IconButton(onPressed: _save, icon: const Icon(Icons.save)),
+          IconButton(
+              onPressed: _save,
+              icon: const Icon(Icons.save),
+              tooltip: '保存'),
         ],
       ),
       body: Form(

--- a/lib/screens/add_edit_note_screen.dart
+++ b/lib/screens/add_edit_note_screen.dart
@@ -26,6 +26,10 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   List<String> _selectedPlantIds = [];
   List<String> _selectedImagePaths = [];
 
+  /// このノートに付けたタグ（Issue #278）
+  List<String> _tags = [];
+  late TextEditingController _tagController;
+
   /// 新規作成時のみ使用する作成日時（デフォルト=現在時刻）。
   /// 一覧では時刻も表示するため、日付だけに丸めず時刻を保持する（Issue #242）。
   late DateTime _selectedDate;
@@ -38,6 +42,8 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
     _selectedPlantIds = widget.note?.plantIds ??
         (widget.initialPlantId != null ? [widget.initialPlantId!] : []);
     _selectedImagePaths = widget.note?.imagePaths ?? [];
+    _tags = List<String>.from(widget.note?.tags ?? const <String>[]);
+    _tagController = TextEditingController();
     // 新規作成時：現在日時を初期値、編集時：既存のcreatedAt
     _selectedDate = widget.note?.createdAt ?? DateTime.now();
   }
@@ -46,7 +52,92 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   void dispose() {
     _titleController.dispose();
     _contentController.dispose();
+    _tagController.dispose();
     super.dispose();
+  }
+
+  /// 入力中のタグを確定して追加する（Issue #278）。
+  ///
+  /// 先頭の `#` と前後の空白は取り除き、重複は追加しない。
+  void _addTag(String raw) {
+    final tag = raw.trim().replaceFirst(RegExp(r'^#+'), '').trim();
+    if (tag.isEmpty || _tags.contains(tag)) {
+      _tagController.clear();
+      return;
+    }
+    setState(() {
+      _tags.add(tag);
+      _tagController.clear();
+    });
+  }
+
+  /// タグ入力欄と、付与済みタグ・既存タグ候補の表示（Issue #278）。
+  Widget _buildTagField(BuildContext context) {
+    final theme = Theme.of(context);
+    return Consumer<NoteProvider>(
+      builder: (context, noteProv, _) {
+        // 未使用の既存タグだけを候補として出す
+        final suggestions =
+            noteProv.allTags.where((t) => !_tags.contains(t)).take(12).toList();
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('タグ', style: theme.textTheme.titleSmall),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _tagController,
+              textInputAction: TextInputAction.done,
+              decoration: InputDecoration(
+                hintText: '例: 発根管理、徒長、開花',
+                border: const OutlineInputBorder(),
+                prefixText: '# ',
+                suffixIcon: IconButton(
+                  icon: const Icon(Icons.add),
+                  tooltip: 'タグを追加',
+                  onPressed: () => _addTag(_tagController.text),
+                ),
+              ),
+              onSubmitted: _addTag,
+            ),
+            if (_tags.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: _tags
+                    .map((tag) => Chip(
+                          label: Text('#$tag'),
+                          visualDensity: VisualDensity.compact,
+                          onDeleted: () => setState(() => _tags.remove(tag)),
+                        ))
+                    .toList(),
+              ),
+            ],
+            if (suggestions.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                '使ったことのあるタグ',
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
+              const SizedBox(height: 4),
+              Wrap(
+                spacing: 6,
+                runSpacing: 4,
+                children: suggestions
+                    .map((tag) => ActionChip(
+                          label: Text('#$tag'),
+                          visualDensity: VisualDensity.compact,
+                          onPressed: () => _addTag(tag),
+                        ))
+                    .toList(),
+              ),
+            ],
+          ],
+        );
+      },
+    );
   }
 
   /// 作成日選択UIウィジェット群（新規作成時のみ利用）
@@ -110,6 +201,11 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
   void _save() async {
     if (!_formKey.currentState!.validate()) return;
 
+    // 入力途中のタグも保存対象に含める（Issue #278）
+    if (_tagController.text.trim().isNotEmpty) {
+      _addTag(_tagController.text);
+    }
+
     final provider = context.read<NoteProvider>();
 
     if (widget.note == null) {
@@ -118,6 +214,7 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
         content: _contentController.text.trim(),
         plantIds: _selectedPlantIds,
         imagePaths: _selectedImagePaths,
+        tags: _tags,
         createdAt: _selectedDate,
       );
     } else {
@@ -126,6 +223,7 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
         content: _contentController.text.trim(),
         plantIds: _selectedPlantIds,
         imagePaths: _selectedImagePaths,
+        tags: _tags,
         updatedAt: DateTime.now(),
       );
       await provider.updateNote(updated);
@@ -215,6 +313,10 @@ class _AddEditNoteScreenState extends State<AddEditNoteScreen> {
                 ],
               );
             }),
+            const SizedBox(height: 16),
+
+            // タグ（Issue #278）
+            _buildTagField(context),
             const SizedBox(height: 16),
 
             // 内容

--- a/lib/screens/add_plant_screen.dart
+++ b/lib/screens/add_plant_screen.dart
@@ -418,6 +418,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
               trailing: _purchaseDate != null
                   ? IconButton(
                       icon: const Icon(Icons.clear),
+                      tooltip: '購入日をクリア',
                       onPressed: () {
                         setState(() {
                           _purchaseDate = null;
@@ -509,6 +510,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
               trailing: _wateringInterval != null
                   ? IconButton(
                       icon: const Icon(Icons.clear),
+                      tooltip: '水やり間隔をクリア',
                       onPressed: () {
                         setState(() {
                           _wateringInterval = null;
@@ -635,6 +637,7 @@ class _AddPlantScreenState extends State<AddPlantScreen> {
       trailing: (intervalDays != null || everyNWaterings != null)
           ? IconButton(
               icon: const Icon(Icons.clear),
+              tooltip: '設定をクリア',
               onPressed: () => onChanged(null, null),
             )
           : null,

--- a/lib/screens/bulk_add_plants_screen.dart
+++ b/lib/screens/bulk_add_plants_screen.dart
@@ -1,0 +1,513 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+
+import '../models/location.dart';
+import '../providers/location_provider.dart';
+import '../providers/plant_provider.dart';
+import '../services/claude_share_service.dart';
+import '../utils/error_utils.dart';
+
+/// 複数の植物をまとめて登録する画面（Issue #66）。
+///
+/// 棚の写真のように複数の植物が写った1枚の画像を Claude アプリに共有して
+/// 判別してもらい、返ってきた一覧を貼り付けると、行ごとに植物として
+/// 連続登録できる。判別を使わず、名前を直接書き並べて登録することもできる。
+///
+/// AI連携は Anthropic API を直接叩かず、OSの共有シート経由で Claude アプリに
+/// 渡す方式に揃えている（Issue #177/#178 と同じ理由で従量課金を避けるため）。
+class BulkAddPlantsScreen extends StatefulWidget {
+  const BulkAddPlantsScreen({super.key});
+
+  @override
+  State<BulkAddPlantsScreen> createState() => _BulkAddPlantsScreenState();
+}
+
+class _BulkAddPlantsScreenState extends State<BulkAddPlantsScreen> {
+  final _picker = ImagePicker();
+  final _pastedTextController = TextEditingController();
+
+  /// 判別を依頼した写真（任意）
+  String? _imagePath;
+
+  /// 貼り付けたテキストから読み取った登録候補
+  final List<PlantDraft> _drafts = [];
+
+  /// 全候補に共通で設定する水やり間隔（null = 未設定）
+  int? _wateringInterval;
+
+  /// 全候補に共通で設定する置き場所（null = 未設定）
+  String? _locationId;
+
+  bool _isSaving = false;
+
+  @override
+  void dispose() {
+    _pastedTextController.dispose();
+    for (final draft in _drafts) {
+      draft.dispose();
+    }
+    super.dispose();
+  }
+
+  /// 判別してもらう写真を選ぶ。
+  Future<void> _pickImage(ImageSource source) async {
+    try {
+      final picked = await _picker.pickImage(source: source, imageQuality: 85);
+      if (picked == null || !mounted) return;
+      setState(() => _imagePath = picked.path);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('画像の取得に失敗しました: ${describeError(e)}')),
+      );
+    }
+  }
+
+  /// 写真を Claude アプリに共有して、写っている植物の一覧を作ってもらう。
+  Future<void> _shareForBulkIdentification() async {
+    final path = _imagePath;
+    if (path == null) return;
+    try {
+      await ClaudeShareService.shareForBulkIdentification(path);
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('共有に失敗しました: ${describeError(e)}')),
+      );
+    }
+  }
+
+  /// 貼り付けたテキストを1行1植物として読み取る。
+  void _parsePastedText() {
+    final drafts = parsePlantList(_pastedTextController.text);
+    if (drafts.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('植物名を読み取れませんでした。1行に1つずつ入力してください')),
+      );
+      return;
+    }
+    setState(() {
+      for (final draft in _drafts) {
+        draft.dispose();
+      }
+      _drafts
+        ..clear()
+        ..addAll(drafts);
+    });
+  }
+
+  /// 選択された候補をまとめて登録する。
+  Future<void> _saveAll() async {
+    final targets = _drafts.where((d) => d.selected).toList();
+    if (targets.isEmpty) return;
+
+    setState(() => _isSaving = true);
+    final plantProvider = context.read<PlantProvider>();
+    final messenger = ScaffoldMessenger.of(context);
+    final navigator = Navigator.of(context);
+
+    try {
+      for (final draft in targets) {
+        final name = draft.nameController.text.trim();
+        if (name.isEmpty) continue;
+        final variety = draft.varietyController.text.trim();
+        await plantProvider.addPlant(
+          name: name,
+          variety: variety.isEmpty ? null : variety,
+          wateringIntervalDays: _wateringInterval,
+          locationId: _locationId,
+        );
+      }
+      messenger.showSnackBar(
+        SnackBar(content: Text('${targets.length}件の植物を登録しました')),
+      );
+      navigator.pop(true);
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _isSaving = false);
+      messenger.showSnackBar(
+        SnackBar(content: Text('登録に失敗しました: ${describeError(e)}')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final selectedCount = _drafts.where((d) => d.selected).length;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('植物をまとめて登録')),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(16, 16, 16, 96),
+        children: [
+          _buildStepHeader(context, 1, '写真から判別する（任意）'),
+          const SizedBox(height: 8),
+          Text(
+            '複数の植物が写った写真を Claude アプリに送ると、写っている植物の一覧を'
+            '作ってもらえます。返ってきた一覧をコピーして、次の欄に貼り付けてください。',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: 12),
+          if (_imagePath != null) ...[
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: Image.file(
+                File(_imagePath!),
+                height: 180,
+                width: double.infinity,
+                fit: BoxFit.cover,
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              OutlinedButton.icon(
+                onPressed: () => _pickImage(ImageSource.camera),
+                icon: const Icon(Icons.photo_camera_outlined),
+                label: const Text('撮影'),
+              ),
+              OutlinedButton.icon(
+                onPressed: () => _pickImage(ImageSource.gallery),
+                icon: const Icon(Icons.photo_library_outlined),
+                label: const Text('写真を選ぶ'),
+              ),
+              FilledButton.tonalIcon(
+                onPressed: _imagePath == null ? null : _shareForBulkIdentification,
+                icon: const Icon(Icons.auto_awesome),
+                label: const Text('Claudeで判別'),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+
+          _buildStepHeader(context, 2, '植物名を貼り付ける'),
+          const SizedBox(height: 8),
+          TextField(
+            controller: _pastedTextController,
+            minLines: 4,
+            maxLines: 10,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              alignLabelWithHint: true,
+              hintText: 'モンステラ / デリシオサ\n'
+                  'サンスベリア（ローレンチー）\n'
+                  'ポトス',
+              helperText: '1行に1つ。「名前 / 品種」「名前（品種）」の形式にも対応します',
+              helperMaxLines: 2,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Align(
+            alignment: Alignment.centerRight,
+            child: FilledButton.icon(
+              onPressed: _parsePastedText,
+              icon: const Icon(Icons.playlist_add_check),
+              label: const Text('読み取る'),
+            ),
+          ),
+
+          if (_drafts.isNotEmpty) ...[
+            const SizedBox(height: 24),
+            _buildStepHeader(context, 3, '内容を確認して登録'),
+            const SizedBox(height: 8),
+            _buildCommonSettings(context),
+            const SizedBox(height: 8),
+            ..._drafts.map(_buildDraftTile),
+          ],
+        ],
+      ),
+      bottomNavigationBar: _drafts.isEmpty
+          ? null
+          : SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+                child: FilledButton.icon(
+                  onPressed:
+                      (_isSaving || selectedCount == 0) ? null : _saveAll,
+                  icon: _isSaving
+                      ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.check),
+                  label: Text('$selectedCount件を登録'),
+                  style: FilledButton.styleFrom(
+                    minimumSize: const Size(double.infinity, 48),
+                  ),
+                ),
+              ),
+            ),
+    );
+  }
+
+  Widget _buildStepHeader(BuildContext context, int step, String title) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        CircleAvatar(
+          radius: 12,
+          backgroundColor: theme.colorScheme.primaryContainer,
+          child: Text(
+            '$step',
+            style: theme.textTheme.labelSmall
+                ?.copyWith(color: theme.colorScheme.onPrimaryContainer),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Text(title, style: theme.textTheme.titleMedium),
+      ],
+    );
+  }
+
+  /// 登録するすべての植物に共通で適用する設定。
+  Widget _buildCommonSettings(BuildContext context) {
+    return Card(
+      margin: EdgeInsets.zero,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+        child: Column(
+          children: [
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.water_drop_outlined),
+              title: const Text('水やり間隔（全件に適用）'),
+              subtitle: Text(
+                  _wateringInterval == null ? '未設定' : '$_wateringInterval日ごと'),
+              trailing: _wateringInterval == null
+                  ? const Icon(Icons.chevron_right)
+                  : IconButton(
+                      icon: const Icon(Icons.clear),
+                      tooltip: '水やり間隔をクリア',
+                      onPressed: () => setState(() => _wateringInterval = null),
+                    ),
+              onTap: _showIntervalPicker,
+            ),
+            Consumer<LocationProvider>(
+              builder: (context, locationProvider, _) {
+                final locations = locationProvider.locations;
+                if (locations.isEmpty) return const SizedBox.shrink();
+                return ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: const Icon(Icons.home_outlined),
+                  title: const Text('置き場所（全件に適用）'),
+                  subtitle: Text(_locationName(locations) ?? '未設定'),
+                  trailing: _locationId == null
+                      ? const Icon(Icons.chevron_right)
+                      : IconButton(
+                          icon: const Icon(Icons.clear),
+                          tooltip: '置き場所をクリア',
+                          onPressed: () => setState(() => _locationId = null),
+                        ),
+                  onTap: () => _showLocationPicker(locations),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String? _locationName(List<Location> locations) {
+    if (_locationId == null) return null;
+    for (final location in locations) {
+      if (location.id == _locationId) return location.name;
+    }
+    return null;
+  }
+
+  Future<void> _showIntervalPicker() async {
+    var days = _wateringInterval ?? 7;
+    final result = await showDialog<int>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialogState) => AlertDialog(
+          title: const Text('水やり間隔'),
+          content: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              IconButton.filledTonal(
+                icon: const Icon(Icons.remove),
+                tooltip: '1日減らす',
+                onPressed: days <= 1
+                    ? null
+                    : () => setDialogState(() => days--),
+              ),
+              SizedBox(
+                width: 96,
+                child: Text(
+                  '$days日ごと',
+                  textAlign: TextAlign.center,
+                  style: Theme.of(ctx).textTheme.titleLarge,
+                ),
+              ),
+              IconButton.filledTonal(
+                icon: const Icon(Icons.add),
+                tooltip: '1日増やす',
+                onPressed: () => setDialogState(() => days++),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(ctx).pop(),
+              child: const Text('キャンセル'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(ctx).pop(days),
+              child: const Text('設定'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (result != null) setState(() => _wateringInterval = result);
+  }
+
+  Future<void> _showLocationPicker(List<Location> locations) async {
+    final result = await showModalBottomSheet<String>(
+      context: context,
+      builder: (ctx) => SafeArea(
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.not_interested),
+              title: const Text('未設定'),
+              onTap: () => Navigator.of(ctx).pop(''),
+            ),
+            ...locations.map((location) => ListTile(
+                  leading: Icon(location.isOutdoor
+                      ? Icons.wb_sunny_outlined
+                      : Icons.home_outlined),
+                  title: Text(location.name),
+                  onTap: () => Navigator.of(ctx).pop(location.id),
+                )),
+          ],
+        ),
+      ),
+    );
+    if (result == null) return;
+    setState(() => _locationId = result.isEmpty ? null : result);
+  }
+
+  Widget _buildDraftTile(PlantDraft draft) {
+    return Card(
+      margin: const EdgeInsets.only(top: 8),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(4, 8, 12, 8),
+        child: Row(
+          children: [
+            Checkbox(
+              value: draft.selected,
+              onChanged: (v) => setState(() => draft.selected = v ?? false),
+            ),
+            Expanded(
+              child: Column(
+                children: [
+                  TextField(
+                    controller: draft.nameController,
+                    decoration: const InputDecoration(
+                      labelText: '植物名',
+                      isDense: true,
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  TextField(
+                    controller: draft.varietyController,
+                    decoration: const InputDecoration(
+                      labelText: '品種（任意）',
+                      isDense: true,
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 登録候補1件分の入力状態。
+class PlantDraft {
+  final TextEditingController nameController;
+  final TextEditingController varietyController;
+  bool selected;
+
+  PlantDraft({required String name, String? variety, this.selected = true})
+      : nameController = TextEditingController(text: name),
+        varietyController = TextEditingController(text: variety ?? '');
+
+  void dispose() {
+    nameController.dispose();
+    varietyController.dispose();
+  }
+}
+
+/// 貼り付けテキストを植物の登録候補に変換する（Issue #66）。
+///
+/// 1行1植物とみなし、以下を取り除く/切り分ける:
+/// - 行頭の箇条書き記号・番号（`- `, `* `, `1. `, `1) ` など）
+/// - Markdown の強調記号（`**`）
+/// - `名前 / 品種`、`名前（品種）`、`名前 (品種)` の区切り
+///
+/// 空行と、区切り線のような記号だけの行は無視する。
+List<PlantDraft> parsePlantList(String raw) {
+  final drafts = <PlantDraft>[];
+  final seen = <String>{};
+
+  for (final line in raw.split('\n')) {
+    var text = line.trim();
+    if (text.isEmpty) continue;
+
+    // 行頭の箇条書き記号・番号を落とす
+    text = text.replaceFirst(RegExp(r'^\s*(?:[-*・●○]|\d+[.)、]|\(\d+\))\s*'), '');
+    // Markdown の強調記号を落とす
+    text = text.replaceAll('**', '').trim();
+    if (text.isEmpty) continue;
+    // 区切り線など記号だけの行は無視する
+    if (!RegExp(r'[0-9A-Za-z぀-ヿ一-鿿]').hasMatch(text)) {
+      continue;
+    }
+
+    String name = text;
+    String? variety;
+
+    // 「名前 / 品種」形式
+    final slash = RegExp(r'\s*[/／|｜]\s*');
+    if (slash.hasMatch(name)) {
+      final parts = name.split(slash);
+      name = parts.first.trim();
+      final rest = parts.skip(1).join(' ').trim();
+      if (rest.isNotEmpty) variety = rest;
+    } else {
+      // 「名前（品種）」形式
+      final paren = RegExp(r'^(.+?)\s*[（(]([^）)]*)[）)]\s*$').firstMatch(name);
+      if (paren != null) {
+        name = paren.group(1)!.trim();
+        final inner = paren.group(2)!.trim();
+        if (inner.isNotEmpty) variety = inner;
+      }
+    }
+
+    if (name.isEmpty) continue;
+    // 同じ名前が複数行に出てきた場合は1件にまとめる
+    final key = '$name|${variety ?? ''}';
+    if (!seen.add(key)) continue;
+
+    drafts.add(PlantDraft(name: name, variety: variety));
+  }
+
+  return drafts;
+}

--- a/lib/screens/iot_settings_screen.dart
+++ b/lib/screens/iot_settings_screen.dart
@@ -398,6 +398,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
                   icon: Icon(_obscureNatureRemo
                       ? Icons.visibility_off
                       : Icons.visibility),
+                  tooltip: _obscureNatureRemo ? 'トークンを表示' : 'トークンを隠す',
                   onPressed: () => setState(
                       () => _obscureNatureRemo = !_obscureNatureRemo),
                 ),
@@ -445,6 +446,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
                   icon: Icon(_obscureSwitchBotToken
                       ? Icons.visibility_off
                       : Icons.visibility),
+                  tooltip: _obscureSwitchBotToken ? 'トークンを表示' : 'トークンを隠す',
                   onPressed: () => setState(() =>
                       _obscureSwitchBotToken = !_obscureSwitchBotToken),
                 ),
@@ -461,6 +463,7 @@ class _IotSettingsScreenState extends State<IotSettingsScreen> {
                   icon: Icon(_obscureSwitchBotSecret
                       ? Icons.visibility_off
                       : Icons.visibility),
+                  tooltip: _obscureSwitchBotSecret ? 'シークレットを表示' : 'シークレットを隠す',
                   onPressed: () => setState(() =>
                       _obscureSwitchBotSecret = !_obscureSwitchBotSecret),
                 ),

--- a/lib/screens/location_list_screen.dart
+++ b/lib/screens/location_list_screen.dart
@@ -19,28 +19,40 @@ class LocationListScreen extends StatelessWidget {
       builder: (context) => StatefulBuilder(
         builder: (context, setState) => AlertDialog(
           title: Text(location == null ? '置き場所を追加' : '置き場所を編集'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: nameController,
-                autofocus: true,
-                decoration: const InputDecoration(
-                  labelText: '場所名',
-                  border: OutlineInputBorder(),
-                  hintText: '例: リビング、ベランダ',
+          // 名前欄を自動フォーカスするとIMEのフローティングツールバーが「屋外」
+          // スイッチに重なり、タップしても切り替わらなくなる（Issue #268）。
+          // 自動フォーカスをやめ、内容もスクロール可能にして退避できるようにする。
+          content: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: nameController,
+                  textInputAction: TextInputAction.done,
+                  decoration: const InputDecoration(
+                    labelText: '場所名',
+                    border: OutlineInputBorder(),
+                    hintText: '例: リビング、ベランダ',
+                  ),
+                  // 保存ボタンの活性状態を即座に反映するため、入力のたびに再描画する
+                  onChanged: (_) => setState(() {}),
+                  // 入力確定でキーボードを閉じ、下のスイッチを操作できるようにする
+                  onSubmitted: (_) => FocusScope.of(context).unfocus(),
                 ),
-                // 保存ボタンの活性状態を即座に反映するため、入力のたびに再描画する
-                onChanged: (_) => setState(() {}),
-              ),
-              const SizedBox(height: 16),
-              SwitchListTile(
-                contentPadding: EdgeInsets.zero,
-                title: const Text('屋外'),
-                value: isOutdoor,
-                onChanged: (value) => setState(() => isOutdoor = value),
-              ),
-            ],
+                const SizedBox(height: 16),
+                SwitchListTile(
+                  contentPadding: EdgeInsets.zero,
+                  title: const Text('屋外'),
+                  subtitle: const Text('天気連動ケアアラートの対象になります'),
+                  value: isOutdoor,
+                  onChanged: (value) {
+                    // スイッチ操作時にキーボードが出ていれば閉じる
+                    FocusScope.of(context).unfocus();
+                    setState(() => isOutdoor = value);
+                  },
+                ),
+              ],
+            ),
           ),
           actions: [
             TextButton(

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -100,12 +100,14 @@ class NoteDetailScreen extends StatelessWidget {
         actions: [
           IconButton(
             icon: const Icon(Icons.edit),
+            tooltip: '編集',
             onPressed: () => Navigator.of(context).push(
               MaterialPageRoute(builder: (_) => AddEditNoteScreen(note: note)),
             ),
           ),
           IconButton(
             icon: const Icon(Icons.delete),
+            tooltip: '削除',
             onPressed: () async {
               final confirmed = await showDialog<bool>(
                 context: context,

--- a/lib/screens/note_detail_screen.dart
+++ b/lib/screens/note_detail_screen.dart
@@ -140,6 +140,22 @@ class NoteDetailScreen extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            // タグチップ（Issue #278）
+            if (note.tags.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Wrap(
+                  spacing: 6,
+                  runSpacing: 4,
+                  children: note.tags
+                      .map((tag) => Chip(
+                            label: Text('#$tag'),
+                            visualDensity: VisualDensity.compact,
+                          ))
+                      .toList(),
+                ),
+              ),
+
             // 植物チップ
             if (note.plantIds.isNotEmpty)
               Consumer<PlantProvider>(builder: (context, plantProv, _) {

--- a/lib/screens/notes_list_screen.dart
+++ b/lib/screens/notes_list_screen.dart
@@ -21,6 +21,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
   final _searchController = TextEditingController();
   String _searchQuery = '';
   String? _filterPlantId; // null = すべての植物
+  String? _filterTag; // null = すべてのタグ（Issue #278）
   bool _isSearching = false;
 
   @override
@@ -43,18 +44,25 @@ class _NotesListScreenState extends State<NotesListScreen> {
   List<Note> _applyFilters(List<Note> notes) {
     var result = notes;
 
-    // キーワード検索（タイトル・内容）
+    // キーワード検索（タイトル・内容・タグ）
     if (_searchQuery.isNotEmpty) {
       final q = _searchQuery.toLowerCase();
       result = result.where((n) {
         return n.title.toLowerCase().contains(q) ||
-            (n.content?.toLowerCase().contains(q) ?? false);
+            (n.content?.toLowerCase().contains(q) ?? false) ||
+            // タグ名でもヒットさせる（Issue #278）
+            n.tags.any((t) => t.toLowerCase().contains(q));
       }).toList();
     }
 
     // 植物フィルタ
     if (_filterPlantId != null) {
       result = result.where((n) => n.plantIds.contains(_filterPlantId)).toList();
+    }
+
+    // タグフィルタ（Issue #278）
+    if (_filterTag != null) {
+      result = result.where((n) => n.tags.contains(_filterTag)).toList();
     }
 
     return result;
@@ -211,7 +219,11 @@ class _NotesListScreenState extends State<NotesListScreen> {
           final filteredNotes = _applyFilters(noteProvider.notes);
 
           // 絞り込み中のフィルタバー
-          final isFiltering = _searchQuery.isNotEmpty || _filterPlantId != null;
+          final isFiltering = _searchQuery.isNotEmpty ||
+              _filterPlantId != null ||
+              _filterTag != null;
+          // 登録済みタグ（Issue #278）
+          final allTags = noteProvider.allTags;
 
           if (noteProvider.notes.isEmpty) {
             return Center(
@@ -259,11 +271,45 @@ class _NotesListScreenState extends State<NotesListScreen> {
                           _searchQuery = '';
                           _searchController.clear();
                           _filterPlantId = null;
+                          _filterTag = null;
                           _isSearching = false;
                         }),
                         child: Icon(Icons.close,
                             size: 16,
                             color: Theme.of(context).colorScheme.onSecondaryContainer),
+                      ),
+                    ],
+                  ),
+                ),
+
+              // ── タグ絞り込みチップ（Issue #278）──
+              if (allTags.isNotEmpty)
+                SizedBox(
+                  height: 48,
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.symmetric(horizontal: 12),
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 6),
+                        child: FilterChip(
+                          label: const Text('すべて'),
+                          selected: _filterTag == null,
+                          onSelected: (_) => setState(() => _filterTag = null),
+                          visualDensity: VisualDensity.compact,
+                        ),
+                      ),
+                      ...allTags.map(
+                        (tag) => Padding(
+                          padding: const EdgeInsets.only(left: 6, top: 6, bottom: 6),
+                          child: FilterChip(
+                            label: Text('#$tag'),
+                            selected: _filterTag == tag,
+                            onSelected: (selected) => setState(
+                                () => _filterTag = selected ? tag : null),
+                            visualDensity: VisualDensity.compact,
+                          ),
+                        ),
                       ),
                     ],
                   ),
@@ -317,6 +363,7 @@ class _NotesListScreenState extends State<NotesListScreen> {
           .firstOrNull;
       if (name != null) parts.add(name);
     }
+    if (_filterTag != null) parts.add('#$_filterTag');
     return '${parts.join(' ・ ')} で絞り込み中';
   }
 
@@ -493,6 +540,31 @@ class _NotesListScreenState extends State<NotesListScreen> {
                                                 materialTapTargetSize:
                                                     MaterialTapTargetSize
                                                         .shrinkWrap,
+                                              ))
+                                          .toList(),
+                                    ),
+                                  ],
+
+                                  // タグチップ（Issue #278）。タップでそのタグに絞り込む。
+                                  if (note.tags.isNotEmpty) ...[
+                                    const SizedBox(height: 6),
+                                    Wrap(
+                                      spacing: 4,
+                                      runSpacing: 2,
+                                      children: note.tags
+                                          .map((tag) => ActionChip(
+                                                label: Text('#$tag'),
+                                                visualDensity:
+                                                    VisualDensity.compact,
+                                                padding: EdgeInsets.zero,
+                                                labelStyle: Theme.of(context)
+                                                    .textTheme
+                                                    .labelSmall,
+                                                materialTapTargetSize:
+                                                    MaterialTapTargetSize
+                                                        .shrinkWrap,
+                                                onPressed: () => setState(
+                                                    () => _filterTag = tag),
                                               ))
                                           .toList(),
                                     ),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,0 +1,196 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/settings_provider.dart';
+import '../services/notification_service.dart';
+
+/// 初回起動時に表示するオンボーディング画面（Issue #277）。
+///
+/// インストール直後は空の「水やりログ」画面がいきなり出るだけで、
+/// 何をすればよいか分からなかった。3画面で使い方の流れを説明し、
+/// 最後の画面で通知が必要な理由を示してから権限をリクエストする。
+class OnboardingScreen extends StatefulWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  final PageController _pageController = PageController();
+  int _currentPage = 0;
+
+  /// 通知権限のリクエスト中かどうか（ボタンの二重押し防止）
+  bool _isRequestingPermission = false;
+
+  static const List<_OnboardingPage> _pages = [
+    _OnboardingPage(
+      icon: Icons.eco,
+      title: 'まずは植物を登録しましょう',
+      description: '育てている植物を登録すると、水やり・肥料・活力剤の記録を\n'
+          '1鉢ずつ管理できます。写真や購入日も残せます。',
+    ),
+    _OnboardingPage(
+      icon: Icons.water_drop,
+      title: '水やりの間隔を決めます',
+      description: '「3日ごと」のように間隔を設定すると、次の水やり予定日を\n'
+          'アプリが計算します。冬は間隔を自動で延ばすこともできます。',
+    ),
+    _OnboardingPage(
+      icon: Icons.notifications_active,
+      title: '予定日にお知らせします',
+      description: '水やり予定がある日だけ、決めた時刻に通知でお知らせします。\n'
+          '通知から直接その日の水やりを記録することもできます。\n\n'
+          'このあと通知の許可を確認します。',
+    ),
+  ];
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  bool get _isLastPage => _currentPage == _pages.length - 1;
+
+  /// オンボーディングを完了させる。
+  ///
+  /// [requestPermission] が true の場合は通知権限をリクエストしてから閉じる。
+  Future<void> _finish({required bool requestPermission}) async {
+    if (_isRequestingPermission) return;
+    setState(() => _isRequestingPermission = true);
+
+    final settingsProvider = context.read<SettingsProvider>();
+    try {
+      if (requestPermission && settingsProvider.notificationEnabled) {
+        final service = NotificationService();
+        final granted = await service.requestPermission();
+        if (granted) {
+          await NotificationService.scheduleSmartWateringReminder(
+            hour: settingsProvider.settings.notificationHour,
+            minute: settingsProvider.settings.notificationMinute,
+          );
+        }
+      }
+    } catch (e) {
+      // 権限リクエストに失敗してもオンボーディング自体は完了させる
+      debugPrint('オンボーディングの通知権限リクエストに失敗しました: $e');
+    }
+
+    await settingsProvider.setOnboardingCompleted(true);
+    if (mounted) setState(() => _isRequestingPermission = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: _isRequestingPermission
+                    ? null
+                    : () => _finish(requestPermission: false),
+                child: const Text('スキップ'),
+              ),
+            ),
+            Expanded(
+              child: PageView.builder(
+                controller: _pageController,
+                itemCount: _pages.length,
+                onPageChanged: (index) => setState(() => _currentPage = index),
+                itemBuilder: (context, index) => _buildPage(_pages[index]),
+              ),
+            ),
+            // ページインジケーター
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: List.generate(_pages.length, (index) {
+                final isActive = index == _currentPage;
+                return AnimatedContainer(
+                  duration: const Duration(milliseconds: 200),
+                  margin: const EdgeInsets.symmetric(horizontal: 4),
+                  width: isActive ? 20 : 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: isActive
+                        ? theme.colorScheme.primary
+                        : theme.colorScheme.outlineVariant,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                );
+              }),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(24, 24, 24, 32),
+              child: SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: _isRequestingPermission
+                      ? null
+                      : () {
+                          if (_isLastPage) {
+                            _finish(requestPermission: true);
+                          } else {
+                            _pageController.nextPage(
+                              duration: const Duration(milliseconds: 250),
+                              curve: Curves.easeInOut,
+                            );
+                          }
+                        },
+                  style: FilledButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                  ),
+                  child: Text(_isLastPage ? 'はじめる' : '次へ'),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPage(_OnboardingPage page) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(page.icon, size: 96, color: theme.colorScheme.primary),
+          const SizedBox(height: 32),
+          Text(
+            page.title,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.headlineSmall,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            page.description,
+            textAlign: TextAlign.center,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// オンボーディング1ページ分の内容。
+class _OnboardingPage {
+  final IconData icon;
+  final String title;
+  final String description;
+
+  const _OnboardingPage({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+}

--- a/lib/screens/plant_detail_screen.dart
+++ b/lib/screens/plant_detail_screen.dart
@@ -169,7 +169,10 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
   }
 
   /// 画像背景上でも見やすいアクションボタンを生成する（半透明の丸背景付き）
-  Widget _buildImageOverlayAction(IconData icon, VoidCallback onPressed) {
+  ///
+  /// [tooltip] はスクリーンリーダーの読み上げにも使われるため必須とする（Issue #282）。
+  Widget _buildImageOverlayAction(
+      IconData icon, String tooltip, VoidCallback onPressed) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
       child: DecoratedBox(
@@ -179,6 +182,7 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
         ),
         child: IconButton(
           icon: Icon(icon, color: Colors.white),
+          tooltip: tooltip,
           onPressed: onPressed,
           iconSize: 22,
           padding: const EdgeInsets.all(6),
@@ -248,8 +252,8 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
             forceElevated: innerBoxIsScrolled,
             actions: [
               if (_plant.imagePath != null)
-                _buildImageOverlayAction(
-                    Icons.auto_awesome_motion, _navigateToGrowthTimeline)
+                _buildImageOverlayAction(Icons.auto_awesome_motion, '成長タイムライン',
+                    _navigateToGrowthTimeline)
               else
                 IconButton(
                   icon: const Icon(Icons.auto_awesome_motion),
@@ -257,17 +261,19 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                   onPressed: _navigateToGrowthTimeline,
                 ),
               if (_plant.imagePath != null)
-                _buildImageOverlayAction(Icons.edit, _navigateToEdit)
+                _buildImageOverlayAction(Icons.edit, '編集', _navigateToEdit)
               else
                 IconButton(
                   icon: const Icon(Icons.edit),
+                  tooltip: '編集',
                   onPressed: _navigateToEdit,
                 ),
               if (_plant.imagePath != null)
-                _buildImageOverlayAction(Icons.delete, _deletePlant)
+                _buildImageOverlayAction(Icons.delete, '削除', _deletePlant)
               else
                 IconButton(
                   icon: const Icon(Icons.delete),
+                  tooltip: '削除',
                   onPressed: _deletePlant,
                 ),
             ],
@@ -537,6 +543,12 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
             label: '季節調整',
             value: '休眠期のため $base日 → $effective日',
           ),
+        // 現在延長中でなくても設定内容が分かるようにする（Issue #279）
+        if (!isExtended)
+          _InfoRow(
+            label: '冬季の延長',
+            value: _seasonalAdjustmentDescription(base),
+          ),
         if (_nextWateringDate != null)
           _InfoRow(
             label: '次回予定',
@@ -547,6 +559,29 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
           ),
       ],
     );
+  }
+
+  /// 「冬季は間隔を延長する」設定の内容を人が読める文言にする（Issue #279）。
+  ///
+  /// [baseIntervalDays] が分かる場合は延長後の日数も添える。
+  String _seasonalAdjustmentDescription(int? baseIntervalDays) {
+    final multiplier = _plant.dormantSeasonIntervalMultiplier;
+    if (!_plant.seasonalAdjustmentEnabled || multiplier == null) {
+      return 'しない';
+    }
+    final months = dormantSeasonMonths.toList()..sort();
+    // 12・1・2月を「12〜2月」と読みやすく表記する
+    final monthsLabel = months.contains(12) && months.contains(1)
+        ? '12〜${months.where((m) => m != 12).reduce((a, b) => a > b ? a : b)}月'
+        : '${months.join('・')}月';
+    final multiplierLabel =
+        multiplier == multiplier.roundToDouble() ? '${multiplier.round()}' : '$multiplier';
+
+    if (baseIntervalDays == null) {
+      return '$monthsLabel は間隔を$multiplierLabel倍にする';
+    }
+    final extended = (baseIntervalDays * multiplier).round();
+    return '$monthsLabel は $baseIntervalDays日 → $extended日（$multiplierLabel倍）';
   }
 
   Widget _buildFertilizerInfoCard() {
@@ -620,8 +655,11 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
                     style: Theme.of(context).textTheme.titleMedium,
                   ),
                   const SizedBox(height: 8),
+                  // 実際の導線に合わせた案内にする（Issue #269）
                   Text(
-                    '「記録」ボタンから水やり・肥料・活力剤を記録できます',
+                    '「その他のケアを記録」から植え替え・剪定・葉水・掃除を記録できます。\n'
+                    '水やり・肥料・活力剤は「水やりログ」タブから記録します。',
+                    textAlign: TextAlign.center,
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                 ],
@@ -1156,56 +1194,164 @@ class _PlantDetailScreenState extends State<PlantDetailScreen> with SingleTicker
   }
 
   Widget _buildGroupedLogRow(DateTime day, List<LogEntry> logs) {
+    final theme = Theme.of(context);
+    // メモ付きのログは本文としても表示する（Issue #267）
+    final logsWithNote =
+        logs.where((log) => (log.note ?? '').trim().isNotEmpty).toList();
+
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-        child: Row(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              DateFormat('yyyy年MM月dd日').format(day),
-              style: Theme.of(context).textTheme.bodyMedium,
+            Row(
+              children: [
+                Text(
+                  DateFormat('yyyy年MM月dd日').format(day),
+                  style: theme.textTheme.bodyMedium,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Wrap(
+                    spacing: 8,
+                    runSpacing: 4,
+                    children:
+                        logs.map((log) => _buildLogTypeChip(log)).toList(),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline, size: 20),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
+                  tooltip: '${DateFormat('M月d日').format(day)}の記録をすべて削除',
+                  onPressed: () => _deleteLogsForDay(day, logs),
+                ),
+              ],
             ),
-            const SizedBox(width: 12),
+            if (logsWithNote.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              ...logsWithNote.map(_buildLogNoteLine),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// ログ1件分のチップ。× で種類ごとに個別削除できる（Issue #272）。
+  ///
+  /// メモがある場合はタップで全文を表示する（Issue #267）。
+  Widget _buildLogTypeChip(LogEntry log) {
+    final theme = Theme.of(context);
+    final typeName = _getLogTypeName(log.type);
+    final hasNote = (log.note ?? '').trim().isNotEmpty;
+
+    return InputChip(
+      avatar: Icon(
+        _getIconForLogType(log.type),
+        size: 16,
+        color: theme.colorScheme.primary,
+      ),
+      label: Text(
+        typeName,
+        style: theme.textTheme.bodySmall
+            ?.copyWith(color: theme.colorScheme.primary),
+      ),
+      visualDensity: VisualDensity.compact,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onPressed: hasNote ? () => _showLogNoteDialog(log) : null,
+      deleteIcon: const Icon(Icons.close, size: 16),
+      deleteButtonTooltipMessage: '$typeName の記録を削除',
+      onDeleted: () => _deleteSingleLog(log),
+    );
+  }
+
+  /// ログのメモを一覧上に本文として表示する行（Issue #267）。
+  ///
+  /// 長い場合は2行で省略し、タップで全文ダイアログを開く。
+  Widget _buildLogNoteLine(LogEntry log) {
+    final theme = Theme.of(context);
+    return InkWell(
+      onTap: () => _showLogNoteDialog(log),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 2),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              Icons.sticky_note_2_outlined,
+              size: 14,
+              color: theme.colorScheme.outline,
+            ),
+            const SizedBox(width: 4),
             Expanded(
-              child: Wrap(
-                spacing: 8,
-                runSpacing: 4,
-                children: logs.map((log) {
-                  return Tooltip(
-                    message: log.note ?? _getLogTypeName(log.type),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Icon(
-                          _getIconForLogType(log.type),
-                          size: 16,
-                          color: Theme.of(context).colorScheme.primary,
-                        ),
-                        const SizedBox(width: 3),
-                        Text(
-                          _getLogTypeName(log.type),
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                            color: Theme.of(context).colorScheme.primary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  );
-                }).toList(),
+              child: Text(
+                '${_getLogTypeName(log.type)}: ${log.note!.trim()}',
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
               ),
-            ),
-            IconButton(
-              icon: const Icon(Icons.delete_outline, size: 20),
-              padding: EdgeInsets.zero,
-              constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
-              tooltip: '${DateFormat('M月d日').format(day)}の記録を削除',
-              onPressed: () => _deleteLogsForDay(day, logs),
             ),
           ],
         ),
       ),
     );
+  }
+
+  /// ログのメモ全文を表示する（Issue #267）。
+  Future<void> _showLogNoteDialog(LogEntry log) async {
+    await showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('${_getLogTypeName(log.type)}のメモ'),
+        content: SingleChildScrollView(
+          child: SelectableText(log.note ?? ''),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('閉じる'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// ログを1件だけ削除する（Issue #272）。
+  Future<void> _deleteSingleLog(LogEntry log) async {
+    // async ギャップ前に context 依存の参照を取得しておく
+    final plantProvider = context.read<PlantProvider>();
+    final typeName = _getLogTypeName(log.type);
+
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('記録を削除'),
+        content: Text(
+            '${DateFormat('yyyy年MM月dd日').format(log.date)}の「$typeName」の記録を削除しますか？'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+            child: const Text('削除'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      await plantProvider.deleteLog(log.id);
+      await _loadData();
+    }
   }
 
   Future<void> _deleteLogsForDay(DateTime day, List<LogEntry> logs) async {

--- a/lib/screens/plant_growth_timeline_screen.dart
+++ b/lib/screens/plant_growth_timeline_screen.dart
@@ -74,6 +74,7 @@ class PlantGrowthTimelineScreen extends StatelessWidget {
               right: 4,
               child: IconButton(
                 icon: const Icon(Icons.close, color: Colors.white),
+                tooltip: '閉じる',
                 onPressed: () => Navigator.of(context).pop(),
               ),
             ),

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -466,6 +466,8 @@ class _PlantListScreenState extends State<PlantListScreen> {
         return '品種名（あ→ん）';
       case PlantSortOrder.varietyDesc:
         return '品種名（ん→あ）';
+      case PlantSortOrder.nextWateringAsc:
+        return '水やり予定が近い順';
     }
   }
 
@@ -485,6 +487,8 @@ class _PlantListScreenState extends State<PlantListScreen> {
       case PlantSortOrder.varietyAsc:
       case PlantSortOrder.varietyDesc:
         return Icons.local_florist;
+      case PlantSortOrder.nextWateringAsc:
+        return Icons.water_drop;
     }
   }
 }

--- a/lib/screens/plant_list_screen.dart
+++ b/lib/screens/plant_list_screen.dart
@@ -9,6 +9,7 @@ import '../models/plant.dart';
 import '../utils/date_utils.dart';
 import '../widgets/plant_image_widget.dart';
 import 'add_plant_screen.dart';
+import 'bulk_add_plants_screen.dart';
 import 'location_list_screen.dart';
 import 'plant_detail_screen.dart';
 import 'settings_screen.dart';
@@ -314,22 +315,47 @@ class _PlantListScreenState extends State<PlantListScreen> {
           );
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        tooltip: '植物を追加',
-        onPressed: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (context) => const AddPlantScreen(),
-            ),
-          );
-        },
-        child: const Icon(Icons.add),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          // 複数の植物をまとめて登録する導線（Issue #66）
+          FloatingActionButton.small(
+            heroTag: 'bulkAddPlants',
+            tooltip: '植物をまとめて登録',
+            onPressed: () async {
+              final added = await Navigator.of(context).push<bool>(
+                MaterialPageRoute(
+                  builder: (context) => const BulkAddPlantsScreen(),
+                ),
+              );
+              if (added == true && context.mounted) {
+                await context.read<PlantProvider>().loadPlants();
+              }
+            },
+            child: const Icon(Icons.playlist_add),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton(
+            heroTag: 'addPlant',
+            tooltip: '植物を追加',
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const AddPlantScreen(),
+                ),
+              );
+            },
+            child: const Icon(Icons.add),
+          ),
+        ],
       ),
     );
   }
 
   /// 「植物を追加」FAB に最後の項目が隠れないよう確保する下部余白（Issue #262）。
-  static const double _fabBottomInset = 80;
+  /// 一括登録FAB（small）が上に増えた分も含めている（Issue #66）。
+  static const double _fabBottomInset = 140;
 
   Widget _buildListView(List<Plant> plants) {
     return ListView.builder(

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -182,7 +182,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   )
                 : const Icon(Icons.upload_file),
             title: const Text('データをエクスポート'),
-            subtitle: const Text('植物・ログ・画像を ZIP ファイルに保存'),
+            subtitle: const Text('植物・ログ・画像を ZIP ファイルに保存／共有'),
             onTap: _isExporting ? null : () => _handleExport(context),
           ),
           ListTile(
@@ -641,18 +641,59 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   /// エクスポート処理
+  ///
+  /// 共有シート経由だとキャッシュ領域にしかファイルが残らず、OS の空き容量確保で
+  /// 消える恐れがあるため、端末への保存を既定の選択肢として提示する（Issue #270）。
   Future<void> _handleExport(BuildContext context) async {
+    final method = await showDialog<_ExportMethod>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('データをエクスポート'),
+        content: const Text(
+          '植物・ログ・画像を ZIP にまとめます。\n'
+          '「端末に保存」は保存先を選んでファイルとして残します。\n'
+          '「共有」はアプリ内の一時ファイルを他アプリへ送るだけで、端末には残りません。',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('キャンセル'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(_ExportMethod.share),
+            child: const Text('共有'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(_ExportMethod.saveToDevice),
+            child: const Text('端末に保存'),
+          ),
+        ],
+      ),
+    );
+    if (method == null || !context.mounted) return;
+
     setState(() => _isExporting = true);
     try {
-      final path = await ExportService().exportToFile();
-      if (!context.mounted) return;
-      if (path == null) {
+      if (method == _ExportMethod.saveToDevice) {
+        final path = await ExportService().exportToDeviceStorage();
+        if (!context.mounted) return;
         // ユーザーがキャンセル
-        return;
+        if (path == null) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('バックアップを保存しました\n$path'),
+            duration: const Duration(seconds: 6),
+          ),
+        );
+      } else {
+        final path = await ExportService().exportToFile();
+        if (!context.mounted) return;
+        // ユーザーがキャンセル
+        if (path == null) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('バックアップファイルを共有しました')),
+        );
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('バックアップファイルを共有しました')),
-      );
     } catch (e) {
       if (!context.mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
@@ -797,4 +838,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
         return Colors.orange;
     }
   }
+}
+
+/// エクスポートの方法（Issue #270）。
+enum _ExportMethod {
+  /// 保存先を選んで端末に残す
+  saveToDevice,
+
+  /// OS の共有シートで他アプリへ送る（端末には残らない）
+  share,
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -473,11 +473,25 @@ class _SettingsScreenState extends State<SettingsScreen> {
     if (confirmed != true) return;
     final days = int.parse(controller.text);
     if (!context.mounted) return;
+
+    // 誤タップで全植物の間隔が書き換わらないよう、対象件数を示して確認する（Issue #274）
+    final plantProvider = context.read<PlantProvider>();
+    final targetCount =
+        plantProvider.countBulkIntervalTargets(onlyWithInterval: false);
+    final applied = await _confirmBulkIntervalChange(
+      context,
+      title: '水やり間隔を一括設定',
+      message: '$targetCount件の植物の水やり間隔を $days 日に変更します。よろしいですか？',
+    );
+    if (applied != true || !context.mounted) return;
+
     try {
-      await context.read<PlantProvider>().bulkUpdateWateringInterval(days);
+      final previous = await plantProvider.bulkUpdateWateringInterval(days);
       if (!context.mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('すべての植物の水やり間隔を $days 日に設定しました')),
+      _showBulkIntervalResultSnackBar(
+        context,
+        message: '$targetCount件の植物の水やり間隔を $days 日に設定しました',
+        previous: previous,
       );
     } catch (e) {
       if (!context.mounted) return;
@@ -485,6 +499,62 @@ class _SettingsScreenState extends State<SettingsScreen> {
         SnackBar(content: Text('更新に失敗しました: ${describeError(e)}')),
       );
     }
+  }
+
+  /// 一括変更前の確認ダイアログ（Issue #274）。
+  Future<bool?> _confirmBulkIntervalChange(
+    BuildContext context, {
+    required String title,
+    required String message,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(title),
+        content: Text(message),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('キャンセル'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('変更する'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 一括変更後の SnackBar。「元に戻す」で変更前の間隔へ復元できる（Issue #274）。
+  void _showBulkIntervalResultSnackBar(
+    BuildContext context, {
+    required String message,
+    required Map<String, int?> previous,
+  }) {
+    final messenger = ScaffoldMessenger.of(context);
+    final plantProvider = context.read<PlantProvider>();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(seconds: 8),
+        action: SnackBarAction(
+          label: '元に戻す',
+          onPressed: () async {
+            try {
+              await plantProvider.restoreWateringIntervals(previous);
+              messenger.showSnackBar(
+                const SnackBar(content: Text('水やり間隔を元に戻しました')),
+              );
+            } catch (e) {
+              messenger.showSnackBar(
+                SnackBar(content: Text('復元に失敗しました: ${describeError(e)}')),
+              );
+            }
+          },
+        ),
+      ),
+    );
   }
 
   /// 水やり間隔を一括調整するダイアログ（増減）
@@ -541,12 +611,26 @@ class _SettingsScreenState extends State<SettingsScreen> {
     );
     if (confirmed != true) return;
     if (!context.mounted) return;
+
+    final label = delta > 0 ? '+$delta' : '$delta';
+    // 誤タップ対策の確認ダイアログ（Issue #274）
+    final plantProvider = context.read<PlantProvider>();
+    final targetCount =
+        plantProvider.countBulkIntervalTargets(onlyWithInterval: true);
+    final applied = await _confirmBulkIntervalChange(
+      context,
+      title: '水やり間隔を一括調整',
+      message: '$targetCount件の植物の水やり間隔を $label 日します。よろしいですか？',
+    );
+    if (applied != true || !context.mounted) return;
+
     try {
-      await context.read<PlantProvider>().bulkAdjustWateringInterval(delta);
+      final previous = await plantProvider.bulkAdjustWateringInterval(delta);
       if (!context.mounted) return;
-      final label = delta > 0 ? '+$delta' : '$delta';
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('水やり間隔を $label 日調整しました')),
+      _showBulkIntervalResultSnackBar(
+        context,
+        message: '$targetCount件の植物の水やり間隔を $label 日調整しました',
+        previous: previous,
       );
     } catch (e) {
       if (!context.mounted) return;

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -321,6 +321,14 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
         if (a.variety == null) return 1;
         if (b.variety == null) return -1;
         return b.variety!.compareTo(a.variety!);
+      case PlantSortOrder.nextWateringAsc:
+        // 次回水やり予定が近い順（予定超過が先頭、予定なしは末尾、Issue #271）
+        final aNext = nextWateringDateCache[a.id];
+        final bNext = nextWateringDateCache[b.id];
+        if (aNext == null && bNext == null) return 0;
+        if (aNext == null) return 1;
+        if (bNext == null) return -1;
+        return aNext.compareTo(bNext);
     }
   }
 
@@ -369,15 +377,24 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
     }
   }
 
-  void _showSuccessMessage(String message) {
-    if (mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(message),
-          duration: const Duration(seconds: 2),
-        ),
-      );
-    }
+  /// 操作結果の SnackBar を表示する。
+  ///
+  /// 画面下部には「その他の植物に水やり」ボタンや一括記録バーがあり、既定の
+  /// 固定表示だとそれらに重なってしまうため、フローティング表示にして下端に
+  /// 余白を確保する（Issue #280）。[onUndo] を渡すと「元に戻す」を表示する。
+  void _showSuccessMessage(String message, {VoidCallback? onUndo}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: Duration(seconds: onUndo == null ? 2 : 6),
+        behavior: SnackBarBehavior.floating,
+        margin: const EdgeInsets.fromLTRB(16, 0, 16, 96),
+        action: onUndo == null
+            ? null
+            : SnackBarAction(label: '元に戻す', onPressed: onUndo),
+      ),
+    );
   }
 
   Future<void> _deleteLog(
@@ -395,14 +412,24 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
     final logTypesToDelete = await _confirmDeletion(hasOtherLogs, plantId, logType, logStatus);
     if (logTypesToDelete == null) return;
 
-    await plantProvider.deleteMultipleLogsForDate(
+    final deletedLogs = await plantProvider.deleteMultipleLogsForDate(
       plantId,
       logTypesToDelete,
       _selectedDate,
     );
 
     await _refreshAfterLogChange();
-    _showSuccessMessage(_buildDeleteMessage(logTypesToDelete, logType));
+    _showSuccessMessage(
+      _buildDeleteMessage(logTypesToDelete, logType),
+      // 誤って取り消した場合に元の記録へ戻せるようにする（Issue #280）
+      onUndo: deletedLogs.isEmpty
+          ? null
+          : () async {
+              await plantProvider.restoreLogs(deletedLogs);
+              await _refreshAfterLogChange();
+              _showSuccessMessage('記録を元に戻しました');
+            },
+    );
   }
 
   Future<List<LogType>?> _confirmDeletion(

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -911,6 +911,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
         children: [
           IconButton(
             icon: const Icon(Icons.chevron_left),
+            tooltip: '前の日',
             onPressed: () {
               if (_isCalendarView) {
                 final prev = AppDateUtils.getDateOnly(
@@ -950,6 +951,7 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
           ),
           IconButton(
             icon: const Icon(Icons.chevron_right),
+            tooltip: '次の日',
             onPressed: () {
               if (_isCalendarView) {
                 final next = AppDateUtils.getDateOnly(

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -677,85 +677,102 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
 
         return Column(
           children: [
-            TableCalendar(
-              firstDay: DateTime(2020),
-              lastDay: DateTime.now().add(const Duration(days: 365)),
-              focusedDay: _focusedDay,
-              selectedDayPredicate: (day) => isSameDay(_selectedDate, day),
-              onDaySelected: (selectedDay, focusedDay) {
-                setState(() {
-                  _selectedDate = AppDateUtils.getDateOnly(selectedDay);
-                  _focusedDay = focusedDay;
-                  _selectedPlantIds.clear();
-                });
-                // 選択日を優先ロードしてから±2日分をバックグラウンドプリロード
-                _loadSelectedDateFirst(_selectedDate).ignore();
-              },
-              onPageChanged: (focusedDay) {
-                setState(() {
-                  _focusedDay = focusedDay;
-                });
-              },
-              calendarBuilders: CalendarBuilders(
-                // 過去ログのある日（primary）と、未来の水やり予定日（secondary）で
-                // マーカーを塗り分ける。両方に該当する場合は実績（過去ログ）を優先。
-                markerBuilder: (context, day, events) {
-                  final d = AppDateUtils.getDateOnly(day);
-                  final hasLog = logDates.contains(d);
-                  final isScheduled = scheduledDates.contains(d);
-                  // 予定日を過ぎても水やりされていない日はエラー色で出す（Issue #275）。
-                  // 従来は「今日より後」の予定しかマーカーが出ず、
-                  // カレンダーを見ても予定超過に気づけなかった。
-                  final isOverdue = isScheduled && !d.isAfter(today);
-                  if (!hasLog && !isScheduled) return null;
+            // TableCalendar（3.2.0時点）のセマンティクスサブツリーは、一度読み取られると
+            // 画面全体のセマンティクスツリーを失わせる（Issue #241）。実測では
+            // カレンダー表示中は1回目のダンプが125ノード、2回目以降は4ノード
+            // （ルートのみ）に落ち、以後復帰しない。スクリーンリーダー利用者は
+            // 画面の内容を一切読み上げられなくなる。
+            //
+            // カレンダー自体をセマンティクスから除外すると、残りの画面（日付ヘッダー・
+            // 植物リスト・記録ボタン）は安定する。日付の変更は日付ヘッダーの
+            // 「前の日」「次の日」ボタンと、日付タップで開く日付ピッカーから
+            // 行えるため、操作手段は失われない。
+            Semantics(
+              container: true,
+              label: 'カレンダー。日付を変更するには、下の日付欄をタップして'
+                  '日付を選ぶか、「前の日」「次の日」のボタンを使ってください。',
+              child: ExcludeSemantics(
+                child: TableCalendar(
+                  firstDay: DateTime(2020),
+                  lastDay: DateTime.now().add(const Duration(days: 365)),
+                  focusedDay: _focusedDay,
+                  selectedDayPredicate: (day) => isSameDay(_selectedDate, day),
+                  onDaySelected: (selectedDay, focusedDay) {
+                    setState(() {
+                      _selectedDate = AppDateUtils.getDateOnly(selectedDay);
+                      _focusedDay = focusedDay;
+                      _selectedPlantIds.clear();
+                    });
+                    // 選択日を優先ロードしてから±2日分をバックグラウンドプリロード
+                    _loadSelectedDateFirst(_selectedDate).ignore();
+                  },
+                  onPageChanged: (focusedDay) {
+                    setState(() {
+                      _focusedDay = focusedDay;
+                    });
+                  },
+                  calendarBuilders: CalendarBuilders(
+                    // 過去ログのある日（primary）と、未来の水やり予定日（secondary）で
+                    // マーカーを塗り分ける。両方に該当する場合は実績（過去ログ）を優先。
+                    markerBuilder: (context, day, events) {
+                      final d = AppDateUtils.getDateOnly(day);
+                      final hasLog = logDates.contains(d);
+                      final isScheduled = scheduledDates.contains(d);
+                      // 予定日を過ぎても水やりされていない日はエラー色で出す（Issue #275）。
+                      // 従来は「今日より後」の予定しかマーカーが出ず、
+                      // カレンダーを見ても予定超過に気づけなかった。
+                      final isOverdue = isScheduled && !d.isAfter(today);
+                      if (!hasLog && !isScheduled) return null;
 
-                  final Color color;
-                  if (isOverdue) {
-                    color = Theme.of(context).colorScheme.error;
-                  } else if (hasLog) {
-                    color = Theme.of(context).colorScheme.primary;
-                  } else {
-                    color = Theme.of(context).colorScheme.tertiary;
-                  }
+                      final Color color;
+                      if (isOverdue) {
+                        color = Theme.of(context).colorScheme.error;
+                      } else if (hasLog) {
+                        color = Theme.of(context).colorScheme.primary;
+                      } else {
+                        color = Theme.of(context).colorScheme.tertiary;
+                      }
 
-                  // 実績と予定超過が同じ日に重なる場合は両方のドットを並べる
-                  final showLogDot = hasLog;
-                  final showOverdueDot = isOverdue;
-                  final dots = <Widget>[
-                    if (showLogDot)
-                      _calendarDot(Theme.of(context).colorScheme.primary),
-                    if (showOverdueDot)
-                      _calendarDot(Theme.of(context).colorScheme.error),
-                    if (!showLogDot && !showOverdueDot) _calendarDot(color),
-                  ];
+                      // 実績と予定超過が同じ日に重なる場合は両方のドットを並べる
+                      final showLogDot = hasLog;
+                      final showOverdueDot = isOverdue;
+                      final dots = <Widget>[
+                        if (showLogDot)
+                          _calendarDot(Theme.of(context).colorScheme.primary),
+                        if (showOverdueDot)
+                          _calendarDot(Theme.of(context).colorScheme.error),
+                        if (!showLogDot && !showOverdueDot) _calendarDot(color),
+                      ];
 
-                  return Align(
-                    alignment: Alignment.bottomCenter,
-                    child: Padding(
-                      padding: const EdgeInsets.only(bottom: 6),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: dots,
-                      ),
+                      return Align(
+                        alignment: Alignment.bottomCenter,
+                        child: Padding(
+                          padding: const EdgeInsets.only(bottom: 6),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: dots,
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                  calendarStyle: CalendarStyle(
+                    selectedDecoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.primary,
+                      shape: BoxShape.circle,
                     ),
-                  );
-                },
-              ),
-              calendarStyle: CalendarStyle(
-                selectedDecoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary,
-                  shape: BoxShape.circle,
+                    todayDecoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.secondary.withValues(alpha: 0.5),
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                  headerStyle: const HeaderStyle(
+                    formatButtonVisible: false,
+                    titleCentered: true,
+                  ),
+                  locale: 'ja_JP',
                 ),
-                todayDecoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.secondary.withValues(alpha: 0.5),
-                  shape: BoxShape.circle,
-                ),
               ),
-              headerStyle: const HeaderStyle(
-                formatButtonVisible: false,
-                titleCentered: true,
-              ),
-              locale: 'ja_JP',
             ),
             // 凡例：実績（過去ログ）と予定（未来の水やり）の色を説明する
             Padding(

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -1221,29 +1221,60 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
   }
 
   Widget _buildEmptyState(bool isToday) {
+    // 植物が1件も無いうちは「予定がありません」より先に登録を促す（Issue #277）
+    final hasNoPlants = context.read<PlantProvider>().plants.isEmpty;
+
     return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.eco_outlined,
-            size: 64,
-            color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
-          ),
-          const SizedBox(height: 16),
-          Text(
-            isToday ? '今日は水やりの予定と記録がありません' : 'この日は水やりの予定と記録がありません',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          const SizedBox(height: 24),
-          FilledButton.icon(
-            onPressed: _showUnscheduledWateringDialog,
-            icon: const Icon(Icons.add),
-            label: const Text('水やり記録をつける'),
-          ),
-        ],
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.eco_outlined,
+              size: 64,
+              color:
+                  Theme.of(context).colorScheme.primary.withValues(alpha: 0.5),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              hasNoPlants
+                  ? 'まずは植物を登録しましょう'
+                  : isToday
+                      ? '今日は水やりの予定と記録がありません'
+                      : 'この日は水やりの予定と記録がありません',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            if (hasNoPlants) ...[
+              const SizedBox(height: 8),
+              Text(
+                '植物を登録すると、水やりの予定日と記録を管理できます。',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+            const SizedBox(height: 24),
+            FilledButton.icon(
+              onPressed: hasNoPlants
+                  ? _navigateToAddPlant
+                  : _showUnscheduledWateringDialog,
+              icon: const Icon(Icons.add),
+              label: Text(hasNoPlants ? '植物を登録' : '水やり記録をつける'),
+            ),
+          ],
+        ),
       ),
     );
+  }
+
+  /// 植物の追加画面へ遷移する（Issue #277 の空状態導線）。
+  Future<void> _navigateToAddPlant() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(builder: (_) => const AddPlantScreen()),
+    );
+    if (!mounted) return;
+    await context.read<PlantProvider>().loadPlants();
   }
 
   Widget _buildDivider() {

--- a/lib/screens/today_watering_screen.dart
+++ b/lib/screens/today_watering_screen.dart
@@ -630,6 +630,16 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
     );
   }
 
+  /// カレンダーのマーカードット1つ分。
+  Widget _calendarDot(Color color) {
+    return Container(
+      width: 6,
+      height: 6,
+      margin: const EdgeInsets.symmetric(horizontal: 1),
+      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+    );
+  }
+
   Widget _buildCalendarView() {
     return Consumer<PlantProvider>(
       builder: (context, plantProvider, _) {
@@ -665,21 +675,41 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
                 markerBuilder: (context, day, events) {
                   final d = AppDateUtils.getDateOnly(day);
                   final hasLog = logDates.contains(d);
-                  // 予定日マーカーは「今日より後」だけに出す。今日以前は実績側で扱う。
-                  final isScheduled =
-                      d.isAfter(today) && scheduledDates.contains(d);
+                  final isScheduled = scheduledDates.contains(d);
+                  // 予定日を過ぎても水やりされていない日はエラー色で出す（Issue #275）。
+                  // 従来は「今日より後」の予定しかマーカーが出ず、
+                  // カレンダーを見ても予定超過に気づけなかった。
+                  final isOverdue = isScheduled && !d.isAfter(today);
                   if (!hasLog && !isScheduled) return null;
-                  final color = hasLog
-                      ? Theme.of(context).colorScheme.primary
-                      : Theme.of(context).colorScheme.tertiary;
+
+                  final Color color;
+                  if (isOverdue) {
+                    color = Theme.of(context).colorScheme.error;
+                  } else if (hasLog) {
+                    color = Theme.of(context).colorScheme.primary;
+                  } else {
+                    color = Theme.of(context).colorScheme.tertiary;
+                  }
+
+                  // 実績と予定超過が同じ日に重なる場合は両方のドットを並べる
+                  final showLogDot = hasLog;
+                  final showOverdueDot = isOverdue;
+                  final dots = <Widget>[
+                    if (showLogDot)
+                      _calendarDot(Theme.of(context).colorScheme.primary),
+                    if (showOverdueDot)
+                      _calendarDot(Theme.of(context).colorScheme.error),
+                    if (!showLogDot && !showOverdueDot) _calendarDot(color),
+                  ];
+
                   return Align(
                     alignment: Alignment.bottomCenter,
-                    child: Container(
-                      width: 6,
-                      height: 6,
-                      margin: const EdgeInsets.only(bottom: 6),
-                      decoration:
-                          BoxDecoration(color: color, shape: BoxShape.circle),
+                    child: Padding(
+                      padding: const EdgeInsets.only(bottom: 6),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: dots,
+                      ),
                     ),
                   );
                 },
@@ -711,6 +741,10 @@ class _TodayWateringScreenState extends State<TodayWateringScreen>
                   const SizedBox(width: 16),
                   _CalendarLegendDot(
                       color: Theme.of(context).colorScheme.tertiary, label: '予定'),
+                  const SizedBox(width: 16),
+                  // 予定超過（Issue #275）
+                  _CalendarLegendDot(
+                      color: Theme.of(context).colorScheme.error, label: '予定超過'),
                 ],
               ),
             ),

--- a/lib/services/claude_share_service.dart
+++ b/lib/services/claude_share_service.dart
@@ -15,6 +15,20 @@ class ClaudeShareService {
     );
   }
 
+  /// 1枚の写真に写っている複数の植物の一覧作成を依頼する（Issue #66）。
+  ///
+  /// アプリ側で機械的に読み取れるよう、1行1植物・`名前 / 品種` の形式を指定する。
+  static Future<void> shareForBulkIdentification(String imagePath) async {
+    await Share.shareXFiles(
+      [XFile(imagePath)],
+      text: 'この写真に写っている植物をすべて挙げてください。'
+          '1行に1つ、「名前 / 品種」の形式で、名前は和名または流通名でお願いします。'
+          '品種が分からない場合は名前だけで構いません。'
+          '説明文や見出しは付けず、一覧だけを返してください。',
+      subject: '植物の一括同定',
+    );
+  }
+
   /// 植物名・品種の同定を依頼するプロンプト付きで画像を共有する。
   static Future<void> shareForIdentification(String imagePath) async {
     await Share.shareXFiles(

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -35,7 +35,7 @@ class DatabaseService {
 
     return await openDatabase(
       newPath,
-      version: 9,
+      version: 10,
       onCreate: _onCreate,
       onUpgrade: (db, oldVersion, newVersion) async {
         if (oldVersion < 2) {
@@ -149,6 +149,14 @@ class DatabaseService {
             // 既にカラムが存在する場合は無視
           }
         }
+        if (oldVersion < 10) {
+          // ノートのタグ（Issue #278）。JSON 配列の文字列として保持する。
+          try {
+            await db.execute('ALTER TABLE notes ADD COLUMN tags TEXT');
+          } catch (_) {
+            // 既にカラムが存在する場合は無視
+          }
+        }
       },
     );
   }
@@ -208,6 +216,7 @@ class DatabaseService {
         content TEXT,
         imagePaths TEXT,
         plantIds TEXT,
+        tags TEXT,
         createdAt TEXT NOT NULL,
         updatedAt TEXT NOT NULL
       )

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -87,6 +87,38 @@ class ExportService {
     return tmpFile.path;
   }
 
+  /// ZIP を端末の任意の場所に保存する（Issue #270）。
+  ///
+  /// 共有シート経由の [exportToFile] はキャッシュ領域にしかファイルが残らず、
+  /// OS の空き容量確保で削除されうる。こちらは SAF（Android のファイル選択
+  /// ダイアログ）でユーザーが選んだ保存先に書き出すため、確実に端末へ残る。
+  ///
+  /// キャンセル時は null を返す。戻り値は保存先のパス。
+  Future<String?> exportToDeviceStorage() async {
+    final ts = DateFormat('yyyyMMdd_HHmm').format(DateTime.now());
+    final fileName = 'botanote_backup_$ts.zip';
+
+    final zipBytes = await _buildZipBytes();
+
+    // Android/iOS では bytes を渡さないとファイルが書き込まれないため必ず渡す
+    final savedPath = await FilePicker.platform.saveFile(
+      dialogTitle: 'バックアップの保存先を選択',
+      fileName: fileName,
+      type: FileType.custom,
+      allowedExtensions: const ['zip'],
+      bytes: zipBytes,
+    );
+    if (savedPath == null) return null;
+
+    // デスクトップ（Windows/macOS/Linux）では bytes が書き込まれず
+    // パスだけが返るため、こちら側で書き出す。
+    if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
+      await File(savedPath).writeAsBytes(zipBytes);
+    }
+
+    return savedPath;
+  }
+
   /// ZIP バイト列を生成する
   Future<Uint8List> _buildZipBytes() async {
     final plants = await _db.getAllPlants();

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -36,10 +36,11 @@ class ExportService {
   /// 書き出すバックアップのバージョン。
   /// 5 でアプリ設定（`settings`）を含めるようになった（Issue #239）。
   /// 6 で植物に読み仮名（`nameReading`）が加わった（Issue #257）。
+  /// 7 でノートにタグ（`tags`）が加わった（Issue #278）。
   ///
   /// 旧バージョンのアプリが新しい形式を取り込むと、DB に存在しない列を
   /// insert しようとして失敗するため、版数を上げて明示的に弾く。
-  static const int _backupVersion = 6;
+  static const int _backupVersion = 7;
 
   /// バックアップに含めないアプリ設定のキー。
   ///

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -5,8 +5,21 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest_all.dart' as tz;
 import 'dart:convert';
+import 'package:uuid/uuid.dart';
+import '../models/log_entry.dart';
 import 'database_service.dart';
 import 'weather_service.dart';
+
+/// 通知アクション「水やり完了」をバックグラウンドIsolateで受け取るエントリポイント。
+///
+/// アプリが起動していない状態でも呼ばれるため、トップレベル関数かつ
+/// `@pragma('vm:entry-point')` が必須（Issue #276）。
+@pragma('vm:entry-point')
+void notificationBackgroundHandler(NotificationResponse response) {
+  if (response.actionId != NotificationService.wateringDoneActionId) return;
+  // await できない同期エントリポイントのため、Future はそのまま流す
+  NotificationService.recordWateringForDuePlants();
+}
 
 class NotificationService {
   static final NotificationService _instance = NotificationService._internal();
@@ -18,6 +31,9 @@ class NotificationService {
 
   static const int _dailyWateringNotificationId = 1;
   static const int _weatherAlertNotificationId = 2;
+
+  /// 通知アクション「水やり完了」の識別子（Issue #276）。
+  static const String wateringDoneActionId = 'watering_done';
 
   bool _initialized = false;
 
@@ -37,19 +53,84 @@ class NotificationService {
 
     const androidSettings =
         AndroidInitializationSettings('@drawable/ic_notification');
-    const darwinSettings = DarwinInitializationSettings(
+    // iOS/macOS では通知カテゴリにアクションを登録する（Issue #276）
+    final darwinSettings = DarwinInitializationSettings(
       requestAlertPermission: false,
       requestBadgePermission: false,
       requestSoundPermission: false,
+      notificationCategories: <DarwinNotificationCategory>[
+        DarwinNotificationCategory(
+          'watering',
+          actions: <DarwinNotificationAction>[
+            DarwinNotificationAction.plain(
+              wateringDoneActionId,
+              '水やり完了',
+            ),
+          ],
+        ),
+      ],
     );
-    const initSettings = InitializationSettings(
+    final initSettings = InitializationSettings(
       android: androidSettings,
       iOS: darwinSettings,
       macOS: darwinSettings,
     );
 
-    await _plugin.initialize(settings: initSettings);
+    await _plugin.initialize(
+      settings: initSettings,
+      onDidReceiveNotificationResponse: _handleNotificationResponse,
+      onDidReceiveBackgroundNotificationResponse: notificationBackgroundHandler,
+    );
     _initialized = true;
+  }
+
+  /// フォアグラウンド（アプリ起動中）で通知アクションを受け取ったときの処理。
+  static void _handleNotificationResponse(NotificationResponse response) {
+    if (response.actionId != wateringDoneActionId) return;
+    recordWateringForDuePlants();
+  }
+
+  /// 今日時点で水やり予定を迎えている（予定超過を含む）植物すべてに、
+  /// 今日の日付で水やりログを記録する（Issue #276）。
+  ///
+  /// 同じ日に既に水やりログがある植物は二重記録しない。
+  /// 通知アクションから呼ばれ、アプリ未起動のバックグラウンドIsolateでも動作する。
+  static Future<void> recordWateringForDuePlants() async {
+    try {
+      final db = DatabaseService();
+      final now = DateTime.now();
+      final duePlants = await db.getPlantsDueOn(now);
+      if (duePlants.isEmpty) return;
+
+      const uuid = Uuid();
+      for (final plant in duePlants) {
+        final existing =
+            await db.getLogsByPlantAndType(plant.id, LogType.watering);
+        final alreadyLogged = existing.any((log) =>
+            log.date.year == now.year &&
+            log.date.month == now.month &&
+            log.date.day == now.day);
+        if (alreadyLogged) continue;
+
+        await db.insertLog(LogEntry(
+          id: uuid.v4(),
+          plantId: plant.id,
+          type: LogType.watering,
+          date: now,
+          createdAt: now,
+          updatedAt: now,
+        ));
+      }
+
+      debugPrint(
+          'NotificationService: recorded watering from notification action '
+          '(${duePlants.length} plants checked)');
+
+      // 記録内容が変わったので次回のリマインダーを組み直す
+      await scheduleSmartWateringReminder();
+    } catch (e) {
+      debugPrint('NotificationService: watering action failed: $e');
+    }
   }
 
   /// 通知パーミッションをリクエストする。
@@ -145,18 +226,28 @@ class NotificationService {
       return;
     }
 
-    // 翌日の水やり予定をDBから確認
-    final tomorrow = DateTime.now().add(const Duration(days: 1));
+    // 通知対象日を決める（Issue #281）。
+    // 当日の通知時刻がまだ来ていなければ「今日」を対象にする。
+    // 「翌日だけ」を見ていると、予定日当日にスケジューリングが走った場合に
+    // その日の通知が登録されず、通知が丸1日遅れてしまう。
+    final now = DateTime.now();
+    final todayNotifyTime =
+        DateTime(now.year, now.month, now.day, notifHour, notifMinute);
+    final bool targetIsToday = now.isBefore(todayNotifyTime);
+    final targetDate =
+        targetIsToday ? now : now.add(const Duration(days: 1));
+
     bool hasDuePlants = false;
     // 通知本文に載せる対象植物名（DBエラー時は空のまま汎用文言にフォールバック）
     var duePlantNames = <String>[];
     try {
       final db = DatabaseService();
-      final duePlants = await db.getPlantsDueOn(tomorrow);
+      // getPlantsDueOn は「予定日が対象日以前」の植物を返すため、予定超過分も含まれる
+      final duePlants = await db.getPlantsDueOn(targetDate);
       hasDuePlants = duePlants.isNotEmpty;
       duePlantNames = duePlants.map((p) => p.name).toList();
-      debugPrint(
-          'NotificationService: plants due tomorrow = ${duePlants.length}');
+      debugPrint('NotificationService: plants due on '
+          '${targetIsToday ? "today" : "tomorrow"} = ${duePlants.length}');
     } catch (e) {
       debugPrint('NotificationService: DB check failed, scheduling anyway: $e');
       // DBエラー時は安全側として通知を登録する
@@ -192,18 +283,18 @@ class NotificationService {
 
     if (!hasDuePlants) {
       debugPrint(
-          'NotificationService: no plants due tomorrow, notification cancelled');
+          'NotificationService: no plants due on target day, notification cancelled');
       return;
     }
 
-    // 翌日の指定時刻に1回限りの通知を登録
+    // 対象日の指定時刻に1回限りの通知を登録
     final location = tz.local;
-    final now = tz.TZDateTime.now(location);
-    var scheduledDate = tz.TZDateTime(
+    final tzNow = tz.TZDateTime.now(location);
+    final scheduledDate = tz.TZDateTime(
       location,
-      now.year,
-      now.month,
-      now.day + 1, // 翌日
+      tzNow.year,
+      tzNow.month,
+      targetIsToday ? tzNow.day : tzNow.day + 1,
       notifHour,
       notifMinute,
     );
@@ -215,6 +306,15 @@ class NotificationService {
       importance: Importance.high,
       priority: Priority.high,
       icon: '@drawable/ic_notification',
+      // 通知から直接その日の水やりを記録できるようにする（Issue #276）
+      actions: <AndroidNotificationAction>[
+        AndroidNotificationAction(
+          wateringDoneActionId,
+          '水やり完了',
+          showsUserInterface: false,
+          cancelNotification: true,
+        ),
+      ],
     );
     const darwinDetails = DarwinNotificationDetails(
       categoryIdentifier: 'watering',

--- a/lib/utils/error_utils.dart
+++ b/lib/utils/error_utils.dart
@@ -3,12 +3,18 @@
 /// 例外 [e] をユーザー表示用の文字列に整形して返す。
 ///
 /// `Object.toString()` の結果には `Exception: ` などの実装都合のプレフィックスが
-/// 付くことがあり、そのままユーザーに見せると分かりにくい。ここで既知の
-/// プレフィックスを取り除き、読みやすい文言に整える。
+/// 付くことがあり、そのままユーザーに見せると分かりにくい。まず代表的な通信系の
+/// 例外を日本語の案内文に置き換え、該当しない場合は既知のプレフィックスを
+/// 取り除いて読みやすい文言に整える（Issue #273）。
 ///
 /// SnackBar 等でエラー内容をユーザーに提示する際は、生の `$e` を埋め込まず
 /// 本関数を通すこと。
+///
+/// Web ビルドでも使えるよう `dart:io` には依存せず、型名と本文の照合で判定する。
 String describeError(Object e) {
+  final friendly = _describeCommonError(e);
+  if (friendly != null) return friendly;
+
   var text = e.toString();
   // よくある実装都合のプレフィックスを除去する。
   const prefixes = ['Exception: ', 'FormatException: ', 'Error: '];
@@ -19,4 +25,49 @@ String describeError(Object e) {
     }
   }
   return text;
+}
+
+/// 代表的な通信・入出力系の例外を日本語の案内文に変換する。
+///
+/// 該当しない場合は null を返す。
+String? _describeCommonError(Object e) {
+  final typeName = e.runtimeType.toString();
+  final text = e.toString();
+
+  // 証明書エラーは端末の日付・時刻ずれが原因のことが多いため、そこを案内する
+  if (typeName.contains('HandshakeException') ||
+      text.contains('CERTIFICATE_VERIFY_FAILED')) {
+    if (text.contains('certificate has expired')) {
+      return '安全な通信を確立できませんでした。端末の日付・時刻の設定を確認してください';
+    }
+    return '安全な通信を確立できませんでした。通信環境を確認してください';
+  }
+
+  if (typeName.contains('TimeoutException')) {
+    return '接続がタイムアウトしました。時間をおいて再度お試しください';
+  }
+
+  // SocketException / ClientException（http パッケージ）はいずれも接続不可
+  if (typeName.contains('SocketException') ||
+      typeName.contains('ClientException') ||
+      text.contains('Failed host lookup')) {
+    return 'ネットワークに接続できませんでした。通信環境を確認してください';
+  }
+
+  if (typeName.contains('HttpException')) {
+    return '通信中にエラーが発生しました。時間をおいて再度お試しください';
+  }
+
+  // ファイル・ストレージ系
+  if (typeName.contains('PathAccessException')) {
+    return 'ファイルにアクセスできませんでした。保存先の権限を確認してください';
+  }
+  if (typeName.contains('PathNotFoundException')) {
+    return '対象のファイルが見つかりませんでした';
+  }
+  if (typeName.contains('FileSystemException')) {
+    return 'ファイルの読み書きに失敗しました。端末の空き容量と権限を確認してください';
+  }
+
+  return null;
 }

--- a/test/bulk_add_plants_parse_test.dart
+++ b/test/bulk_add_plants_parse_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:bota_note/screens/bulk_add_plants_screen.dart';
+
+void main() {
+  group('parsePlantList', () {
+    test('1行1植物として名前を読み取る', () {
+      final drafts = parsePlantList('モンステラ\nポトス\nサンスベリア');
+      expect(drafts.map((d) => d.nameController.text).toList(),
+          ['モンステラ', 'ポトス', 'サンスベリア']);
+      expect(drafts.every((d) => d.varietyController.text.isEmpty), isTrue);
+    });
+
+    test('「名前 / 品種」を名前と品種に分ける', () {
+      final drafts = parsePlantList('モンステラ / デリシオサ');
+      expect(drafts.single.nameController.text, 'モンステラ');
+      expect(drafts.single.varietyController.text, 'デリシオサ');
+    });
+
+    test('「名前（品種）」を名前と品種に分ける', () {
+      final drafts = parsePlantList('サンスベリア（ローレンチー）');
+      expect(drafts.single.nameController.text, 'サンスベリア');
+      expect(drafts.single.varietyController.text, 'ローレンチー');
+    });
+
+    test('箇条書き記号・番号・Markdownの強調を取り除く', () {
+      final drafts = parsePlantList('- モンステラ\n'
+          '1. ポトス\n'
+          '* **サンスベリア**\n'
+          '・アガベ');
+      expect(drafts.map((d) => d.nameController.text).toList(),
+          ['モンステラ', 'ポトス', 'サンスベリア', 'アガベ']);
+    });
+
+    test('空行と記号だけの行は無視する', () {
+      final drafts = parsePlantList('モンステラ\n\n---\n\nポトス');
+      expect(drafts.map((d) => d.nameController.text).toList(),
+          ['モンステラ', 'ポトス']);
+    });
+
+    test('同じ名前と品種の行が重複しても1件にまとめる', () {
+      final drafts = parsePlantList('モンステラ\nモンステラ\nモンステラ / デリシオサ');
+      expect(drafts.length, 2);
+      expect(drafts[0].varietyController.text, '');
+      expect(drafts[1].varietyController.text, 'デリシオサ');
+    });
+
+    test('読み取った候補は既定で選択済みになる', () {
+      final drafts = parsePlantList('モンステラ');
+      expect(drafts.single.selected, isTrue);
+    });
+
+    test('空文字からは何も読み取らない', () {
+      expect(parsePlantList(''), isEmpty);
+      expect(parsePlantList('   \n\n  '), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
利用シミュレーションで発見した2件（#281 / #282）を起票したうえで、オープン中のIssueをまとめて対応しました。

Issue ごとにコミットを分けています。件数が多いため、コミット単位でのレビューを想定しています。

## 🔴 バグ修正

| Issue | 内容 |
|---|---|
| #281 | 水やり予定日「当日」のリマインダーが登録されず通知が1日遅れる |
| #282 | 植物詳細のAppBarアイコンにセマンティクスラベルが無い |
| #241 | カレンダー表示で画面のセマンティクス情報が消失する |
| #267 | ケアログのメモがツールチップでしか読めない |
| #268 | 置き場所ダイアログで「屋外」スイッチがIMEに隠れる |
| #269 | ログの空状態の案内文が実際のUIと一致していない |

### #281 通知が1日遅れる
`scheduleSmartWateringReminder` が常に「翌日」だけを見て「翌日の通知時刻」に登録していたため、予定日当日にスケジューリングが走ってもその日の通知が登録されませんでした。対象日を「当日の通知時刻が未来なら今日、そうでなければ翌日」に変更しています。

### #241 セマンティクス消失
調査の結果、`table_calendar`（3.2.0＝最新でも再現）のセマンティクスサブツリーが原因でした。エミュレーター（Android 16）での実測値:

- リスト表示: 何度ダンプしても 24 ノードで安定
- カレンダー表示（修正前）: 1回目 125 ノード → 2回目以降 4 ノード（ルートのみ）で復帰しない
- カレンダー表示（修正後）: 日付タップ後も 27 ノードで安定

Issue では日付タップが引き金と報告されていましたが、実際にはカレンダーを表示してセマンティクスを一度読み取った時点で発生します。Flutter 側の例外は出ません。`TableCalendar` を `ExcludeSemantics` で包み、領域全体のラベルを付ける回避策としました。日付変更は日付ヘッダーの「前の日」「次の日」と日付ピッカーから行えるため操作手段は失われません。

**上流の不具合のため、`table_calendar` 側が修正されたら回避策を外せます。**

## 🟢 機能追加・改善

| Issue | 内容 |
|---|---|
| #66 | 植物の一括登録機能 |
| #270 | エクスポートしたZIPを端末に保存できるようにする |
| #271 | 並び替えに「水やり予定が近い順」を追加 |
| #272 | 同じ日のケアログを種類ごとに個別削除 |
| #273 | 通信エラーの文言を日本語化 |
| #274 | 一括設定・一括調整に確認と取り消し |
| #275 | 予定超過の植物をカレンダー上でも分かるように |
| #276 | 通知から直接記録できるアクションボタン |
| #277 | 初回起動時のオンボーディング |
| #278 | ノートのタグと横断検索・絞り込み |
| #279 | 植物詳細に「冬季は間隔を延長する」の設定内容を表示 |
| #280 | 記録の取り消しに「元に戻す」／ボタンとの重なり修正 |

### #66 について
「複数写った画像から植物を判別して連続登録する」の判別部分は、Anthropic API を直接呼ぶ従量課金方式ではなく、**#177/#178 と同じ共有シート経由で Claude アプリに渡す方式**に揃えました。写真を Claude に送って一覧を作ってもらい、返ってきたテキストを貼り付けると行ごとに登録候補へ展開されます。判別を使わず名前を書き並べるだけでも一括登録できます。

## データベース・バックアップの変更

- DB を **v10** にマイグレーション（`notes.tags` カラム追加）
- バックアップ版数を **7** に更新（旧アプリが新形式を取り込んで失敗しないよう明示的に弾く）

## テスト

- `flutter analyze`: エラー・警告なし（既存の info 10件のみ）
- `flutter test`: 25件すべてパス（一括登録のテキスト解析テスト8件を追加）
- エミュレーター（Medium_Phone_API_36.1 / Android 16）で実機確認:
  - オンボーディング3画面 → 通知許可 → 空状態「まずは植物を登録しましょう」
  - カレンダーのセマンティクス安定（27ノード）と「予定超過」凡例
  - 並び替えメニューの「水やり予定が近い順」
  - 一括登録（`1. Pothos / Marble` → 名前/品種に分割して3件登録）
  - ノートのタグ付与 → 一覧のタグ絞り込みチップ → カードのタグ表示
  - 一括調整の確認ダイアログ（対象件数表示）と「元に戻す」
  - エクスポート「端末に保存」→ SAF → `/sdcard/Download/botanote_backup_*.zip` の生成を確認
  - ケアログのメモ本文表示と種類ごとの個別削除

## 未対応

**#195（管理場所と植物・センサーの連携機能）は既に実装済み**でした。3項目とも確認済みのため、このPRには含めず別途クローズします。

- `SensorDeviceMapping.locationId` … `lib/models/sensor_device_mapping.dart`
- 管理場所詳細画面（植物・センサーの一括紐づけ）… `lib/screens/location_detail_screen.dart`
- Workmanager によるセンサー定期取得 … `lib/services/sensor_auto_fetch_service.dart`

Closes #241
Closes #267
Closes #268
Closes #269
Closes #270
Closes #271
Closes #272
Closes #273
Closes #274
Closes #275
Closes #276
Closes #277
Closes #278
Closes #279
Closes #280
Closes #281
Closes #282
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)