### PR TITLE
fix: 通知アクション・肥料/活力剤の予定日・一括変更SnackBarの不具合を修正 (#284, #285, #286)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,6 +62,13 @@
         <receiver
             android:exported="false"
             android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationReceiver"/>
+        <!-- flutter_local_notifications: 通知アクション「水やり完了」の受信（Issue #284）
+             showsUserInterface:false のアクションはこのレシーバー経由で
+             バックグラウンドIsolateへ配送される。プラグイン側のマニフェストは
+             レシーバーを一切宣言しないため、アプリ側での宣言が必須。 -->
+        <receiver
+            android:exported="false"
+            android:name="com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver"/>
         <!-- flutter_local_notifications: 端末起動後の通知再スケジュール -->
         <receiver
             android:exported="false"

--- a/lib/providers/plant_provider.dart
+++ b/lib/providers/plant_provider.dart
@@ -484,8 +484,12 @@ class PlantProvider with ChangeNotifier {
   ///
   /// 起算日の優先順位（日数指定モード）:
   /// 1. 最後に肥料を与えた日
-  /// 2. 肥料ログがなければ最後に水やりをした日
+  /// 2. 肥料ログがなければ**最初に**水やりをした日
   /// 3. 水やりログもなければ次回水やり予定日
+  ///
+  /// 起算日2で「最後の水やり日」を使うと、水やりを記録するたびに予定日が
+  /// 後ろへずれて永久に到来しなくなる（Issue #285）。肥料ログが1件も無い間の
+  /// 起算日は、以降の水やりで動かない「ケアを始めた日」に固定する。
   ///
   /// - [fertilizerEveryNWaterings] が設定されている場合: 最終肥料日以降の
   ///   水やり回数が N 回に達する日（水やり間隔から推定）
@@ -505,11 +509,11 @@ class PlantProvider with ChangeNotifier {
             days: _adjustedInterval(
                 plant, plant.fertilizerIntervalDays!, sorted.first.date)));
       }
-      // 起算日2: 最後に水やりをした日
+      // 起算日2: 最初に水やりをした日（Issue #285）
       final wateringLogs2 =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
       if (wateringLogs2.isNotEmpty) {
-        final sorted2 = [...wateringLogs2]..sort((a, b) => b.date.compareTo(a.date));
+        final sorted2 = [...wateringLogs2]..sort((a, b) => a.date.compareTo(b.date));
         return sorted2.first.date.add(Duration(
             days: _adjustedInterval(
                 plant, plant.fertilizerIntervalDays!, sorted2.first.date)));
@@ -570,7 +574,7 @@ class PlantProvider with ChangeNotifier {
   ///
   /// 起算日の優先順位（日数指定モード）:
   /// 1. 最後に活力剤を与えた日
-  /// 2. 活力剤ログがなければ最後に水やりをした日
+  /// 2. 活力剤ログがなければ**最初に**水やりをした日（Issue #285）
   /// 3. 水やりログもなければ次回水やり予定日
   ///
   /// ロジックは [calculateNextFertilizerDate] と同様。
@@ -589,11 +593,11 @@ class PlantProvider with ChangeNotifier {
             days: _adjustedInterval(
                 plant, plant.vitalizerIntervalDays!, sorted.first.date)));
       }
-      // 起算日2: 最後に水やりをした日
+      // 起算日2: 最初に水やりをした日（Issue #285）
       final wateringLogs2 =
           await _db.getLogsByPlantAndType(plantId, LogType.watering);
       if (wateringLogs2.isNotEmpty) {
-        final sorted2 = [...wateringLogs2]..sort((a, b) => b.date.compareTo(a.date));
+        final sorted2 = [...wateringLogs2]..sort((a, b) => a.date.compareTo(b.date));
         return sorted2.first.date.add(Duration(
             days: _adjustedInterval(
                 plant, plant.vitalizerIntervalDays!, sorted2.first.date)));
@@ -755,6 +759,7 @@ class PlantProvider with ChangeNotifier {
 
   /// ログリストから次回肥料予定日を計算する（DBアクセスなし・同期的）。
   ///
+  /// 起算日の優先順位は [calculateNextFertilizerDate] と同じ。
   /// [nextWateringDate] は起算日3（水やり予定日）として使用する。
   DateTime? calcNextFertilizerDateFromLogs(
     Plant plant,
@@ -770,9 +775,10 @@ class PlantProvider with ChangeNotifier {
             days: _adjustedInterval(
                 plant, plant.fertilizerIntervalDays!, sorted.first.date)));
       }
+      // 起算日2: 最初に水やりをした日（Issue #285）
       if (wateringLogs.isNotEmpty) {
         final sorted = [...wateringLogs]
-          ..sort((a, b) => b.date.compareTo(a.date));
+          ..sort((a, b) => a.date.compareTo(b.date));
         return sorted.first.date.add(Duration(
             days: _adjustedInterval(
                 plant, plant.fertilizerIntervalDays!, sorted.first.date)));
@@ -797,9 +803,14 @@ class PlantProvider with ChangeNotifier {
                 .where((l) => l.date.isAfter(lastFertDate))
                 .toList()
               ..sort((a, b) => a.date.compareTo(b.date)));
+      // completedInCurrentGroup == 0 は 2 パターンある（DBアクセス版と同じ扱いにする）:
+      //   ・水やり実績なし（起算後まだ0回）→ 次のN回目が期限（remaining = n）
+      //   ・水やりが N の倍数に到達済み（例: N=3 で3回）→ 施肥期限に到達済みで
+      //     期限は最後の水やり日（remaining = 0）。ここを n にすると施肥忘れが
+      //     Nサイクル先に飛び、超過状態が隠れてしまう。
       final completedInCurrentGroup = wateringsAfter.length % n;
       final remaining = completedInCurrentGroup == 0
-          ? n
+          ? (wateringsAfter.isEmpty ? n : 0)
           : n - completedInCurrentGroup;
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date
@@ -813,6 +824,7 @@ class PlantProvider with ChangeNotifier {
 
   /// ログリストから次回活力剤予定日を計算する（DBアクセスなし・同期的）。
   ///
+  /// 起算日の優先順位は [calculateNextVitalizerDate] と同じ。
   /// [nextWateringDate] は起算日3（水やり予定日）として使用する。
   DateTime? calcNextVitalizerDateFromLogs(
     Plant plant,
@@ -828,9 +840,10 @@ class PlantProvider with ChangeNotifier {
             days: _adjustedInterval(
                 plant, plant.vitalizerIntervalDays!, sorted.first.date)));
       }
+      // 起算日2: 最初に水やりをした日（Issue #285）
       if (wateringLogs.isNotEmpty) {
         final sorted = [...wateringLogs]
-          ..sort((a, b) => b.date.compareTo(a.date));
+          ..sort((a, b) => a.date.compareTo(b.date));
         return sorted.first.date.add(Duration(
             days: _adjustedInterval(
                 plant, plant.vitalizerIntervalDays!, sorted.first.date)));
@@ -855,9 +868,14 @@ class PlantProvider with ChangeNotifier {
                 .where((l) => l.date.isAfter(lastVitDate))
                 .toList()
               ..sort((a, b) => a.date.compareTo(b.date)));
+      // completedInCurrentGroup == 0 は 2 パターンある（DBアクセス版と同じ扱いにする）:
+      //   ・水やり実績なし（起算後まだ0回）→ 次のN回目が期限（remaining = n）
+      //   ・水やりが N の倍数に到達済み（例: N=3 で3回）→ 期限に到達済みで
+      //     期限は最後の水やり日（remaining = 0）。ここを n にすると付与忘れが
+      //     Nサイクル先に飛び、超過状態が隠れてしまう。
       final completedInCurrentGroup = wateringsAfter.length % n;
       final remaining = completedInCurrentGroup == 0
-          ? n
+          ? (wateringsAfter.isEmpty ? n : 0)
           : n - completedInCurrentGroup;
       final baseDate = wateringsAfter.isNotEmpty
           ? wateringsAfter.last.date

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -29,10 +29,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
   /// 取得完了までは null で、その間はバージョン行を控えめに「取得中」と表示する。
   String? _appVersion;
 
+  /// 一括変更の結果 SnackBar。設定画面を離れるときに閉じるため保持する（Issue #286）。
+  ScaffoldFeatureController<SnackBar, SnackBarClosedReason>? _bulkResultSnackBar;
+
   @override
   void initState() {
     super.initState();
     _loadAppVersion();
+  }
+
+  @override
+  void dispose() {
+    // SnackBar はルートの ScaffoldMessenger に出るため、閉じないと設定画面を
+    // 抜けた後もタブ画面に残り、植物一覧の FAB に重なって誤タップの原因になる。
+    _bulkResultSnackBar?.close();
+    super.dispose();
   }
 
   /// アプリのバージョンを取得して表示用に整形する（Issue #221）。
@@ -534,7 +545,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }) {
     final messenger = ScaffoldMessenger.of(context);
     final plantProvider = context.read<PlantProvider>();
-    messenger.showSnackBar(
+    _bulkResultSnackBar = messenger.showSnackBar(
       SnackBar(
         content: Text(message),
         duration: const Duration(seconds: 8),

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show DartPluginRegistrant;
+
 import 'package:flutter/foundation.dart' show debugPrint;
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
@@ -14,11 +16,20 @@ import 'weather_service.dart';
 ///
 /// アプリが起動していない状態でも呼ばれるため、トップレベル関数かつ
 /// `@pragma('vm:entry-point')` が必須（Issue #276）。
+///
+/// 別Isolateで動くのでプラグインのチャネルが未登録の状態で始まる。
+/// `DartPluginRegistrant.ensureInitialized()` を呼ばないと sqflite / path_provider が
+/// MissingPluginException になり、DB書き込みが黙って失敗する（Issue #284）。
+///
+/// 戻り値の Future は呼び出し側からは await されないが、非同期にしておかないと
+/// DB書き込みの完了前にIsolateが破棄されうるため `async` で最後まで待つ。
 @pragma('vm:entry-point')
-void notificationBackgroundHandler(NotificationResponse response) {
+Future<void> notificationBackgroundHandler(NotificationResponse response) async {
   if (response.actionId != NotificationService.wateringDoneActionId) return;
-  // await できない同期エントリポイントのため、Future はそのまま流す
-  NotificationService.recordWateringForDuePlants();
+  debugPrint('NotificationService: background action received '
+      '(${response.actionId})');
+  DartPluginRegistrant.ensureInitialized();
+  await NotificationService.recordWateringForDuePlants();
 }
 
 class NotificationService {
@@ -87,6 +98,9 @@ class NotificationService {
   /// フォアグラウンド（アプリ起動中）で通知アクションを受け取ったときの処理。
   static void _handleNotificationResponse(NotificationResponse response) {
     if (response.actionId != wateringDoneActionId) return;
+    debugPrint('NotificationService: foreground action received '
+        '(${response.actionId})');
+    // UIスレッドを止めないため await せずに流す（完了は debugPrint で追える）
     recordWateringForDuePlants();
   }
 

--- a/test/care_schedule_test.dart
+++ b/test/care_schedule_test.dart
@@ -1,0 +1,185 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:bota_note/models/log_entry.dart';
+import 'package:bota_note/models/plant.dart';
+import 'package:bota_note/providers/plant_provider.dart';
+
+/// 肥料・活力剤の次回予定日の起算日ルールの回帰テスト（Issue #285）。
+///
+/// `calcNextFertilizerDateFromLogs` / `calcNextVitalizerDateFromLogs` は
+/// DBアクセスを伴わない同期メソッドなので、Provider を素で生成して検証できる。
+void main() {
+  final created = DateTime(2028, 8, 11);
+
+  Plant buildPlant({
+    int? wateringIntervalDays = 3,
+    int? fertilizerIntervalDays,
+    int? fertilizerEveryNWaterings,
+    int? vitalizerIntervalDays,
+    int? vitalizerEveryNWaterings,
+  }) {
+    return Plant(
+      id: 'p1',
+      name: 'テスト株',
+      wateringIntervalDays: wateringIntervalDays,
+      fertilizerIntervalDays: fertilizerIntervalDays,
+      fertilizerEveryNWaterings: fertilizerEveryNWaterings,
+      vitalizerIntervalDays: vitalizerIntervalDays,
+      vitalizerEveryNWaterings: vitalizerEveryNWaterings,
+      createdAt: created,
+      updatedAt: created,
+    );
+  }
+
+  LogEntry log(LogType type, DateTime date) {
+    return LogEntry(
+      id: '${type.name}-${date.toIso8601String()}',
+      plantId: 'p1',
+      type: type,
+      date: date,
+      createdAt: date,
+      updatedAt: date,
+    );
+  }
+
+  group('活力剤の次回予定日（日数指定）', () {
+    test('活力剤ログが無い間、水やりを重ねても予定日が後ろへずれない', () {
+      final provider = PlantProvider();
+      final plant = buildPlant(vitalizerIntervalDays: 10);
+
+      final firstWatering = DateTime(2028, 8, 11);
+      final secondWatering = DateTime(2028, 8, 14);
+
+      final afterFirst = provider.calcNextVitalizerDateFromLogs(
+        plant,
+        const <LogEntry>[],
+        [log(LogType.watering, firstWatering)],
+        DateTime(2028, 8, 14),
+      );
+      final afterSecond = provider.calcNextVitalizerDateFromLogs(
+        plant,
+        const <LogEntry>[],
+        [
+          log(LogType.watering, firstWatering),
+          log(LogType.watering, secondWatering),
+        ],
+        DateTime(2028, 8, 17),
+      );
+
+      // 起算日は「最初の水やり日」に固定されるので 8/11 + 10日 = 8/21 のまま
+      expect(afterFirst, DateTime(2028, 8, 21));
+      expect(afterSecond, DateTime(2028, 8, 21));
+    });
+
+    test('活力剤ログがあれば最後の活力剤日を起算日にする', () {
+      final provider = PlantProvider();
+      final plant = buildPlant(vitalizerIntervalDays: 10);
+
+      final result = provider.calcNextVitalizerDateFromLogs(
+        plant,
+        [log(LogType.vitalizer, DateTime(2028, 8, 20))],
+        [
+          log(LogType.watering, DateTime(2028, 8, 11)),
+          log(LogType.watering, DateTime(2028, 8, 23)),
+        ],
+        DateTime(2028, 8, 26),
+      );
+
+      expect(result, DateTime(2028, 8, 30));
+    });
+
+    test('水やりログも無ければ次回水やり予定日を起算日にする', () {
+      final provider = PlantProvider();
+      final plant = buildPlant(vitalizerIntervalDays: 10);
+
+      final result = provider.calcNextVitalizerDateFromLogs(
+        plant,
+        const <LogEntry>[],
+        const <LogEntry>[],
+        DateTime(2028, 8, 14),
+      );
+
+      expect(result, DateTime(2028, 8, 24));
+    });
+  });
+
+  group('肥料の次回予定日（日数指定）', () {
+    test('肥料ログが無い間、水やりを重ねても予定日が後ろへずれない', () {
+      final provider = PlantProvider();
+      final plant = buildPlant(fertilizerIntervalDays: 30);
+
+      final waterings = [
+        log(LogType.watering, DateTime(2028, 8, 11)),
+        log(LogType.watering, DateTime(2028, 8, 14)),
+        log(LogType.watering, DateTime(2028, 8, 17)),
+      ];
+
+      expect(
+        provider.calcNextFertilizerDateFromLogs(
+            plant, const <LogEntry>[], waterings.take(1).toList(), null),
+        DateTime(2028, 9, 10),
+      );
+      expect(
+        provider.calcNextFertilizerDateFromLogs(
+            plant, const <LogEntry>[], waterings, null),
+        DateTime(2028, 9, 10),
+      );
+    });
+  });
+
+  group('肥料の次回予定日（水やりN回に1回）', () {
+    test('N回に到達したら期限は最後の水やり日（超過を隠さない）', () {
+      final provider = PlantProvider();
+      final plant =
+          buildPlant(wateringIntervalDays: 3, fertilizerEveryNWaterings: 3);
+
+      final result = provider.calcNextFertilizerDateFromLogs(
+        plant,
+        const <LogEntry>[],
+        [
+          log(LogType.watering, DateTime(2028, 8, 11)),
+          log(LogType.watering, DateTime(2028, 8, 14)),
+          log(LogType.watering, DateTime(2028, 8, 17)),
+        ],
+        DateTime(2028, 8, 20),
+      );
+
+      // 3回目で期限到達。Nサイクル先へ飛ばさず最後の水やり日を返す
+      expect(result, DateTime(2028, 8, 17));
+    });
+
+    test('途中の回数なら残り回数ぶん先の日付を返す', () {
+      final provider = PlantProvider();
+      final plant =
+          buildPlant(wateringIntervalDays: 3, fertilizerEveryNWaterings: 3);
+
+      final result = provider.calcNextFertilizerDateFromLogs(
+        plant,
+        const <LogEntry>[],
+        [
+          log(LogType.watering, DateTime(2028, 8, 11)),
+          log(LogType.watering, DateTime(2028, 8, 14)),
+        ],
+        DateTime(2028, 8, 17),
+      );
+
+      // 残り1回 → 最後の水やり日 8/14 + 3日
+      expect(result, DateTime(2028, 8, 17));
+    });
+
+    test('水やりが1回も無ければN回ぶん先の日付を返す', () {
+      final provider = PlantProvider();
+      final plant =
+          buildPlant(wateringIntervalDays: 3, fertilizerEveryNWaterings: 3);
+
+      final result = provider.calcNextFertilizerDateFromLogs(
+        plant,
+        const <LogEntry>[],
+        const <LogEntry>[],
+        DateTime(2028, 8, 14),
+      );
+
+      expect(result, DateTime(2028, 8, 23));
+    });
+  });
+}


### PR DESCRIPTION
`/user-simulation`（ベテラン主婦ペルソナ・2年分の拡張モード）で見つかった不具合3件をまとめて修正しました。

## 変更内容

### #284 通知の「水やり完了」アクションが無反応

`android/app/src/main/AndroidManifest.xml` に
`com.dexterous.flutterlocalnotifications.ActionBroadcastReceiver` の宣言を追加しました。

`showsUserInterface: false` のアクションはこのレシーバー経由でバックグラウンド Isolate へ配送されますが、
flutter_local_notifications 20.1.0 のプラグイン側マニフェストは permission のみでレシーバーを一切宣言しないため、
アプリ側での宣言が必須でした。宣言が無いためブロードキャストを誰も受信せず、
Issue #276 で追加した機能が実質未動作でした。

あわせてバックグラウンド Isolate 側も直しています。

- `DartPluginRegistrant.ensureInitialized()` を追加。別 Isolate ではプラグインのチャネルが未登録のため、
  これが無いと sqflite / path_provider が `MissingPluginException` になり DB 書き込みが黙って失敗します
- ハンドラを `async` にして DB 書き込みの完了まで待つ（Isolate が先に破棄されるのを防ぐ）
- 受信時に `debugPrint` を出す。今回、成功時も失敗時もログが一切出ず原因特定に時間がかかったため

### #285 肥料・活力剤の次回予定日が水やりのたびに先送りされる

日数指定モードで肥料/活力剤ログが0件のとき、起算日に「**最後**の水やり日」を使っていました。
水やりは肥料/活力剤より高頻度に記録されるため、記録のたびに起算日が更新されて予定日が後退し、
**活力剤間隔 > 水やり間隔** という一般的な設定では予定日が永久に到来しませんでした。

起算日を「**最初**の水やり日」に変更し、以降の水やりで動かないようにしました。
起算日1（最後の肥料/活力剤日）・起算日3（次回水やり予定日）は変更していません。

あわせて「水やりN回に1回」モードの残り回数計算が DB アクセス版とログリスト版で食い違っていたのを揃えました。
ログリスト版（画面が実際に使う方）だけ N の倍数到達時に `remaining = n` としていたため、
施肥忘れの超過状態が N サイクル先へ隠れていました。DB アクセス版のコメントが警告していた挙動そのものです。

### #286 一括変更の SnackBar が植物一覧の FAB に重なる

SnackBar はルートの `ScaffoldMessenger` に出るため、設定画面を抜けてもタブ画面に残り続けます。
FAB を持つのは `home_screen` の外側 Scaffold ではなくタブ内側の Scaffold なので押し上げも効かず、
「植物を追加」FAB が SnackBar の下に隠れていました。

- 「元に戻す」`[774,1975][1049,2101]`
- FAB「植物を追加」`[891,1938][1038,2085]`

FAB のつもりでタップすると「元に戻す」が反応し、一括変更が取り消されます
（シミュレーション中に実際に踏みました）。設定画面の `dispose` で SnackBar を閉じるようにしました。

## テスト

`test/care_schedule_test.dart` を追加しました（起算日ルール4件＋「水やりN回に1回」の残り回数3件）。

- `flutter analyze`: エラーなし（info 10件はいずれも既存分）
- `flutter test`: 32件パス

## 動作確認（Android エミュレータ Medium_Phone_API_36.1 / 2年分のデータで復元した状態）

**#284**: 通知の「水やり完了」をタップ

```
NotificationService: background action received (watering_done)
NotificationService: recorded watering from notification action (15 plants checked)
NotificationService: plants due on tomorrow = 0
NotificationService: no plants due on target day, notification cancelled
```

15件の水やりが記録され、通知も消え、翌日ぶんのリマインダーが組み直されました。

**#285**: TestVit（水やり3日ごと・活力剤10日ごと・活力剤ログ0件）

| | 修正前 | 修正後 |
|---|---|---|
| 8/11 に水やり① | 活力剤 8/21 | 活力剤 8/21 |
| 8/14 に水やり② | 活力剤 **8/24（後退）** | 活力剤 **8/21（固定）** |

8/20 に通知アクションで水やりを記録しても活力剤の予定日は「明日（8/21）」のまま動きませんでした。

**#286**: 設定 → 一括調整 → 適用 → 戻る → 植物一覧
SnackBar が残らず、FAB「植物を追加」が隠れないことを確認しました。

## 補足（本PRの対象外）

同じシミュレーションで見つかった UX 上の気になり点は、必要であれば別途 Issue 化します。

- 再インストール後のオンボーディングに「バックアップから復元」の導線が無い
- インポート完了メッセージに画像の件数が出ない（参照先の画像が ZIP に無いと既存の写真が黙って消える）
- 植物詳細の「次回予定」に年が無く、年をまたぐ予定超過が判別できない
- ケア統計が「直近6ヶ月」固定・植物ごとの頻度が上位10件のみ
- 置き場所ドロップダウンに「新規作成」が無い / 置き場所詳細の植物行がタップできない
- 植物の選択ダイアログの並び順が画面ごとに違い、全選択が無い

Closes #284
Closes #285
Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
